### PR TITLE
Suppress effects with expired durations

### DIFF
--- a/src/module/apps/actor-sheet.mjs
+++ b/src/module/apps/actor-sheet.mjs
@@ -333,7 +333,7 @@ export class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
     // Iterate over active effects, classifying them into categories
     for (const e of this.actor.allApplicableEffects()) {
-      if (e.disabled) categories.inactive.effects.push(e);
+      if (!e.active) categories.inactive.effects.push(e);
       else if (e.isTemporary) categories.temporary.effects.push(e);
       else categories.passive.effects.push(e);
     }

--- a/src/module/apps/item-sheet.mjs
+++ b/src/module/apps/item-sheet.mjs
@@ -191,7 +191,7 @@ export class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
     // Iterate over active effects, classifying them into categories
     for (const e of this.item.effects) {
       if (!e.transfer) categories.applied.effects.push(e);
-      else if (e.disabled) categories.inactive.effects.push(e);
+      else if (!e.active) categories.inactive.effects.push(e);
       else if (e.isTemporary) categories.temporary.effects.push(e);
       else categories.passive.effects.push(e);
     }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -2,10 +2,11 @@ export class DrawSteelActiveEffect extends ActiveEffect {
 
   /**
    * Automatically deactivate effects with expired durations
+   * @type {Boolean}
    */
   get isSuppressed() {
-    if (Number.isNumeric(this.duration?.remaining)) {
-      return this.duration?.remaining <= 0;
+    if (Number.isNumeric(this.duration.remaining)) {
+      return this.duration.remaining <= 0;
     }
     return false;
   }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -1,4 +1,15 @@
 export class DrawSteelActiveEffect extends ActiveEffect {
+
+  /**
+   * Automatically deactivate effects with expired durations
+   */
+  get isSuppressed() {
+    if (Number.isNumeric(this.duration?.remaining)) {
+      return this.duration?.remaining <= 0;
+    }
+    return false;
+  }
+
   /** @override */
   prepareDerivedData() {
     super.prepareDerivedData();


### PR DESCRIPTION
Leveraging the `isSuppressed` and `active` getters to maybe-cleanly handle effect expiration.