### PR TITLE
Add characteristics to ability power roll

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -268,6 +268,9 @@
             "enabled": {
               "label": "Has Power Roll"
             },
+            "characteristics": {
+              "label": "Characteristics"
+            },
             "tier1": {
               "label": "Tier 1 Result",
               "damage": {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -207,7 +207,7 @@ export default class AbilityModel extends BaseItemModel {
 
     context.showDamageDisplay = this.keywords.has("melee") && this.keywords.has("ranged");
 
-    context.damageType = Object.entries(ds.CONFIG.damageTypes).map(([value, {label}]) => ({value, label}));
+    context.damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([value, {label}]) => ({value, label}));
     context.appliedEffects = this.parent.effects.filter(e => !e.transfer).map(e => ({label: e.name, value: e.id}));
 
     context.characteristics = Object.entries(ds.CONFIG.characteristics).map(([value], {label}) => ({value, label}));

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -60,6 +60,7 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.powerRoll = new fields.SchemaField({
       enabled: new fields.BooleanField(),
+      characteristics: new fields.SetField(new fields.StringField({choices: ds.CONFIG.characteristics})),
       tier1: new fields.SchemaField(powerRollSchema()),
       tier2: new fields.SchemaField(powerRollSchema()),
       tier3: new fields.SchemaField(powerRollSchema())
@@ -88,10 +89,19 @@ export default class AbilityModel extends BaseItemModel {
 
   /**
    * Adds kit bonuses as native "active effect" like adjustments.
+   * Also selects the highest characteristic from the options.
    * TODO: Consider adding an `overrides` like property if that makes sense for the item sheet handling
    * @protected
    */
   _prepareCharacterData() {
+    this.powerRoll.characteristic = null;
+    for (const characteristic of this.powerRoll.characteristics) {
+      if (this.powerRoll.characteristic === null) this.powerRoll.characteristic = characteristic;
+
+      const actorCharacteristics = this.actor.system.characteristics;
+      if (actorCharacteristics[characteristic].value > actorCharacteristics[this.powerRoll.characteristic].value) this.powerRoll.characteristic = characteristic;
+    }
+
     /** @type {import("../actor/character.mjs").default["abilityBonuses"]} */
     const bonuses = foundry.utils.getProperty(this.actor ?? {}, "system.abilityBonuses");
     if (bonuses) { // Data prep order of operations issues

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -60,7 +60,7 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.powerRoll = new fields.SchemaField({
       enabled: new fields.BooleanField(),
-      characteristics: new fields.SetField(new fields.StringField({choices: ds.CONFIG.characteristics})),
+      characteristics: new fields.SetField(new fields.StringField({required: true, blank: false})),
       tier1: new fields.SchemaField(powerRollSchema()),
       tier2: new fields.SchemaField(powerRollSchema()),
       tier3: new fields.SchemaField(powerRollSchema())
@@ -209,5 +209,7 @@ export default class AbilityModel extends BaseItemModel {
 
     context.damageType = Object.entries(ds.CONFIG.damageTypes).map(([value, {label}]) => ({value, label}));
     context.appliedEffects = this.parent.effects.filter(e => !e.transfer).map(e => ({label: e.name, value: e.id}));
+
+    context.characteristics = Object.entries(ds.CONFIG.characteristics).map(([value], {label}) => ({value, label}));
   }
 }

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -32,7 +32,7 @@
 </fieldset>
 {{formGroup systemFields.powerRoll.fields.enabled value=system.powerRoll.enabled}}
 {{#if system.powerRoll.enabled}}
-{{formGroup systemFields.powerRoll.fields.characteristics value=system.powerRoll.characteristics}}
+{{formGroup systemFields.powerRoll.fields.characteristics value=system.powerRoll.characteristics options=characteristics}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier1 value=system.powerRoll.tier1}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier2 value=system.powerRoll.tier}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier3 value=system.powerRoll.tier2}}

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -32,6 +32,7 @@
 </fieldset>
 {{formGroup systemFields.powerRoll.fields.enabled value=system.powerRoll.enabled}}
 {{#if system.powerRoll.enabled}}
+{{formGroup systemFields.powerRoll.fields.characteristics value=system.powerRoll.characteristics}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier1 value=system.powerRoll.tier1}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier2 value=system.powerRoll.tier}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier3 value=system.powerRoll.tier2}}


### PR DESCRIPTION
Schema includes the characteristics that can be used for the ability. In _prepareCharacterData, the highest characteristic is chosen. Future work includes:

- Add checkbox to each tiers damage for adding characteristic to damage
- Add characteristic to damage if checked

Closes #92
