### PR TITLE
Add turns to actor and combatant models

### DIFF
--- a/src/module/apps/hooks/combatTracker.mjs
+++ b/src/module/apps/hooks/combatTracker.mjs
@@ -40,17 +40,17 @@ export function renderCombatTracker(app, [html], context) {
     }
     initControl.classList.add(dispositionColor);
     if (combatant.isOwner) {
-      initControl.innerHTML = `<a class="activate-combatant" data-tooltip="DRAW_STEEL.Combat.Initiative.Actions.${combatant.initiative ? "Act" : "Restore"}">
-        ${combatant.initiative > 1 ? combatant.initiative + " " : ""}<i class="fa-solid ${combatant.initiative ? "fa-arrow-right" : "fa-clock-rotate-left"}"></i>
+      initControl.innerHTML = `<a class="activate-combatant" data-tooltip="DRAW_STEEL.Combat.Initiative.Actions.${combatant.system.turns ? "Act" : "Restore"}">
+        ${combatant.system.turns > 1 ? combatant.system.turns + " " : ""}<i class="fa-solid ${combatant.system.turns ? "fa-arrow-right" : "fa-clock-rotate-left"}"></i>
         </a>`;
 
       /** @type {HTMLAnchorElement} */
       const button = initControl.children[0];
 
       button.addEventListener("click", async (element, event) => {
-        const oldValue = combatant.initiative;
-        const newValue = oldValue ? oldValue - 1 : 1;
-        await combatant.update({initiative: newValue});
+        const oldValue = combatant.system.turns;
+        const newValue = oldValue ? oldValue - 1 : combatant.actor.system.combat.turns;
+        await combatant.update({"system.turns": newValue});
         if (oldValue) {
           const newTurn = app.viewed.turns.findIndex((c) => c === combatant);
           combat.update({turn: newTurn}, {direction: 1});

--- a/src/module/apps/hooks/combatTracker.mjs
+++ b/src/module/apps/hooks/combatTracker.mjs
@@ -40,17 +40,17 @@ export function renderCombatTracker(app, [html], context) {
     }
     initControl.classList.add(dispositionColor);
     if (combatant.isOwner) {
-      initControl.innerHTML = `<a class="activate-combatant" data-tooltip="DRAW_STEEL.Combat.Initiative.Actions.${combatant.system.turns ? "Act" : "Restore"}">
-        ${combatant.system.turns > 1 ? combatant.system.turns + " " : ""}<i class="fa-solid ${combatant.system.turns ? "fa-arrow-right" : "fa-clock-rotate-left"}"></i>
+      initControl.innerHTML = `<a class="activate-combatant" data-tooltip="DRAW_STEEL.Combat.Initiative.Actions.${combatant.initiative ? "Act" : "Restore"}">
+        ${combatant.initiative > 1 ? combatant.initiative + " " : ""}<i class="fa-solid ${combatant.initiative ? "fa-arrow-right" : "fa-clock-rotate-left"}"></i>
         </a>`;
 
       /** @type {HTMLAnchorElement} */
       const button = initControl.children[0];
 
       button.addEventListener("click", async (element, event) => {
-        const oldValue = combatant.system.turns;
+        const oldValue = combatant.initiative;
         const newValue = oldValue ? oldValue - 1 : combatant.actor.system.combat.turns;
-        await combatant.update({"system.turns": newValue});
+        await combatant.update({initiative: newValue});
         if (oldValue) {
           const newTurn = app.viewed.turns.findIndex((c) => c === combatant);
           combat.update({turn: newTurn}, {direction: 1});

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -27,7 +27,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
 
     schema.combat = new fields.SchemaField({
       size: new fields.EmbeddedDataField(SizeModel),
-      stability: requiredInteger({initial: 0})
+      stability: requiredInteger({initial: 0}),
+      turns: requiredInteger({initial: 1})
     });
 
     schema.biography = new fields.SchemaField(this.actorBiography());
@@ -157,6 +158,13 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
       const active = Number.isNumeric(threshold) && (this.stamina.value <= threshold);
       await this.parent.toggleStatusEffect(key, {active});
     }
+  }
+
+  /**
+   * Update combatant at the start of combat
+   */
+  async startCombat(combatant) {
+    await combatant.update({"system.turns": this.combat.turns});
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -164,7 +164,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
    * Update combatant at the start of combat
    */
   async startCombat(combatant) {
-    await combatant.update({"system.turns": this.combat.turns});
+    await combatant.update({initiative: this.combat.turns});
   }
 
   /**

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -153,6 +153,12 @@ export default class CharacterModel extends BaseActorModel {
   }
 
   /** @override */
+  async startCombat(combatant) {
+    await super.startCombat(combatant);
+    await this.parent.update({"system.hero.primary.value": this.hero.victories});
+  }
+
+  /** @override */
   get reach() {
     return 1 + this.abilityBonuses.melee.distance;
   }

--- a/src/module/data/combatant/base.mjs
+++ b/src/module/data/combatant/base.mjs
@@ -1,3 +1,5 @@
+import {requiredInteger} from "../helpers.mjs";
+
 const fields = foundry.data.fields;
 
 export default class BaseCombatantModel extends foundry.abstract.TypeDataModel {
@@ -13,7 +15,8 @@ export default class BaseCombatantModel extends foundry.abstract.TypeDataModel {
     return {
       disposition: new fields.NumberField({nullable: true, choices: Object.values(CONST.TOKEN_DISPOSITIONS),
         validationError: "must be a value in CONST.TOKEN_DISPOSITIONS"
-      })
+      }),
+      turns: requiredInteger({initial: 0})
     };
   }
 }

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -10,9 +10,8 @@ export class DrawSteelCombat extends Combat {
 
   /** @override */
   async startCombat() {
-    const characters = this.combatants.filter(combatant => combatant.actor.type === "character");
-    for (const character of characters) {
-      await character.actor.update({"system.hero.primary.value": character.actor.system.hero.victories});
+    for (const combatant of this.combatants) {
+      await combatant.actor.system.startCombat(combatant);
     }
 
     return super.startCombat();
@@ -22,7 +21,7 @@ export class DrawSteelCombat extends Combat {
   async nextRound() {
     await super.nextRound();
     if (game.settings.get(systemID, "initiativeMode") !== "default") return;
-    const combatantUpdates = this.combatants.filter(c => !c.initiative).map(c => ({_id: c.id, initiative: 1}));
+    const combatantUpdates = this.combatants.map(c => ({_id: c.id, "system.turns": c.actor.system.combat.turns}));
     this.updateEmbeddedDocuments("Combatant", combatantUpdates);
   }
 

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -21,7 +21,7 @@ export class DrawSteelCombat extends Combat {
   async nextRound() {
     await super.nextRound();
     if (game.settings.get(systemID, "initiativeMode") !== "default") return;
-    const combatantUpdates = this.combatants.map(c => ({_id: c.id, "system.turns": c.actor.system.combat.turns}));
+    const combatantUpdates = this.combatants.map(c => ({_id: c.id, initiative: c.actor.system.combat.turns}));
     this.updateEmbeddedDocuments("Combatant", combatantUpdates);
   }
 

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -21,7 +21,7 @@ export class DrawSteelCombat extends Combat {
   async nextRound() {
     await super.nextRound();
     if (game.settings.get(systemID, "initiativeMode") !== "default") return;
-    const combatantUpdates = this.combatants.map(c => ({_id: c.id, initiative: c.actor.system.combat.turns}));
+    const combatantUpdates = this.combatants.map(c => ({_id: c.id, initiative: c.actor?.system.combat.turns ?? 1}));
     this.updateEmbeddedDocuments("Combatant", combatantUpdates);
   }
 

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -11,7 +11,7 @@ export class DrawSteelCombat extends Combat {
   /** @override */
   async startCombat() {
     for (const combatant of this.combatants) {
-      await combatant.actor.system.startCombat(combatant);
+      await combatant.actor?.system.startCombat(combatant);
     }
 
     return super.startCombat();

--- a/src/module/documents/combatant.mjs
+++ b/src/module/documents/combatant.mjs
@@ -1,4 +1,3 @@
-import {systemID} from "../constants.mjs";
 
 export class DrawSteelCombatant extends Combatant {
   /**
@@ -23,13 +22,5 @@ export class DrawSteelCombatant extends Combatant {
   prepareDerivedData() {
     super.prepareDerivedData();
     Hooks.callAll("ds.prepareCombatantData", this);
-  }
-
-  async _preCreate(data, options, user) {
-    const allowed = await super._preCreate(data, options, user);
-    if (allowed === false) return false;
-
-    // Start all combatants as ready to act
-    if ((game.settings.get(systemID, "initiativeMode") === "default") && !Number.isNumeric(data.initiative)) this.updateSource({initiative: 1});
   }
 }


### PR DESCRIPTION
Added turns to the actor and combatant models. Actor turns is a static number for the combatant to pull from at combat start and next round.

Previously if you set an initiative of 5, on a new round, it would just update to 1. Now this allows it reset to the proper number. Useful for solo monsters.

Added a startCombat method to the actor models to run actor specific stuff like adding heroic resources for characters

If this isn't how you think this should be handled, let me know if you have changes or just want to decline it.

EDIT: I just remembered that players can't update system properties of Combatant. I remembered I saw your issue on the main foundry repo. I've updated the combat tracker to use initiative again instead of the system property. But I still think updating it to the actors turn amount on combat start/new round/reset is helpful. Once v13 hits, can update to using combatant.system.turns