### PR TITLE
Added power roll results to embeds

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -936,6 +936,11 @@
           "Two": "Tier 2",
           "Three": "Tier 3"
         },
+        "Results": {
+          "Tier1": "11 or lower",
+          "Tier2": "12–16",
+          "Tier3": "17+"
+        },
         "Types": {
           "Ability": "Ability Roll",
           "Test": "Test"

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -212,12 +212,11 @@ export default class AbilityModel extends BaseItemModel {
     // All abilities are rendered inline
     config.inline = true;
 
-    // TODO: Determine syntax for including tier 1, 2, & 3 results
-
+    // If unspecified assume all three tiers are desired for display
     if (!(("tier1" in config) || ("tier2" in config) || ("tier3" in config))) {
-      config.tier1 = true;
-      config.tier2 = true;
-      config.tier3 = true;
+      config.tier1 = this.powerRoll.enabled;
+      config.tier2 = this.powerRoll.enabled;
+      config.tier3 = this.powerRoll.enabled;
     }
 
     const embed = document.createElement("div");

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -211,6 +211,15 @@ export default class AbilityModel extends BaseItemModel {
   async toEmbed(config, options = {}) {
     // All abilities are rendered inline
     config.inline = true;
+
+    // TODO: Determine syntax for including tier 1, 2, & 3 results
+
+    if (!(("tier1" in config) || ("tier2" in config) || ("tier3" in config))) {
+      config.tier1 = true;
+      config.tier2 = true;
+      config.tier3 = true;
+    }
+
     const embed = document.createElement("div");
     embed.classList.add("ability");
     embed.insertAdjacentHTML("afterbegin", `<h5>${this.parent.name}</h5>`);
@@ -220,6 +229,9 @@ export default class AbilityModel extends BaseItemModel {
       config: ds.CONFIG,
       resourceName: this.actor?.system.coreResource.name ?? game.i18n.localize("DRAW_STEEL.Actor.Character.FIELDS.hero.primary.label")
     };
+    if (config.tier1) context.tier1 = true;
+    if (config.tier2) context.tier2 = true;
+    if (config.tier3) context.tier3 = true;
     this.getSheetContext(context);
     const abilityBody = await renderTemplate(systemPath("templates/item/embeds/ability.hbs"), context);
     embed.insertAdjacentHTML("beforeend", abilityBody);

--- a/src/module/data/message/ability-use.mjs
+++ b/src/module/data/message/ability-use.mjs
@@ -35,8 +35,6 @@ export default class AbilityUseModel extends BaseMessageModel {
 
     const content = html.querySelector(".message-content");
 
-    console.log(item, tier);
-
     if (this.embedText) {
       /** @type {HTMLDivElement} */
       let embed;

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -26,7 +26,7 @@
     </p>
   </div>
 </section>
-{{#if (and (or tier1 tier2 tier3) system.powerRoll.enabled)}}
+{{#if (or tier1 tier2 tier3)}}
 <section class="powerResult">
   {{#if tier1}}
   <p>

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -26,6 +26,25 @@
     </p>
   </div>
 </section>
+{{#if (and (or tier1 tier2 tier3) system.powerRoll.enabled)}}
+<section class="powerResult">
+  {{#if tier1}}
+  <p>
+    <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier1"}}:</strong> {{system.powerRoll.tier1.description}}
+  </p>
+  {{/if}}
+  {{#if tier2}}
+  <p>
+    <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier2"}}:</strong> {{system.powerRoll.tier2.description}}
+  </p>
+  {{/if}}
+  {{#if tier3}}
+  <p>
+    <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier3"}}:</strong> {{system.powerRoll.tier3.description}}
+  </p>
+  {{/if}}
+</section>
+{{/if}}
 {{#if system.effect}}
 <section class="effect">
   <p>
@@ -33,4 +52,3 @@
   </p>
 </section>
 {{/if}}
-{{!-- Power Tiers --}}

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -15,7 +15,7 @@
 </fieldset>
 {{/inline}}
 {{#if isPlay}}
-{{> "systems/draw-steel/templates/item/embeds/ability.hbs"}}
+{{> "systems/draw-steel/templates/item/embeds/ability.hbs" tier1="true" tier2="true" tier3="true"}}
 {{else}}
 {{formGroup systemFields.description.fields.flavor value=system.description.flavor}}
 {{formGroup systemFields.keywords value=system.keywords options=config.abilities.keywords.optgroups}}


### PR DESCRIPTION
Further leverages the embed system to conditionally show descriptions for each power roll tier, adding clarity to the play mode sheet as well as the chat rolls

Closes #178

![image](https://github.com/user-attachments/assets/8032eee2-cc21-4ad6-a208-70f8d979b699)

![image](https://github.com/user-attachments/assets/c60eafc1-4ae9-4773-8767-c53164ab9e63)
