### PR TITLE
Added initial and placeholder values for ability roll bonus

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -71,7 +71,7 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.powerRoll = new fields.SchemaField({
       enabled: new fields.BooleanField(),
-      formula: new FormulaField({initial: "@chr"}),
+      formula: new FormulaField({blank: false, initial: "@chr"}),
       characteristics: new fields.SetField(setOptions()),
       tier1: new fields.SchemaField(powerRollSchema()),
       tier2: new fields.SchemaField(powerRollSchema()),

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -71,7 +71,7 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.powerRoll = new fields.SchemaField({
       enabled: new fields.BooleanField(),
-      formula: new FormulaField(),
+      formula: new FormulaField({initial: "@chr"}),
       characteristics: new fields.SetField(setOptions()),
       tier1: new fields.SchemaField(powerRollSchema()),
       tier2: new fields.SchemaField(powerRollSchema()),

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -46,7 +46,7 @@
 {{formGroup systemFields.powerRoll.fields.enabled value=system.powerRoll.enabled}}
 {{#if system.powerRoll.enabled}}
 {{formGroup systemFields.powerRoll.fields.characteristics value=system.powerRoll.characteristics options=characteristics}}
-{{formGroup systemFields.powerRoll.fields.formula value=system.powerRoll.formula}}
+{{formGroup systemFields.powerRoll.fields.formula value=system.powerRoll.formula placeholder=systemFields.powerRoll.fields.formula.initial}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier1 value=system.powerRoll.tier1}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier2 value=system.powerRoll.tier2}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier3 value=system.powerRoll.tier3}}


### PR DESCRIPTION
Theory is simple - `@chr` will evaluate to 0 if no characteristics are set, but otherwise this is going to be the default for a *lot* of powers.

![image](https://github.com/user-attachments/assets/4d2ea2c9-b0f8-4099-a349-cfe4d21ea1f7)
