### PR TITLE
Add potency information to chat card

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -384,6 +384,9 @@
             "characteristics": {
               "label": "Characteristics"
             },
+            "potencyCharacteristic": {
+              "label": "Potency Characteristic"
+            },
             "tier1": {
               "label": "Tier 1 Result",
               "damage": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -404,9 +404,6 @@
                 "enabled": {
                   "label": "Has Potency"
                 },
-                "characteristic": {
-                  "label": "Potency Characteristic"
-                },
                 "value": {
                   "label": "Potency Value"
                 },
@@ -433,9 +430,6 @@
                 "enabled": {
                   "label": "Has Potency"
                 },
-                "characteristic": {
-                  "label": "Potency Characteristic"
-                },
                 "value": {
                   "label": "Potency Value"
                 },
@@ -461,9 +455,6 @@
               "potency": {
                 "enabled": {
                   "label": "Has Potency"
-                },
-                "characteristic": {
-                  "label": "Potency Characteristic"
                 },
                 "value": {
                   "label": "Potency Value"

--- a/lang/en.json
+++ b/lang/en.json
@@ -398,6 +398,15 @@
                 "label": "Applied Effects"
               },
               "potency": {
+                "enabled": {
+                  "label": "Has Potency"
+                },
+                "characteristic": {
+                  "label": "Potency Characteristic"
+                },
+                "value": {
+                  "label": "Potency Value"
+                },
                 "label": "Potency"
               },
               "description": {
@@ -418,6 +427,15 @@
                 "label": "Applied Effects"
               },
               "potency": {
+                "enabled": {
+                  "label": "Has Potency"
+                },
+                "characteristic": {
+                  "label": "Potency Characteristic"
+                },
+                "value": {
+                  "label": "Potency Value"
+                },
                 "label": "Potency"
               },
               "description": {
@@ -438,6 +456,15 @@
                 "label": "Applied Effects"
               },
               "potency": {
+                "enabled": {
+                  "label": "Has Potency"
+                },
+                "characteristic": {
+                  "label": "Potency Characteristic"
+                },
+                "value": {
+                  "label": "Potency Value"
+                },
                 "label": "Potency"
               },
               "description": {
@@ -562,7 +589,16 @@
           "SlideX": "Slide {x}",
           "Vertical": "Vertical"
         },
-        "EmbedFail": "Failed to find item for this ability roll"
+        "EmbedFail": "Failed to find item for this ability roll",
+        "Potency": {
+          "label": "Potency",
+          "Weak": "Weak",
+          "Average": "Average",
+          "Strong": "Strong",
+          "Embed": "{characteristic}<{value}",
+          "Success": "Success",
+          "Failure": "Failure"
+        }
       },
       "Ancestry": {
         "FIELDS": {}
@@ -920,7 +956,8 @@
           "Bane": "Bane",
           "Banes": "Banes",
           "Label": "{number} {mod}"
-        }
+        },
+        "BaseRoll": "Base Power Roll"
       },
       "Project": {
         "Label": "Project Roll",

--- a/src/module/_types.d.ts
+++ b/src/module/_types.d.ts
@@ -40,5 +40,6 @@ export interface PowerRollPromptOptions {
   actor: DrawSteelActor;
   data: Record<string, unknown>;
   skills: string[];
-  targets: PowerRollTargets[]
+  targets: PowerRollTargets[],
+  ability?: string
 }

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1054,7 +1054,7 @@ preLocalize("abilities.keywords", {keys: ["label", "group"]});
 preLocalize("abilities.types", {key: "label"});
 preLocalize("abilities.categories", {key: "label"});
 // Embed labels intentionally not pre-localized because they rely on `format` instead of `localize`
-preLocalize("abilities.distances", {keys: ["label", "primary", "secondary"]});
+preLocalize("abilities.distances", {keys: ["label", "primary", "secondary", "tertiary"]});
 preLocalize("abilities.targets", {keys: ["label", "all"]});
 preLocalize("abilities.forcedMovement", {key: "label"});
 

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -27,12 +27,25 @@ declare module "./base.mjs" {
 }
 
 declare module "./ability.mjs" {
+
+  export interface Potency {
+    potency: {
+      enabled: boolean,
+      value: string | number;
+      characteristic: string;
+    }
+  }
+  export interface PotencyData extends Potency {
+    embed: string
+  }
+
   type PowerRoll = {
     damage: {
       value: string;
       type: string;
     }
     ae: string;
+    potency: Potency;
     forced: {
       type: string;
       value: number;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -62,7 +62,7 @@ export default class AbilityModel extends BaseItemModel {
       ae: new fields.SetField(setOptions({validate: foundry.data.validators.isValidId})),
       potency: new fields.SchemaField({
         enabled: new fields.BooleanField(),
-        value: new FormulaField({deterministic: true, initial: initialPotency, required: false})
+        value: new FormulaField({deterministic: true, initial: initialPotency, blank: false})
       }),
       forced: new fields.SchemaField({
         type: new fields.StringField({choices: config.forcedMovement, blank: false}),
@@ -190,9 +190,10 @@ export default class AbilityModel extends BaseItemModel {
       enabled: potency.enabled && !!this.powerRoll.potencyCharacteristic
     };
 
-    if (!potencyData.enabled) return potencyData;
+    // If potency is not enabled or there is no potency value return early
+    if (!potencyData.enabled && !potency.value) return potencyData;
 
-    const potencyValue = (await new DSRoll(potency.value, this.parent.getRollData()).evaluate()).total;
+    const potencyValue = new DSRoll(potency.value, this.parent.getRollData()).evaluateSync().total;
     potencyData.characteristic = potency.characteristic;
     potencyData.value = potencyValue;
     potencyData.embed = game.i18n.format("DRAW_STEEL.Item.Ability.Potency.Embed", {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -180,10 +180,9 @@ export default class AbilityModel extends BaseItemModel {
 
   /**
    * Generate the potency data for a given tier.
-   * Unable to have this done during ability data preparation as the actor potency information isn't updated yet
    *
    * @param {string} tierName The name of the tier to pull from the power roll
-   * @returns {PotencyData}
+   * @returns {Promise<PotencyData>}
    */
   async getPotencyData(tierName) {
     const potency = this.powerRoll[tierName].potency;
@@ -376,7 +375,6 @@ export default class AbilityModel extends BaseItemModel {
 
       if (!powerRolls) return null;
       const baseRoll = powerRolls.findSplice(powerRoll => powerRoll.options.baseRoll);
-      console.log(baseRoll);
 
       // Power Rolls grouped by tier of success
       const groupedRolls = powerRolls.reduce((accumulator, powerRoll) => {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -196,7 +196,7 @@ export default class AbilityModel extends BaseItemModel {
     potencyData.characteristic = potency.characteristic;
     potencyData.value = potencyValue;
     potencyData.embed = game.i18n.format("DRAW_STEEL.Item.Ability.Potency.Embed", {
-      characteristic: game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${potency.characteristic}.abbreviation`),
+      characteristic: game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${this.powerRoll.potencyCharacteristic}.abbreviation`),
       value: potencyValue
     });
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -182,9 +182,9 @@ export default class AbilityModel extends BaseItemModel {
    * Generate the potency data for a given tier.
    *
    * @param {string} tierName The name of the tier to pull from the power roll
-   * @returns {Promise<Partial<PotencyData>>}
+   * @returns {Partial<PotencyData>}
    */
-  async getPotencyData(tierName) {
+  getPotencyData(tierName) {
     const potency = this.powerRoll[tierName].potency;
     const potencyData = {
       enabled: potency.enabled && !!this.powerRoll.potencyCharacteristic
@@ -194,10 +194,10 @@ export default class AbilityModel extends BaseItemModel {
     if (!potencyData.enabled && !potency.value) return potencyData;
 
     const potencyValue = new DSRoll(potency.value, this.parent.getRollData()).evaluateSync().total;
-    potencyData.characteristic = potency.characteristic;
+    potencyData.characteristic = this.powerRoll.potencyCharacteristic;
     potencyData.value = potencyValue;
     potencyData.embed = game.i18n.format("DRAW_STEEL.Item.Ability.Potency.Embed", {
-      characteristic: game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${this.powerRoll.potencyCharacteristic}.abbreviation`),
+      characteristic: game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${potencyData.characteristic}.abbreviation`),
       value: potencyValue
     });
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -181,9 +181,9 @@ export default class AbilityModel extends BaseItemModel {
   /**
    * Generate the potency data for a given tier.
    * Unable to have this done during ability data preparation as the actor potency information isn't updated yet
-   * 
+   *
    * @param {string} tierName The name of the tier to pull from the power roll
-   * @returns {PotencyData}    
+   * @returns {PotencyData}
    */
   getPotencyData(tierName) {
     const potency = this.powerRoll[tierName].potency;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -62,7 +62,7 @@ export default class AbilityModel extends BaseItemModel {
       ae: new fields.SetField(setOptions({validate: foundry.data.validators.isValidId})),
       potency: new fields.SchemaField({
         enabled: new fields.BooleanField(),
-        characteristic: new fields.StringField(),
+        characteristic: new fields.StringField({initial: "might"}),
         value: new FormulaField({deterministic: true, initial: initialPotency, required: false})
       }),
       forced: new fields.SchemaField({
@@ -185,9 +185,9 @@ export default class AbilityModel extends BaseItemModel {
    * @param {string} tierName The name of the tier to pull from the power roll
    * @returns {PotencyData}
    */
-  getPotencyData(tierName) {
+  async getPotencyData(tierName) {
     const potency = this.powerRoll[tierName].potency;
-    const potencyValue = DSRoll.replaceFormulaData(potency.value, this.parent.getRollData());
+    const potencyValue = (await new DSRoll(potency.value, this.parent.getRollData()).evaluate()).total;
     return {
       enabled: potency.enabled,
       characteristic: potency.characteristic,

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -281,7 +281,7 @@ export class PowerRoll extends DSRoll {
     if (this.options.target) context.target = await fromUuid(this.options.target);
     if (this.options.ability) {
       context.ability = await fromUuid(this.options.ability);
-      const abilityPotency = context.ability.system.getPotencyData(this.tier);
+      const abilityPotency = await context.ability.system.getPotencyData(this.tier);
 
       if (abilityPotency.enabled) {
         context.potency = {...abilityPotency};

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -128,7 +128,7 @@ export class PowerRoll extends DSRoll {
     const flavor = options.flavor ?? typeLabel;
 
     this.getActorModifiers(options);
-    const context = {     
+    const context = {
       modifiers: options.modifiers,
       targets: options.targets
     };
@@ -158,7 +158,7 @@ export class PowerRoll extends DSRoll {
 
     const baseRoll = new this(formula, options.data, {baseRoll: true});
     await baseRoll.evaluate();
-    
+
     const speaker = DrawSteelChatMessage.getSpeaker({actor: options.actor});
     const rolls = [baseRoll];
     for (const context of rollContexts) {
@@ -176,7 +176,7 @@ export class PowerRoll extends DSRoll {
           rolls.push(await roll.toMessage({speaker}));
           break;
       }
-    }    
+    }
     return rolls;
   }
 
@@ -295,7 +295,7 @@ export class PowerRoll extends DSRoll {
     return context;
   }
 
-  /** 
+  /**
    * Modify the options object based on conditions that apply to all Power Rolls
    * @param {Partial<PowerRollPromptOptions>} [options] Options for the dialog
    */

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -287,7 +287,6 @@ export class PowerRoll extends DSRoll {
       if (abilityPotency.enabled) {
         context.potency = {...abilityPotency};
         if (context.target) {
-          console.log(context.target.system.characteristics[abilityPotency.characteristic]?.value, abilityPotency);
           context.potency.result = context.target.system.characteristics[abilityPotency.characteristic]?.value >= abilityPotency.value ? "Success" : "Failure";
         }
       }

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -133,6 +133,8 @@ export class PowerRoll extends DSRoll {
       targets: options.targets
     };
 
+    if (options.ability) context.ability = options.ability;
+
     if (options.skills) {
       context.skills = options.skills.reduce((obj, skill) => {
         const label = ds.CONFIG.skills.list[skill]?.label;
@@ -154,12 +156,13 @@ export class PowerRoll extends DSRoll {
 
     if (!rollContexts) return null;
 
-    const baseRoll = new this(formula);
+    const baseRoll = new this(formula, options.data, {baseRoll: true});
     await baseRoll.evaluate();
     
     const speaker = DrawSteelChatMessage.getSpeaker({actor: options.actor});
-    const rolls = [];
+    const rolls = [baseRoll];
     for (const context of rollContexts) {
+      if (options.ability) context.ability = options.ability;
       const roll = new this(formula, options.data, {flavor, ...context});
       roll.terms[0] = baseRoll.terms[0];
       switch (evaluation) {
@@ -275,8 +278,18 @@ export class PowerRoll extends DSRoll {
       mod: game.i18n.localize(modString)
     };
 
-    context.target = await fromUuid(this.options.target);
+    if (this.options.target) context.target = await fromUuid(this.options.target);
+    if (this.options.ability) {
+      context.ability = await fromUuid(this.options.ability);
+      const abilityPotency = context.ability.system.getPotencyData(this.tier);
 
+      if (abilityPotency.enabled) {
+        context.potency = {...abilityPotency};
+        if (context.target) context.potency.result = context.target.system.characteristics[abilityPotency.characteristic]?.value >= abilityPotency.value ? "Success" : "Failure";
+      }
+    }
+
+    context.baseRoll = this.options.baseRoll ?? false;
     context.critical = (this.isCritical || this.isNat20) ? "critical" : "";
 
     return context;

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -281,11 +281,15 @@ export class PowerRoll extends DSRoll {
     if (this.options.target) context.target = await fromUuid(this.options.target);
     if (this.options.ability) {
       context.ability = await fromUuid(this.options.ability);
-      const abilityPotency = await context.ability.system.getPotencyData(this.tier);
+      const abilityPotency = context.ability.system.getPotencyData(this.tier);
 
+      console.log(abilityPotency);
       if (abilityPotency.enabled) {
         context.potency = {...abilityPotency};
-        if (context.target) context.potency.result = context.target.system.characteristics[abilityPotency.characteristic]?.value >= abilityPotency.value ? "Success" : "Failure";
+        if (context.target) {
+          console.log(context.target.system.characteristics[abilityPotency.characteristic]?.value, abilityPotency);
+          context.potency.result = context.target.system.characteristics[abilityPotency.characteristic]?.value >= abilityPotency.value ? "Success" : "Failure";
+        }
       }
     }
 

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -282,8 +282,7 @@ export class PowerRoll extends DSRoll {
     if (this.options.ability) {
       context.ability = await fromUuid(this.options.ability);
       const abilityPotency = context.ability.system.getPotencyData(this.tier);
-
-      console.log(abilityPotency);
+      
       if (abilityPotency.enabled) {
         context.potency = {...abilityPotency};
         if (context.target) {

--- a/src/scss/global/_roll.scss
+++ b/src/scss/global/_roll.scss
@@ -22,5 +22,19 @@
 
   .potency {
     flex-basis: 100%;
+
+    .label {
+      font-weight: bold;
+    }
+
+    .result {
+      &.Success {
+        color: var(--draw-steel-c-success);
+      }
+
+      &.Failure {
+        color: var(--draw-steel-c-failure);
+      }
+    }
   }
 }

--- a/src/scss/global/_roll.scss
+++ b/src/scss/global/_roll.scss
@@ -3,9 +3,11 @@
   padding: 5px;
   border-radius: 5px;
 
-  .target-info {
+  .header {
     flex-basis: 100%;
     text-align: center;
+    font-size: var(--font-size-16);
+    font-weight: bold;
   }
 
   .dice-result {
@@ -16,5 +18,9 @@
     .failure {
       color: red;
     }
+  }
+
+  .potency {
+    flex-basis: 100%;
   }
 }

--- a/src/scss/utils/_colors.scss
+++ b/src/scss/utils/_colors.scss
@@ -6,6 +6,8 @@
   --draw-steel-c-white: #ffffff;
   --draw-steel-c-black: #000000;
   --draw-steel-c-groove: #eeede0;
+  --draw-steel-c-success: green;
+  --draw-steel-c-failure: red;
 }
 
 .theme-dark {

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -4,10 +4,11 @@
   {{formGroup field.fields.damage.fields.value value=value.damage.value}}
   {{formGroup field.fields.damage.fields.type value=value.damage.type options=damageTypes blank=""}}
   {{formGroup field.fields.ae value=value.ae options=appliedEffects}}
+  {{#if @root.system.powerRoll.potencyCharacteristic}}
   {{formGroup field.fields.potency.fields.enabled value=value.potency.enabled}}
   {{#if value.potency.enabled}}
-  {{formGroup field.fields.potency.fields.characteristic value=value.potency.characteristic options=@root.characteristics}}
   {{formGroup field.fields.potency.fields.value value=value.potency.value}}
+  {{/if}}
   {{/if}}
   {{formGroup field.fields.description value=value.description}}
   {{!-- TODO: Forced Movement --}}
@@ -51,6 +52,7 @@
 {{#if system.powerRoll.enabled}}
 {{formGroup systemFields.powerRoll.fields.characteristics value=system.powerRoll.characteristics options=characteristics}}
 {{formGroup systemFields.powerRoll.fields.formula value=system.powerRoll.formula}}
+{{formGroup systemFields.powerRoll.fields.potencyCharacteristic value=system.powerRoll.potencyCharacteristic options=characteristics blank=""}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier1 value=system.powerRoll.tier1}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier2 value=system.powerRoll.tier2}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier3 value=system.powerRoll.tier3}}

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -7,7 +7,7 @@
   {{#if @root.system.powerRoll.potencyCharacteristic}}
   {{formGroup field.fields.potency.fields.enabled value=value.potency.enabled}}
   {{#if value.potency.enabled}}
-  {{formGroup field.fields.potency.fields.value value=value.potency.value}}
+  {{formGroup field.fields.potency.fields.value value=value.potency.value placeholder=field.fields.potency.fields.value.initial}}
   {{/if}}
   {{/if}}
   {{formGroup field.fields.description value=value.description}}

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -6,7 +6,7 @@
   {{formGroup field.fields.ae value=value.ae options=appliedEffects}}
   {{formGroup field.fields.potency.fields.enabled value=value.potency.enabled}}
   {{#if value.potency.enabled}}
-  {{formGroup field.fields.potency.fields.characteristic value=value.potency.characteristic options=@root.characteristics blank=""}}
+  {{formGroup field.fields.potency.fields.characteristic value=value.potency.characteristic options=@root.characteristics}}
   {{formGroup field.fields.potency.fields.value value=value.potency.value}}
   {{/if}}
   {{formGroup field.fields.description value=value.description}}

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -4,7 +4,11 @@
   {{formGroup field.fields.damage.fields.value value=value.damage.value}}
   {{formGroup field.fields.damage.fields.type value=value.damage.type options=damageTypes blank=""}}
   {{formGroup field.fields.ae value=value.ae options=appliedEffects}}
-  {{formGroup field.fields.potency value=value.potency}}
+  {{formGroup field.fields.potency.fields.enabled value=value.potency.enabled}}
+  {{#if value.potency.enabled}}
+  {{formGroup field.fields.potency.fields.characteristic value=value.potency.characteristic options=@root.characteristics blank=""}}
+  {{formGroup field.fields.potency.fields.value value=value.potency.value}}
+  {{/if}}
   {{formGroup field.fields.description value=value.description}}
   {{!-- TODO: Forced Movement --}}
 </fieldset>

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -7,7 +7,7 @@
     {{target.name}}
     {{/if}}
   </div>
-  
+
   {{#unless baseRoll}}
   <div class="tier {{tier.class}}">
     {{tier.label}}

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -23,7 +23,7 @@
     <span class="label">{{localize "DRAW_STEEL.Item.Ability.Potency.label"}}: </span>
     <span class="embed">{{potency.embed}}</span>
     {{#if potency.result}}
-    <span class="result">({{localize (concat "DRAW_STEEL.Item.Ability.Potency." potency.result)}})</span>
+    <span class="result {{potency.result}}">({{localize (concat "DRAW_STEEL.Item.Ability.Potency." potency.result)}})</span>
     {{/if}}
   </div>
   {{/if}}

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -1,5 +1,4 @@
 <div class="dice-roll">
-  {{log baseRoll}}
   <div class="header" data-uuid="{{target.uuid}}">
     {{#if baseRoll}}
     {{localize "DRAW_STEEL.Roll.Power.BaseRoll"}}

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -1,21 +1,40 @@
 <div class="dice-roll">
-  {{#if target}}
-  <div class="target-info" data-uuid="{{target.uuid}}">
+  {{log baseRoll}}
+  <div class="header" data-uuid="{{target.uuid}}">
+    {{#if baseRoll}}
+    {{localize "DRAW_STEEL.Roll.Power.BaseRoll"}}
+    {{else if target}}
     {{target.name}}
+    {{/if}}
   </div>
-  {{/if}}
+  
+  {{#unless baseRoll}}
   <div class="tier {{tier.class}}">
     {{tier.label}}
     {{#if modifier.number}}
     <em>({{localize "DRAW_STEEL.Roll.Power.Modifier.Label" number=modifier.number mod=modifier.mod}})</em>
     {{/if}}
   </div>
+  {{/unless}}
   {{#if flavor}}
   <div class="dice-flavor">{{flavor}}</div>
   {{/if}}
+  {{#if potency}}
+  <div class="potency" data-result="{{potency.result}}">
+    {{localize "DRAW_STEEL.Item.Ability.Potency.label"}}: {{potency.embed}}
+    {{#if potency.result}}
+    -
+    {{localize (concat "DRAW_STEEL.Item.Ability.Potency." potency.result)}}
+    {{/if}}
+  </div>
+  {{/if}}
   <div class="dice-result">
+    {{#if baseRoll}}
     <div class="dice-formula">{{formula}}</div>
     {{{tooltip}}}
+    {{/if}}
+    {{#unless baseRoll}}
     <h4 class="dice-total {{critical}}">{{total}}</h4>
+    {{/unless}}
   </div>
 </div>

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -20,10 +20,10 @@
   {{/if}}
   {{#if potency}}
   <div class="potency" data-result="{{potency.result}}">
-    {{localize "DRAW_STEEL.Item.Ability.Potency.label"}}: {{potency.embed}}
+    <span class="label">{{localize "DRAW_STEEL.Item.Ability.Potency.label"}}: </span>
+    <span class="embed">{{potency.embed}}</span>
     {{#if potency.result}}
-    -
-    {{localize (concat "DRAW_STEEL.Item.Ability.Potency." potency.result)}}
+    <span class="result">({{localize (concat "DRAW_STEEL.Item.Ability.Potency." potency.result)}})</span>
     {{/if}}
   </div>
   {{/if}}


### PR DESCRIPTION
Closes #177

Summary of changes:
- Updated potency property to a schema that includes `enabled`, `characteristic`, and `value`. Value has an initial value of the relevant potency values roll data (i.e. @potency.weak).
- Added a `getPotencyData` method for retrieving the potency data for a given tier. This will evaluate the potency value and generate the embed text.
- Added the ability uuid to the roll data, so the ability info can be pulled during the roll's context preparation.
- The roll chat card now displays the potency embed text and whether the given target passes the potency value.
- I also updated the chat card to remove the duplicate formulas. Now the base power roll is displayed and for each target/roll only the total is shown. This will save space if there are many targets.
- Random bug fix for ability distance's not localizing the tertiary values.

Updated chat card
![update-chat-card](https://github.com/user-attachments/assets/3ded04e6-79c3-474b-bcce-a29e1323be7f)
