### PR TITLE
Reduce speeds when slowed

### DIFF
--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -122,7 +122,7 @@ preLocalize("damageTypes", {key: "label"});
 /**
  * Condition definitions provided by the system that are merged in during the `init` hook
  * Afterwards all references *should* use the core-provided CONFIG.statusEffects
- * @type {Record<string, {img: string, name: string, rule: string, targeted? boolean}>}
+ * @type {Record<string, {img: string, name: string, rule: string, targeted? boolean, maxSources?: number, defaultSpeed?: number}>}
  */
 DRAW_STEEL.conditions = {
   bleeding: {
@@ -161,7 +161,8 @@ DRAW_STEEL.conditions = {
   slowed: {
     name: "DRAW_STEEL.Effect.Conditions.Slowed.name",
     img: "systems/draw-steel/assets/icons/snail.svg",
-    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.aFEwQG4OcYDNp8DL"
+    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.aFEwQG4OcYDNp8DL",
+    defaultSpeed: 2
   },
   taunted: {
     name: "DRAW_STEEL.Effect.Conditions.Taunted.name",

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -80,6 +80,12 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     this.potency = {
       bonuses: 0
     };
+
+    this.statuses = {
+      slowed: {
+        speed: ds.CONFIG.conditions.slowed.defaultSpeed
+      }
+    };
   }
 
   /** @override */
@@ -90,9 +96,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
 
     // Reduce all movement speeds when slowed
     if (this.parent.statuses.has("slowed")) {
-      const slowedSpeed = this.statuses?.slowed?.speed ?? ds.CONFIG.conditions.slowed.defaultSpeed;
       for (const movement in this.movement) {
-        if (this.movement[movement] > slowedSpeed) this.movement[movement] = slowedSpeed;
+        if (this.movement[movement] > this.statuses.slowed.speed) this.movement[movement] = this.statuses.slowed.speed;
       }
     }
   }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -87,6 +87,13 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     super.prepareDerivedData();
 
     this.stamina.winded = Math.floor(this.stamina.max / 2);
+
+    // Reduce all movement speeds when slowed
+    if (this.parent.statuses.has("slowed")) {
+      for (const movement in this.movement) {
+        this.movement[movement] = this.statuses?.slowed?.speed ?? ds.CONFIG.conditions.slowed.defaultSpeed;
+      }
+    }
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -90,8 +90,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
 
     // Reduce all movement speeds when slowed
     if (this.parent.statuses.has("slowed")) {
+      const slowedSpeed = this.statuses?.slowed?.speed ?? ds.CONFIG.conditions.slowed.defaultSpeed;
       for (const movement in this.movement) {
-        const slowedSpeed = this.statuses?.slowed?.speed ?? ds.CONFIG.conditions.slowed.defaultSpeed;
         if (this.movement[movement] > slowedSpeed) this.movement[movement] = slowedSpeed;
       }
     }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -91,7 +91,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     // Reduce all movement speeds when slowed
     if (this.parent.statuses.has("slowed")) {
       for (const movement in this.movement) {
-        this.movement[movement] = this.statuses?.slowed?.speed ?? ds.CONFIG.conditions.slowed.defaultSpeed;
+        const slowedSpeed = this.statuses?.slowed?.speed ?? ds.CONFIG.conditions.slowed.defaultSpeed;
+        if (this.movement[movement] > slowedSpeed) this.movement[movement] = slowedSpeed;
       }
     }
   }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -88,7 +88,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
   apply(actor, change) {
     // If there's a change to the slowed speed, and the property does not exist, set it to the default slowed speed. This allows for upgrade/downgrade to apply.
     const path = "system.statuses.slowed.speed";
-    if ((change.key === path) && foundry.utils.hasProperty(actor, path))
+    if ((change.key === path) && !foundry.utils.hasProperty(actor, path))
       foundry.utils.setProperty(actor, path, ds.CONFIG.conditions.slowed.defaultSpeed);
 
     return super.apply(actor, change);

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -85,8 +85,17 @@ export class DrawSteelActiveEffect extends ActiveEffect {
   }
 
   /** @override */
+  apply(actor, change) {
+    // If there's a change to the slowed speed, and the property does not exist, set it to the default slowed speed. This allows for upgrade/downgrade to apply.
+    const slowedSpeedChange = change.key.match(/^system\.statuses\.slowed\.speed$/);
+    if (!!slowedSpeedChange && !actor.system.statuses?.slowed?.speed) foundry.utils.mergeObject(actor, {"system.statuses.slowed.speed": ds.CONFIG.conditions.slowed.defaultSpeed});
+
+    return super.apply(actor, change);
+  }
+
+  /** @override */
   _applyAdd(actor, change, current, delta, changes) {
-    // If the change is setting a condition source and it doesn't exist on the actor, set the current value to an empty array. 
+    // If the change is setting a condition source and it doesn't exist on the actor, set the current value to an empty array.
     // If it does exist, convert the Set to an Array.
     const match = change.key.match(/^system\.statuses\.(?<condition>[a-z]+)\.sources$/);
     const condition = match?.groups.condition;
@@ -99,12 +108,11 @@ export class DrawSteelActiveEffect extends ActiveEffect {
     // Have the base class apply the changes
     super._applyAdd(actor, change, current, delta, changes);
 
-    // If the condition has a max value, slice the array to the max length
-    if (config?.maxSources) {
-      changes[change.key] = changes[change.key].slice(-config.maxSources);
+    // If we're modifying a condition source, slice the array to the max length if applicable, then convert back to Set
+    if (config) {
+      if (config.maxSources) changes[change.key] = changes[change.key].slice(-config.maxSources);
+      changes[change.key] = new Set(changes[change.key]);
     }
-
-    changes[change.key] = new Set(changes[change.key]);
   }
 
   /** @override */

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -85,16 +85,6 @@ export class DrawSteelActiveEffect extends ActiveEffect {
   }
 
   /** @override */
-  apply(actor, change) {
-    // If there's a change to the slowed speed, and the property does not exist, set it to the default slowed speed. This allows for upgrade/downgrade to apply.
-    const path = "system.statuses.slowed.speed";
-    if ((change.key === path) && !foundry.utils.hasProperty(actor, path))
-      foundry.utils.setProperty(actor, path, ds.CONFIG.conditions.slowed.defaultSpeed);
-
-    return super.apply(actor, change);
-  }
-
-  /** @override */
   _applyAdd(actor, change, current, delta, changes) {
     // If the change is setting a condition source and it doesn't exist on the actor, set the current value to an empty array.
     // If it does exist, convert the Set to an Array.

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -125,4 +125,22 @@ export class DrawSteelActiveEffect extends ActiveEffect {
 
     super._applyOverride(actor, change, current, delta, changes);
   }
+
+  /**
+   * TODO: REMOVE IN V13
+   * Fix bug where _applyUpgrade can set value to undefined
+   * @override
+   */
+  _applyUpgrade(actor, change, current, delta, changes) {
+    let update = current;
+    const ct = foundry.utils.getType(current);
+    switch (ct) {
+      case "boolean":
+      case "number":
+        if ((change.mode === CONST.ACTIVE_EFFECT_MODES.UPGRADE) && (delta > current)) update = delta;
+        else if ((change.mode === CONST.ACTIVE_EFFECT_MODES.DOWNGRADE) && (delta < current)) update = delta;
+        break;
+    }
+    changes[change.key] = update;
+  }
 }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -87,8 +87,9 @@ export class DrawSteelActiveEffect extends ActiveEffect {
   /** @override */
   apply(actor, change) {
     // If there's a change to the slowed speed, and the property does not exist, set it to the default slowed speed. This allows for upgrade/downgrade to apply.
-    const slowedSpeedChange = change.key.match(/^system\.statuses\.slowed\.speed$/);
-    if (!!slowedSpeedChange && !actor.system.statuses?.slowed?.speed) foundry.utils.mergeObject(actor, {"system.statuses.slowed.speed": ds.CONFIG.conditions.slowed.defaultSpeed});
+    const path = "system.statuses.slowed.speed";
+    if ((change.key === path) && foundry.utils.getProperty(actor, path))
+      foundry.utils.setProperty(actor, path, ds.CONFIG.conditions.slowed.defaultSpeed);
 
     return super.apply(actor, change);
   }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -88,7 +88,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
   apply(actor, change) {
     // If there's a change to the slowed speed, and the property does not exist, set it to the default slowed speed. This allows for upgrade/downgrade to apply.
     const path = "system.statuses.slowed.speed";
-    if ((change.key === path) && foundry.utils.getProperty(actor, path))
+    if ((change.key === path) && foundry.utils.hasProperty(actor, path))
       foundry.utils.setProperty(actor, path, ds.CONFIG.conditions.slowed.defaultSpeed);
 
     return super.apply(actor, change);

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -282,7 +282,7 @@ export class PowerRoll extends DSRoll {
     return context;
   }
 
-  /** 
+  /**
    * Modify the options object based on conditions that apply to all Power Rolls
    * @param {Partial<PowerRollPromptOptions>} [options] Options for the dialog
    */


### PR DESCRIPTION
Closes #121 

Summary of Change:
- Added `defaultSpeed` to the slowed condition config.
- In `ActiveEffect.apply` if there's a speed change, set `system.statuses.slowed.speed` to `defaultSpeed`. This is necessary for the upgrade mode to apply. I made the AE key similar to the condition sources one.
- In `Actor.prepareDerivedData` set all movement speeds to either `system.statuses.slowed.speed` or the `defaultSpeed`. 
- In testing this, I realized that I messed up on the frightened PR. It was always converting the value to a Set instead of only when it was a change to a condition source.

There is currently an issue with `ActiveEffect._applyUpgrade` potentially making the value `undefined`. Looks like it's fixed in V13. https://github.com/foundryvtt/foundryvtt/issues/11527. Should I apply an override to that method to fix it until we swap to V13?