### PR TITLE
Power roll crits

### DIFF
--- a/src/module/helpers/rolls.mjs
+++ b/src/module/helpers/rolls.mjs
@@ -230,6 +230,9 @@ export class PowerRoll extends DSRoll {
    */
   get product() {
     if (this._total === undefined) return undefined;
+    // Crits are always a tier 3 result
+    if (this.critical) return 3;
+
     const tier = Object.values(this.constructor.RESULT_TIERS).reduce((t, {threshold}) => t + Number(this.total >= threshold), 0);
     // Adjusts tiers for double edge/bane
     const adjustment = this.netBoon - Math.sign(this.netBoon);

--- a/src/module/helpers/rolls.mjs
+++ b/src/module/helpers/rolls.mjs
@@ -268,7 +268,6 @@ export class PowerRoll extends DSRoll {
    * otherwise returns if the dice total is a 19 or higher
    */
   get critical() {
-    if (this.options.type !== "ability") return null;
     if (this._total === undefined) return null;
     return (this.dice[0].total >= this.options.criticalThreshold);
   }


### PR DESCRIPTION
This fixes #10 

Nat19 and Nat20 are always a crit regardless of the Power Roll type.
Nat19 and Nat20 are always a tier 3 result