### PR TITLE
Add ability categories

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -244,6 +244,9 @@
           "type": {
             "label": "Type"
           },
+          "category": {
+            "label": "Category"
+          },
           "distance": {
             "label": "Distance",
             "type": {
@@ -375,6 +378,12 @@
           "FreeManeuver": "Free Maneuver",
           "Triggered": "Triggered Action",
           "FreeTriggered": "Free Triggered Action"
+        },
+        "Category": {
+          "Heroic": "Heroic Ability",
+          "FreeStrike": "Free Strike",
+          "Signature": "Signature Ability",
+          "Villain": "Villain Action"
         },
         "Distance": {
           "Melee": "Melee",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -818,6 +818,21 @@ DRAW_STEEL.abilities = {
       triggered: true
     }
   },
+  /** @type {Record<string, {label: string}>} */
+  categories: {
+    heroic: {
+      label: "DRAW_STEEL.Item.Ability.Category.Heroic"
+    },
+    freeStrike: {
+      label: "DRAW_STEEL.Item.Ability.Category.FreeStrike"
+    },
+    signature: {
+      label: "DRAW_STEEL.Item.Ability.Category.Signature"
+    },
+    villain: {
+      label: "DRAW_STEEL.Item.Ability.Category.Villain"
+    }
+  },
   /**
    * Valid distances in Draw Steel
    * `primary` and `secondary`, if present represent additional measures/dimensions that are valid for this type
@@ -913,6 +928,7 @@ DRAW_STEEL.abilities = {
 };
 preLocalize("abilities.keywords", {keys: ["label", "group"]});
 preLocalize("abilities.types", {key: "label"});
+preLocalize("abilities.categories", {key: "label"});
 preLocalize("abilities.distances", {keys: ["label", "primary", "secondary"]});
 preLocalize("abilities.targets", {keys: ["label", "all"]});
 preLocalize("abilities.forcedMovement", {key: "label"});

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -50,6 +50,7 @@ declare module "./ability.mjs" {
     }
     keywords: Set<string>;
     type: keyof typeof ds["CONFIG"]["abilities"]["types"];
+    category: keyof typeof ds["CONFIG"]["abilities"]["categories"] | "";
     damageDisplay: "melee" | "ranged";
     distance: {
       type: keyof typeof ds["CONFIG"]["abilities"]["distances"];

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -29,6 +29,7 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.keywords = new fields.SetField(new fields.StringField({required: true, blank: false}));
     schema.type = new fields.StringField({required: true, blank: false, initial: "action"});
+    schema.category = new fields.StringField({required: true, blank: true, initial: ""}),
     schema.trigger = new fields.StringField();
     schema.distance = new fields.SchemaField({
       type: new fields.StringField({required: true, blank: false, initial: "self"}),
@@ -164,6 +165,7 @@ export default class AbilityModel extends BaseItemModel {
   getSheetContext(context) {
     const config = ds.CONFIG.abilities;
     context.actionTypes = Object.entries(config.types).map(([value, {label}]) => ({value, label}));
+    context.abilityCategories = Object.entries(config.categories).map(([value, {label}]) => ({value, label}));
 
     context.triggeredAction = !!config.types[this.type]?.triggered;
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -29,7 +29,7 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.keywords = new fields.SetField(new fields.StringField({required: true, blank: false}));
     schema.type = new fields.StringField({required: true, blank: false, initial: "action"});
-    schema.category = new fields.StringField({required: true, blank: true, initial: ""}),
+    schema.category = new fields.StringField({required: true, nullable: false}),
     schema.trigger = new fields.StringField();
     schema.distance = new fields.SchemaField({
       type: new fields.StringField({required: true, blank: false, initial: "self"}),

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -11,6 +11,7 @@
 {{/inline}}
 {{formGroup systemFields.keywords value=system.keywords options=config.abilities.keywords.optgroups}}
 {{formGroup systemFields.type value=system.type options=actionTypes}}
+{{formGroup systemFields.category value=system.category options=abilityCategories blank=""}}
 {{#if triggeredAction}}
 {{formGroup systemFields.trigger value=system.trigger}}
 {{/if}}


### PR DESCRIPTION
Added categories to ability config and add category to AbilityModel. I updated the type for AbilityModel to include this new field. I think I did this correctly as I'm not terribly familiar with TS, so please correct me on the best way.

Current categories are: 

- Heroic Ability
- Signature Ability
- Villain Action
- Free Strike

Closes #114