### PR TITLE
Update keywords

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -340,7 +340,7 @@
         },
         "KeywordGroups": {
           "Elementalist": "Elementalist",
-          "Fury" :"Fury",
+          "Fury": "Fury",
           "Talent": "Talent",
           "Troubador": "Troubador"
         },

--- a/lang/en.json
+++ b/lang/en.json
@@ -338,14 +338,35 @@
             "label": "Spend"
           }
         },
+        "KeywordGroups": {
+          "Elementalist": "Elementalist",
+          "Fury" :"Fury",
+          "Talent": "Talent",
+          "Troubador": "Troubador"
+        },
         "Keywords": {
+          "Animal": "Animal",
+          "Animapathy" :"Animapathy",
           "Area": "Area",
-          "Attack": "Attack",
           "Charge": "Charge",
+          "Chronopathy": "Chronopathy",
+          "Cryokinesis": "Cryokinesis",
+          "Earth": "Earth",
+          "Fire": "Fire",
+          "Green": "Green",
           "Magic": "Magic",
           "Melee": "Melee",
+          "Metamorphosis": "Metamorphosis",
           "Psionic": "Psionic",
+          "Pyrokinesis": "Pyrokinesis",
           "Ranged": "Ranged",
+          "Resopathy": "Resopathy",
+          "Rot": "Rot",
+          "Routine": "Routine",
+          "Strike": "Strike",
+          "Telekinesis": "Telekinesis",
+          "Telepathy": "Telepathy",
+          "Void": "Void",
           "Weapon": "Weapon"
         },
         "Type": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -346,7 +346,7 @@
         },
         "Keywords": {
           "Animal": "Animal",
-          "Animapathy" :"Animapathy",
+          "Animapathy": "Animapathy",
           "Area": "Area",
           "Charge": "Charge",
           "Chronopathy": "Chronopathy",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1,4 +1,4 @@
-import { preLocalize } from "./helpers/utils.mjs";
+import {preLocalize} from "./helpers/utils.mjs";
 
 /** @import {FormSelectOption} from "../../foundry/client-esm/applications/forms/fields.mjs" */
 
@@ -922,18 +922,18 @@ Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
   get: function() {
     const sortedKeywords = Object.entries(ds.CONFIG.abilities.keywords).sort(([keyA, valueA], [keyB, valueB]) => {
       // When no group, sort between their keys
-      if(valueA.group === undefined && valueB.group === undefined) return keyA.localeCompare(keyB);
+      if (valueA.group === undefined && valueB.group === undefined) return keyA.localeCompare(keyB);
 
       // When or the other, but not both have a group, the one without a group comes first
-      if(valueA.group === undefined && valueB.group !== undefined) return -1
-      if(valueA.group !== undefined && valueB.group === undefined) return 1;
+      if (valueA.group === undefined && valueB.group !== undefined) return -1;
+      if (valueA.group !== undefined && valueB.group === undefined) return 1;
 
       // When they both have a group and they are equal, sort between their keys
-      if(valueA.group === valueB.group) return keyA.localeCompare(keyB);
+      if (valueA.group === valueB.group) return keyA.localeCompare(keyB);
 
       // When they both have a group and are not equal, sort between their groups
       return valueA.group.localeCompare(valueB.group);
-    })
+    });
     return sortedKeywords.reduce((arr, [value, {label, group}]) => {
       arr.push({label, group, value});
       return arr;

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1,4 +1,4 @@
-import {preLocalize} from "./helpers/utils.mjs";
+import { preLocalize } from "./helpers/utils.mjs";
 
 /** @import {FormSelectOption} from "../../foundry/client-esm/applications/forms/fields.mjs" */
 
@@ -916,6 +916,30 @@ preLocalize("abilities.types", {key: "label"});
 preLocalize("abilities.distances", {keys: ["label", "primary", "secondary"]});
 preLocalize("abilities.targets", {keys: ["label", "all"]});
 preLocalize("abilities.forcedMovement", {key: "label"});
+
+Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
+  /** @type {FormSelectOption[]} */
+  get: function() {
+    const sortedKeywords = Object.entries(ds.CONFIG.abilities.keywords).sort(([keyA, valueA], [keyB, valueB]) => {
+      // When no group, sort between their keys
+      if(valueA.group === undefined && valueB.group === undefined) return keyA.localeCompare(keyB);
+
+      // When or the other, but not both have a group, the one without a group comes first
+      if(valueA.group === undefined && valueB.group !== undefined) return -1
+      if(valueA.group !== undefined && valueB.group === undefined) return 1;
+
+      // When they both have a group and they are equal, sort between their keys
+      if(valueA.group === valueB.group) return keyA.localeCompare(keyB);
+
+      // When they both have a group and are not equal, sort between their groups
+      return valueA.group.localeCompare(valueB.group);
+    })
+    return sortedKeywords.reduce((arr, [value, {label, group}]) => {
+      arr.push({label, group, value});
+      return arr;
+    }, []);
+  }
+});
 
 /**
  * Configuration details for Culture items

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -922,11 +922,11 @@ Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
   get: function() {
     const sortedKeywords = Object.entries(ds.CONFIG.abilities.keywords).sort(([keyA, valueA], [keyB, valueB]) => {
       // When no group, sort between their keys
-      if (valueA.group === undefined && valueB.group === undefined) return keyA.localeCompare(keyB);
+      if ((valueA.group === undefined) && (valueB.group === undefined)) return keyA.localeCompare(keyB);
 
       // When or the other, but not both have a group, the one without a group comes first
-      if (valueA.group === undefined && valueB.group !== undefined) return -1;
-      if (valueA.group !== undefined && valueB.group === undefined) return 1;
+      if ((valueA.group === undefined) && (valueB.group !== undefined)) return -1;
+      if ((valueA.group !== undefined) && (valueB.group === undefined)) return 1;
 
       // When they both have a group and they are equal, sort between their keys
       if (valueA.group === valueB.group) return keyA.localeCompare(keyB);

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -705,16 +705,41 @@ preLocalize("monsters.subroles", {key: "label"});
  * Configuration information for Ability items
  */
 DRAW_STEEL.abilities = {
-  /** @type {Record<string, {label: string, damage?: boolean}>} */
+  /** @type {Record<string, {label: string, group?: string, damage?: boolean}>} */
   keywords: {
+    animal: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Animal",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Fury"
+    },
+    animapathy: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Animapathy",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
     area: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Area"
     },
-    attack: {
-      label: "DRAW_STEEL.Item.Ability.Keywords.Attack"
-    },
     charge: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Charge"
+    },
+    chronopathy: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Chronopathy",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
+    cryokinesis: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Cryokinesis",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
+    earth: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Earth",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
+    },
+    fire: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Fire",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
+    },
+    green: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Green",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
     },
     magic: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Magic",
@@ -723,12 +748,47 @@ DRAW_STEEL.abilities = {
     melee: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Melee"
     },
+    metamorphosis: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Metamorphosis",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
     psionic: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Psionic",
       damage: true
     },
+    pyrokinesis: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Pyrokinesis",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
     ranged: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Ranged"
+    },
+    resopathy: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Resopathy",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
+    rot: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Rot",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
+    },
+    routine: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Routine",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Troubador"
+    },
+    strike: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Strike"
+    },
+    telekinesis: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Telekinesis",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
+    telepathy: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Telepathy",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
+    },
+    void: {
+      label: "DRAW_STEEL.Item.Ability.Keywords.Void",
+      group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
     },
     weapon: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Weapon",
@@ -851,7 +911,7 @@ DRAW_STEEL.abilities = {
     }
   }
 };
-preLocalize("abilities.keywords", {key: "label"});
+preLocalize("abilities.keywords", {keys: ["label", "group"]});
 preLocalize("abilities.types", {key: "label"});
 preLocalize("abilities.distances", {keys: ["label", "primary", "secondary"]});
 preLocalize("abilities.targets", {keys: ["label", "all"]});

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -163,7 +163,6 @@ export default class AbilityModel extends BaseItemModel {
   /** @override */
   getSheetContext(context) {
     const config = ds.CONFIG.abilities;
-    context.keywords = Object.entries(config.keywords).map(([value, {label}]) => ({value, label}));
     context.actionTypes = Object.entries(config.types).map(([value, {label}]) => ({value, label}));
 
     context.triggeredAction = !!config.types[this.type]?.triggered;

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -9,7 +9,7 @@
   {{!-- TODO: Forced Movement --}}
 </fieldset>
 {{/inline}}
-{{formGroup systemFields.keywords value=system.keywords options=keywords}}
+{{formGroup systemFields.keywords value=system.keywords options=config.abilities.keywords.optgroups}}
 {{formGroup systemFields.type value=system.type options=actionTypes}}
 {{#if triggeredAction}}
 {{formGroup systemFields.trigger value=system.trigger}}


### PR DESCRIPTION
- Removed Attack and added Strike keywords.
- Added other keywords from class abilities
- I used a similar method to add the optgroups as the skills config. I just added sorting to it. Sorting is by no group first, then by group, then by key

With sorting
<img src="https://github.com/user-attachments/assets/59ca7578-d538-438c-aeb7-86bcb7f79995" height="450" alt="dropdown with sort">

Without sorting
<img src="https://github.com/user-attachments/assets/668c79d0-30b0-461f-9989-3467cfd80b6b" height="450" alt="dropdown without sort">


Closes #61 
