### PR TITLE
Update drag-drop to use .draggable

### DIFF
--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -1,4 +1,3 @@
-import {systemPath} from "../../constants.mjs";
 import {DrawSteelItem} from "../../documents/item.mjs";
 import {DrawSteelItemSheet} from "../item-sheet.mjs";
 
@@ -30,7 +29,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       useAbility: this._useAbility
     },
     // Custom property that's merged into `this.options`
-    dragDrop: [{dragSelector: "[data-drag]", dropSelector: null}],
+    dragDrop: [{dragSelector: ".draggable", dropSelector: null}],
     form: {
       submitOnChange: true
     }
@@ -116,11 +115,11 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         context.tab = context.tabs[partId];
         break;
       case "features":
-        context.features = this.actor.items.filter(i => i.type === "feature");
+        context.features = this.actor.items.filter(i => i.type === "feature").sort((a, b) => a.sort - b.sort);
         context.tab = context.tabs[partId];
         break;
       case "abilities":
-        context.abilities = this.actor.items.filter(i => i.type === "ability");
+        context.abilities = this.actor.items.filter(i => i.type === "ability").sort((a, b) => a.sort - b.sort);
         context.tab = context.tabs[partId];
         break;
       case "biography":

--- a/src/module/apps/actor-sheet/character.mjs
+++ b/src/module/apps/actor-sheet/character.mjs
@@ -1,5 +1,5 @@
-import DrawSteelActorSheet from "./base.mjs";
 import {systemID, systemPath} from "../../constants.mjs";
+import DrawSteelActorSheet from "./base.mjs";
 /** @import {HeroTokenModel} from "../../data/settings/hero-tokens.mjs"; */
 
 export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
@@ -48,6 +48,9 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
     switch (partId) {
       case "stats":
         context.skills = this._getSkillList();
+        break;
+      case "features":
+        context.kits = this.actor.system.kits.sort((a, b) => a.sort - b.sort);
         break;
     }
     return context;

--- a/src/module/apps/actor-sheet/npc.mjs
+++ b/src/module/apps/actor-sheet/npc.mjs
@@ -1,5 +1,5 @@
-import DrawSteelActorSheet from "./base.mjs";
 import {systemID, systemPath} from "../../constants.mjs";
+import DrawSteelActorSheet from "./base.mjs";
 /** @import {FormSelectOption} from "../../../../foundry/client-esm/applications/forms/fields.mjs" */
 
 export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
@@ -130,6 +130,8 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
   /* -------------------------------------------------- */
 
   _onRender(context, options) {
+    super._onRender(context, options);
+
     /** @type {HTMLInputElement} */
     const maliceInput = this.element.querySelector("[data-setting=\"malice\"]");
     if (maliceInput) {

--- a/src/module/apps/item-sheet.mjs
+++ b/src/module/apps/item-sheet.mjs
@@ -26,7 +26,7 @@ export class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
       submitOnChange: true
     },
     // Custom property that's merged into `this.options`
-    dragDrop: [{dragSelector: "[data-drag]", dropSelector: null}]
+    dragDrop: [{dragSelector: ".draggable", dropSelector: null}]
   };
 
   /* -------------------------------------------- */

--- a/templates/actor/character/features.hbs
+++ b/templates/actor/character/features.hbs
@@ -7,7 +7,7 @@
   </div>
   <div class="item-list features">
     {{#each features as |feature index|}}
-    <button type="button" class="item flexrow" data-action="viewDoc" data-document-class="Item" data-item-id="{{feature.id}}">
+    <button type="button" class="item flexrow draggable" data-action="viewDoc" data-document-class="Item" data-item-id="{{feature.id}}">
       <img class="img" src="{{feature.img}}" alt="{{feature.name}}">
       <span class="name">{{feature.name}}</span>
       {{#unless @root.isPlay}}
@@ -20,8 +20,8 @@
   </div>
   <fieldset class="item-list kits">
     <legend>{{localize "TYPES.Item.kit"}}</legend>
-    {{#each system.kits as |kit|}}
-    <button type="button" class="item flexrow" data-action="viewDoc" data-document-class="Item" data-item-id="{{kit.id}}">
+    {{#each kits as |kit|}}
+    <button type="button" class="item flexrow draggable" data-action="viewDoc" data-document-class="Item" data-item-id="{{kit.id}}">
       <img class="img" src="{{kit.img}}" alt="{{kit.name}}">
       <span class="name">{{kit.name}}</span>
       {{#unless @root.isPlay}}

--- a/templates/actor/npc/features.hbs
+++ b/templates/actor/npc/features.hbs
@@ -7,7 +7,7 @@
   </div>
   <div class="item-list features">
     {{#each features as |feature index|}}
-    <button type="button" class="item flexrow" data-action="viewDoc" data-document-class="Item" data-item-id="{{feature.id}}">
+    <button type="button" class="item flexrow draggable" data-action="viewDoc" data-document-class="Item" data-item-id="{{feature.id}}">
       <img class="img" src="{{feature.img}}" alt="{{feature.name}}">
       <span class="name">{{feature.name}}</span>
       {{#unless @root.isPlay}}

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -7,7 +7,7 @@
   </div>
   <div class="item-list">
     {{#each abilities as |ability index|}}
-    <button type="button" class="item flexrow" data-action="{{ifThen @root.isPlay "useAbility" "viewDoc"}}" data-document-class="Item" data-item-id="{{ability.id}}" data-drag="true">
+    <button type="button" class="item flexrow draggable" data-action="{{ifThen @root.isPlay "useAbility" "viewDoc"}}" data-document-class="Item" data-item-id="{{ability.id}}">
       <img class="img" src="{{ability.img}}" alt="{{ability.name}}">
       <span class="name">{{ability.name}}</span>
       {{#unless @root.isPlay}}

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -2,7 +2,7 @@
 <section class="tab effects flexcol {{tab.cssClass}}" data-group="primary" data-tab="effects">
   <ol class="effects-list">
     {{#each effects as |section sid|}}
-    <li class="effects-header flexrow" data-effect-type="{{section.type}}" data-drag="true">
+    <li class="effects-header flexrow draggable" data-effect-type="{{section.type}}">
       <div class="effect-name flexrow">
         {{localize section.label}}
       </div>
@@ -34,7 +34,7 @@
 
     <ol class="effect-list">
       {{#each section.effects as |effect|}}
-      <li class="effect effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect" data-drag="true">
+      <li class="effect effect flexrow draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
         <div class="effect-name flexrow">
           <img class="effect-image" src="{{effect.img}}" height="24" width="24" alt="{{effect.name}}">
           <div>{{effect.name}}</div>

--- a/templates/item/effects.hbs
+++ b/templates/item/effects.hbs
@@ -35,7 +35,7 @@
     </li>
     <ol class="effect-list">
       {{#each section.effects as |effect|}}
-      <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-drag="true">
+      <li class="item effect flexrow draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
         <div class="effect-name effect-name flexrow">
           <img class="effect-image" src="{{effect.img}}" height="24" width="24" alt="{{effect.name}}">
           <div>{{effect.name}}</div>


### PR DESCRIPTION
Closes #47 

Summary of Changes:
- Updated the `dragSelector` to `.draggable` added this class to the relevant items. Features and kits didn't have the `[data-drag]`, but I added the class to them anyways.
- Updated the sheet context variables for `features`, `kits`, and `abilities` to be sorted by their sort value, so that they can be rearranged on the sheet.
- The NPC sheet wasn't calling `super._onRender`, so dragDrop wasn't being registered.