### PR TITLE
Add echelon to actor data and roll data

### DIFF
--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -109,7 +109,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
   get echelon() {
     return Object.entries(ds.CONFIG.echelons).reduce((acc, current) => {
       return this.level >= current[1].threshold? Number(current[0]) : acc;
-    }, 0);
+    }, 1);
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -97,6 +97,22 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
   }
 
   /**
+   * The actor's level
+   */
+  get level() {
+    return 1;
+  }
+  
+  /**
+   * The actor's echelon based on their current level
+   */
+  get echelon() {
+    return Object.entries(ds.CONFIG.echelons).reduce((acc, current) => {
+      return this.level >= current[1].threshold? Number(current[0]) : acc;
+    }, 0);
+  }
+
+  /**
    * @override
    * @param {Record<string, unknown>} changes
    * @param {import("../../../../foundry/common/abstract/_types.mjs").DatabaseUpdateOperation} operation

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -87,6 +87,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
       const rollKey = ds.CONFIG.characteristics[key].rollKey;
       rollData[rollKey] = obj.value;
     }
+
+    rollData.echelon = this.echelon;
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -107,8 +107,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
    * The actor's echelon based on their current level
    */
   get echelon() {
-    return Object.entries(ds.CONFIG.echelons).reduce((acc, current) => {
-      return this.level >= current[1].threshold? Number(current[0]) : acc;
+    return Object.entries(ds.CONFIG.echelons).reduce((acc, [key,value]) => {
+      return this.level >= value.threshold ? Number(key) : acc;
     }, 1);
   }
 

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -141,6 +141,11 @@ export default class CharacterModel extends BaseActorModel {
     return 1 + this.abilityBonuses.melee.distance;
   }
 
+  /** @override */
+  get level() {
+    return this.class?.system.level ?? 0;
+  }
+
   /**
    * @typedef {import("../../documents/item.mjs").DrawSteelItem} DrawSteelItem
    */

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -32,11 +32,17 @@ export default class NPCModel extends BaseActorModel {
 
     schema.monster = new fields.SchemaField({
       keywords: new fields.SetField(new fields.StringField({blank: true, required: true})),
+      level: requiredInteger({initial: 1}),
       ev: requiredInteger({initial: 4}),
       role: new fields.StringField({choices: config.monsters.roles}),
       subrole: new fields.StringField({choices: config.monsters.subroles})
     });
 
     return schema;
+  }
+
+  /** @override */
+  get level() {
+    return this.monster.level;
   }
 }

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -8,8 +8,6 @@ export class DrawSteelActor extends Actor {
       this.system.modifyRollData(rollData);
     }
 
-    rollData.echelon = this.system.echelon;
-
     return rollData;
   }
 

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -8,6 +8,8 @@ export class DrawSteelActor extends Actor {
       this.system.modifyRollData(rollData);
     }
 
+    rollData.echelon = this.system.echelon;
+
     return rollData;
   }
 


### PR DESCRIPTION
Closes #106 

- I had to add level to `NPCModel`. 
- Added a level getter so that I could use that instead of actor type checking in the echelon getter. 
- Added echelon to roll data