### PR TITLE
Add prompt for targeted conditions (taunted, grabbed, frightened)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -834,6 +834,12 @@
           "name": "Weakened"
         }
       },
+      "TargetedConditionPrompt": {
+        "Title": "{condition} Configuration",
+        "Prompt": "Input the imposing actor's UUID",
+        "SelectFirstTarget": "Select First Target",
+        "Warning": "An invalid UUID was provided."
+      },
       "StaminaEffects": {
         "Dying": "Dying",
         "Winded": "Winded"

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -122,7 +122,7 @@ preLocalize("damageTypes", {key: "label"});
 /**
  * Condition definitions provided by the system that are merged in during the `init` hook
  * Afterwards all references *should* use the core-provided CONFIG.statusEffects
- * @type {Record<string, {img: string, name: string}>}
+ * @type {Record<string, {img: string, name: string, rule: string, targeted? boolean}>}
  */
 DRAW_STEEL.conditions = {
   bleeding: {
@@ -138,12 +138,15 @@ DRAW_STEEL.conditions = {
   frightened: {
     name: "DRAW_STEEL.Effect.Conditions.Frightened.name",
     img: "icons/svg/terror.svg",
-    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.bXiI9vUF3tF78qXg"
+    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.bXiI9vUF3tF78qXg",
+    targeted: true
+
   },
   grabbed: {
     name: "DRAW_STEEL.Effect.Conditions.Grabbed.name",
     img: "systems/draw-steel/assets/icons/hand-grabbing-fill.svg",
-    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.aWBP2vfXXM3fzuVn"
+    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.aWBP2vfXXM3fzuVn",
+    targeted: true
   },
   prone: {
     name: "DRAW_STEEL.Effect.Conditions.Prone.name",
@@ -163,7 +166,8 @@ DRAW_STEEL.conditions = {
   taunted: {
     name: "DRAW_STEEL.Effect.Conditions.Taunted.name",
     img: "systems/draw-steel/assets/icons/flag-banner-fold-fill.svg",
-    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.9zseFmXdcSw8MuKh"
+    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.9zseFmXdcSw8MuKh",
+    targeted: true
   },
   weakened: {
     name: "DRAW_STEEL.Effect.Conditions.Weakened.name",

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -20,8 +20,13 @@ export class DrawSteelActiveEffect extends ActiveEffect {
    */
   static async targetedConditionPrompt(statusId, sourceData) {
     try {
+      const title = game.i18n.format("DRAW_STEEL.Effect.TargetedConditionPrompt.Title", {
+        condition: CONFIG.statusEffects.find(condition => condition.id === statusId)?.name ?? ""
+      });
       let imposingActorId = await foundry.applications.api.DialogV2.prompt({
-        content: `The imposing actor's UUID: 
+        window: {title},
+        content: `
+            ${game.i18n.localize("DRAW_STEEL.Effect.TargetedConditionPrompt.Prompt")}: 
             <input type=text name="actorId" value="${game.user.targets.first()?.actor?.uuid ?? ""}" />
           `,
         ok: {
@@ -29,8 +34,8 @@ export class DrawSteelActiveEffect extends ActiveEffect {
         },
         buttons: [{
           action: "select-target",
-          label: "Select First Target's UUID",
-          callback: (event, button, dialog) => game.user.targets.first()?.actor?.uuid
+          label: "DRAW_STEEL.Effect.TargetedConditionPrompt.SelectFirstTarget",
+          callback: (event, button, dialog) => game.user.targets.first()?.actor?.uuid ?? ""
         }]
       });
   
@@ -42,7 +47,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
         }];
       }
     } catch (error) {
-      ui.notifications.error("An Invalid UUID was provided. Value was not set and automation won't apply");
+      ui.notifications.warn("DRAW_STEEL.Effect.TargetedConditionPrompt.Warning", {localize: true});
     }
   }
 

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -1,9 +1,49 @@
+import {systemID} from "../constants.mjs";
+
 export class DrawSteelActiveEffect extends ActiveEffect {
   /** @override */
   static async _fromStatusEffect(statusId, effectData, options) {
     const effect = await super._fromStatusEffect(statusId, effectData, options);
-    if (effectData.rule) effect.updateSource({description: `@Embed[${effectData.rule} inline]`});
+    const sourceData = {};
+
+    if (effectData.rule) sourceData.description = `@Embed[${effectData.rule} inline]`;
+    if (["frightened", "grabbed", "taunted"].includes(statusId)) this.targetedConditionPrompt(statusId, sourceData);
+    
+    effect.updateSource(sourceData);
     return effect;
+  }
+
+  /**
+   * Modify the sourceData for the new effect with the changes to include the imposing actor's UUID in the appropriate flag.
+   * @param {string} statusId 
+   * @param {object} sourceData
+   */
+  static async targetedConditionPrompt(statusId, sourceData) {
+    try {
+      let imposingActorId = await foundry.applications.api.DialogV2.prompt({
+        content: `The imposing actor's UUID: 
+            <input type=text name="actorId" value="${game.user.targets.first()?.actor?.uuid ?? ""}" />
+          `,
+        ok: {
+          callback: (event, button, dialog) => dialog.querySelector("input").value
+        },
+        buttons: [{
+          action: "select-target",
+          label: "Select First Target's UUID",
+          callback: (event, button, dialog) => game.user.targets.first()?.actor?.uuid
+        }]
+      });
+  
+      if (foundry.utils.parseUuid(imposingActorId)) {
+        sourceData.changes = [{
+          key: `flags.${systemID}.${statusId}`,
+          mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+          value: imposingActorId
+        }];
+      }
+    } catch (error) {
+      ui.notifications.error("An Invalid UUID was provided. Value was not set and automation won't apply");
+    }
   }
 
   /**

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -7,7 +7,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
     const sourceData = {};
 
     if (effectData.rule) sourceData.description = `@Embed[${effectData.rule} inline]`;
-    if (ds.CONFIG.conditions[statusId]?.targeted) this.targetedConditionPrompt(statusId, sourceData);
+    if (ds.CONFIG.conditions[statusId]?.targeted) await this.targetedConditionPrompt(statusId, sourceData);
     
     effect.updateSource(sourceData);
     return effect;

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -7,7 +7,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
     const sourceData = {};
 
     if (effectData.rule) sourceData.description = `@Embed[${effectData.rule} inline]`;
-    if (["frightened", "grabbed", "taunted"].includes(statusId)) this.targetedConditionPrompt(statusId, sourceData);
+    if (ds.CONFIG.conditions[statusId]?.targeted) this.targetedConditionPrompt(statusId, sourceData);
     
     effect.updateSource(sourceData);
     return effect;


### PR DESCRIPTION
In `DrawSteelActiveEffect._fromStatusEffect`, a prompt will spawn if the statusEffect is a targeted condition. It will automatically pull the first targeted token's actor uuid. There's a button to select the first targeted token's actor uuid. If the uuid seems valid, set a flag in the system's object for the condtion to the uuid. If no valid uuid is input (left blank), a warning will pop up, but it doesn't stop the effect from being added.

Using the targeting system seemed like the easiest way for a user to get a UUID without the help of a GM. Later on, if conditions/effects are auto applied on ability roll, then these could be set there without user interaction.

I made what conditions are considered targeted extensible using a similar method as used in the other places of the config.

Here's what the prompt looks like
![targeted-condition-prompt](https://github.com/user-attachments/assets/3ff93b83-56d2-430f-9f2b-5c2b6c987931)
