### PR TITLE
Add statuses object to rollData to prevent errors

### DIFF
--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -2,7 +2,7 @@ export class DrawSteelActor extends Actor {
   /** @override */
   getRollData() {
     // Shallow copy
-    const rollData = {...this.system, flags: this.flags, name: this.name};
+    const rollData = {...this.system, flags: this.flags, name: this.name, statuses: {}};
 
     for (const status of this.statuses) {
       rollData.statuses[status] = 1;


### PR DESCRIPTION
Previously rollData.statuses was undefined and erroring.