### PR TITLE
Add feature subtypes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -758,8 +758,18 @@
           }
         },
         "Types": {
-          "Perk": "Perk",
-          "Title": "Title"
+          "Perk": {
+            "label": "Perk",
+            "Crafting": "Crafting",
+            "Exploration": "Exploration",
+            "Interpersonal": "Interpersonal",
+            "Intrigue": "Intrigue",
+            "Lore": "Lore",
+            "Supernatural": "Supernatural"
+          },
+          "Title": {
+            "label":"Title"
+          }
         }
       },
       "Kit": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -759,7 +759,7 @@
         },
         "Types": {
           "Perk": {
-            "label": "Perk",
+            "Label": "Perk",
             "Crafting": "Crafting",
             "Exploration": "Exploration",
             "Interpersonal": "Interpersonal",
@@ -768,7 +768,7 @@
             "Supernatural": "Supernatural"
           },
           "Title": {
-            "label":"Title"
+            "Label":"Title"
           }
         }
       },

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1307,14 +1307,50 @@ preLocalize("equipment.implement", {key: "label"});
 preLocalize("equipment.other", {key: "label"});
 
 DRAW_STEEL.features = {
-  /** @type {Record<string, {label: string, subtypes?: Record<string, string>}>} */
+  /** @type {Record<string, {label: string, subtypes?: Record<string, {label: string}>}>} */
   types: {
     perk: {
-      label: "DRAW_STEEL.Item.Feature.Types.Perk"
+      label: "DRAW_STEEL.Item.Feature.Types.Perk.label",
+      subtypes: {
+        crafting: {
+          label: "DRAW_STEEL.Item.Feature.Types.Perk.Crafting"
+        },
+        exploration: {
+          label: "DRAW_STEEL.Item.Feature.Types.Perk.Exploration"
+        },
+        interpersonal: {
+          label: "DRAW_STEEL.Item.Feature.Types.Perk.Interpersonal"
+        },
+        intrigue: {
+          label: "DRAW_STEEL.Item.Feature.Types.Perk.Intrigue"
+        },
+        lore: {
+          label: "DRAW_STEEL.Item.Feature.Types.Perk.Lore"
+        },
+        supernatural: {
+          label: "DRAW_STEEL.Item.Feature.Types.Perk.Supernatural"
+        }
+      }
     },
     title: {
-      label: "DRAW_STEEL.Item.Feature.Types.Title"
+      label: "DRAW_STEEL.Item.Feature.Types.Title.label",
+      subtypes: {
+        1: {
+          label: "DRAW_STEEL.Echelon.1"
+        },
+        2: {
+          label: "DRAW_STEEL.Echelon.2"
+        },
+        3: {
+          label: "DRAW_STEEL.Echelon.3"
+        },
+        4: {
+          label: "DRAW_STEEL.Echelon.4"
+        }
+      }
     }
   }
 };
 preLocalize("features.types", {key: "label"});
+preLocalize("features.types.perk.subtypes", {key: "label"});
+preLocalize("features.types.title.subtypes", {key: "label"});

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1310,7 +1310,7 @@ DRAW_STEEL.features = {
   /** @type {Record<string, {label: string, subtypes?: Record<string, {label: string}>}>} */
   types: {
     perk: {
-      label: "DRAW_STEEL.Item.Feature.Types.Perk.label",
+      label: "DRAW_STEEL.Item.Feature.Types.Perk.Label",
       subtypes: {
         crafting: {
           label: "DRAW_STEEL.Item.Feature.Types.Perk.Crafting"
@@ -1333,7 +1333,7 @@ DRAW_STEEL.features = {
       }
     },
     title: {
-      label: "DRAW_STEEL.Item.Feature.Types.Title.label",
+      label: "DRAW_STEEL.Item.Feature.Types.Title.Label",
       subtypes: {
         1: {
           label: "DRAW_STEEL.Echelon.1"

--- a/src/module/data/item/feature.mjs
+++ b/src/module/data/item/feature.mjs
@@ -44,7 +44,7 @@ export default class FeatureModel extends BaseItemModel {
     context.featureTypes = Object.entries(featureConfig.types).map(([value, entry]) => ({value, label: entry.label}));
 
     if (featureConfig.types[this.type.value]?.subtypes) {
-      context.featureSubtypes = Object.entries(featureConfig.types[this.type.value].subtypes).map(([value, label]) => ({value, label}));
+      context.featureSubtypes = Object.entries(featureConfig.types[this.type.value].subtypes).map(([value, {label}]) => ({value, label}));
     }
   }
 }


### PR DESCRIPTION
Closes #63

For the localization, the Perks subtypes includes a non-skill category (supernatural), so I put all of the subtypes in the Perk object instead of just adding supernatural only and reusing the existing keys. For titles, they're all just the existing echelons, so I just reused the keys already in the file. Let me know if you'd rather me do it differently.