### PR TITLE
Add takeDamage method to BaseActorModel

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -171,7 +171,7 @@
         }
       },
       "DamageNotification": {
-        "ImmunityReducedToZero": "Your immunities have reduced the damage to zero."
+        "ImmunityReducedToZero": "The actor's immunities have reduced the damage to zero."
       }
     },
     "Combat": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -169,6 +169,9 @@
             "Vengeance": "Vengeance"
           }
         }
+      },
+      "DamageNotification": {
+        "ImmunityReducedToZero": "Your immunities have reduced the damage to zero."
       }
     },
     "Combat": {

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -705,7 +705,7 @@ preLocalize("monsters.subroles", {key: "label"});
  * Configuration information for Ability items
  */
 DRAW_STEEL.abilities = {
-  /** @type {Record<string, {label: string, group?: string, damage?: boolean}>} */
+  /** @type {Record<string, {label: string, group?: string}>} */
   keywords: {
     animal: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Animal",
@@ -742,8 +742,7 @@ DRAW_STEEL.abilities = {
       group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
     },
     magic: {
-      label: "DRAW_STEEL.Item.Ability.Keywords.Magic",
-      damage: true
+      label: "DRAW_STEEL.Item.Ability.Keywords.Magic"
     },
     melee: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Melee"
@@ -753,8 +752,7 @@ DRAW_STEEL.abilities = {
       group: "DRAW_STEEL.Item.Ability.KeywordGroups.Talent"
     },
     psionic: {
-      label: "DRAW_STEEL.Item.Ability.Keywords.Psionic",
-      damage: true
+      label: "DRAW_STEEL.Item.Ability.Keywords.Psionic"
     },
     pyrokinesis: {
       label: "DRAW_STEEL.Item.Ability.Keywords.Pyrokinesis",
@@ -791,8 +789,7 @@ DRAW_STEEL.abilities = {
       group: "DRAW_STEEL.Item.Ability.KeywordGroups.Elementalist"
     },
     weapon: {
-      label: "DRAW_STEEL.Item.Ability.Keywords.Weapon",
-      damage: true
+      label: "DRAW_STEEL.Item.Ability.Keywords.Weapon"
     }
   },
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -187,7 +187,10 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
 
     damage = Math.max(0, damage + weaknessAmount - immunityAmount);
 
-    if(damage === 0) return this.parent;
+    if(damage === 0) {
+      ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", {localize: true});
+      return this.parent;
+    }
 
     // If there's damage left after weakness/immunities, apply damage to temporary stamina then stamina value
     const staminaUpdates = {};

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -188,6 +188,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     damage = Math.max(0, damage + weaknessAmount - immunityAmount);
 
     if(damage === 0) {
+      // TODO: V13 allows the format option to be passed. Notification could be updated to include the damaged actor's name
       ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", {localize: true});
       return this.parent;
     }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -42,8 +42,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     });
 
     schema.damage = new fields.SchemaField({
-      immunities: damageTypes(requiredInteger, {all: true, keywords: true}),
-      weaknesses: damageTypes(requiredInteger, {all: true, keywords: true})
+      immunities: damageTypes(requiredInteger, {all: true}),
+      weaknesses: damageTypes(requiredInteger, {all: true})
     });
 
     return schema;

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -201,6 +201,6 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     const remainingDamage = Math.max(0, damage - damageToTempStamina);
     if(remainingDamage > 0) staminaUpdates.value = this.stamina.value - remainingDamage;
 
-    return await this.parent.update({"system.stamina": staminaUpdates});
+    return this.parent.update({"system.stamina": staminaUpdates});
   }
 }

--- a/src/module/data/helpers.mjs
+++ b/src/module/data/helpers.mjs
@@ -31,7 +31,7 @@ export const requiredInteger = ({initial = 0, label} = {}) => new NumberField({i
  * @param {DamageTypeCallback} inner Callback that returns a field
  * @returns A Schema with entries for each damage type
  */
-export const damageTypes = (inner, {all = false, keywords = false} = {}) => {
+export const damageTypes = (inner, {all = false} = {}) => {
   const schema = {};
   const config = ds.CONFIG;
 
@@ -41,13 +41,6 @@ export const damageTypes = (inner, {all = false, keywords = false} = {}) => {
     obj[type] = inner({label: value.label});
     return obj;
   }, schema);
-
-  if (keywords) {
-    Object.entries(config.abilities.keywords).reduce((obj, [key, value]) => {
-      if (value.damage) obj[key] = inner({label: value.label});
-      return obj;
-    }, schema);
-  }
 
   return new SchemaField(schema);
 };


### PR DESCRIPTION
I also removed the keyword stuff from the damage weaknesses/immunities. I wasn't sure what the typing should be for `option.ignoredImmunities` to have it be either a damage type or all, so I just used string.

Closes #124
Closes #125 