### PR TITLE
Add ability restrictions with dazed as an example

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -592,7 +592,8 @@
           "Embed": "{characteristic}<{value}",
           "Success": "Success",
           "Failure": "Failure"
-        }
+        },
+        "Restricted": "A condition or ability effect is restricting the usage of this ability."
       },
       "Ancestry": {
         "FIELDS": {}

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -133,7 +133,22 @@ DRAW_STEEL.conditions = {
   dazed: {
     name: "DRAW_STEEL.Effect.Conditions.Dazed.name",
     img: "icons/svg/daze.svg",
-    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.K2dZpCsAOU7xMpWb"
+    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.K2dZpCsAOU7xMpWb",
+    changes: [{
+      key: "system.restrictions.type",
+      value: "triggered",
+      mode: 2
+    },
+    {
+      key: "system.restrictions.type",
+      value: "freeTriggered",
+      mode: 2
+    },
+    {
+      key: "system.restrictions.type",
+      value: "freeManeuver",
+      mode: 2
+    }]
   },
   frightened: {
     name: "DRAW_STEEL.Effect.Conditions.Frightened.name",

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -86,6 +86,11 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
         speed: ds.CONFIG.conditions.slowed.defaultSpeed
       }
     };
+
+    this.restrictions = {
+      type: new Set(),
+      dsid: new Set()
+    };
   }
 
   /** @override */

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -455,4 +455,22 @@ export default class AbilityModel extends BaseItemModel {
 
     return modifiers;
   }
+
+  /**
+   * Determine if an Active Effect or a status is restricting this ability.
+   * @returns {boolean}
+   */
+  get restricted() {
+    if (!this.actor) return false;
+
+    // Checking if active effects have restricted this type
+    const restrictions = this.actor.system.restrictions;
+    if (restrictions.type.has(this.type)) return true;
+    if (restrictions.dsid.has(this._dsid)) return true;
+
+    // Checking if statuses have restricted this type. In case the main condition isn't toggled, but the status is added to an effect
+    if (this.actor.statuses.has("dazed") && ["freeManeuver", "triggered", "freeTriggered"].includes(this.type)) return true;
+
+    return false;
+  }
 }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -96,8 +96,9 @@ export class DrawSteelActiveEffect extends ActiveEffect {
       else if (!current) current = [];
     }
 
-    // Have the base class apply the changes
-    super._applyAdd(actor, change, current, delta, changes);
+    // If the type is Set, add to it, otherwise have the base class apply the changes
+    if (foundry.utils.getType(current) === "Set") current.add(delta);
+    else super._applyAdd(actor, change, current, delta, changes);
 
     // If we're modifying a condition source, slice the array to the max length if applicable, then convert back to Set
     if (config) {
@@ -108,11 +109,12 @@ export class DrawSteelActiveEffect extends ActiveEffect {
 
   /** @override */
   _applyOverride(actor, change, current, delta, changes) {
-    // If the property is a condition, convert the delta to a Set
+    // If the property is a condition or a Set, convert the delta to a Set
     const match = change.key.match(/^system\.statuses\.(?<condition>[a-z]+)\.sources$/);
     const condition = match?.groups.condition;
     const config = ds.CONFIG.conditions[condition];
-    if (config) delta = new Set([delta]);
+    const isSetChange = (foundry.utils.getType(current) === "Set") || config;
+    if (isSetChange) delta = new Set([delta]);
 
     super._applyOverride(actor, change, current, delta, changes);
   }

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -7,9 +7,16 @@
   </div>
   <div class="item-list">
     {{#each abilities as |ability index|}}
-    <button type="button" class="item flexrow draggable" data-action="{{ifThen @root.isPlay "useAbility" "viewDoc"}}" data-document-class="Item" data-item-id="{{ability.id}}">
+    <button type="button" class="item flexrow draggable {{#if ability.system.restricted}}restricted{{/if}}" data-action="{{ifThen @root.isPlay "useAbility" "viewDoc"}}" data-document-class="Item" data-item-id="{{ability.id}}">
       <img class="img" src="{{ability.img}}" alt="{{ability.name}}">
-      <span class="name">{{ability.name}}</span>
+      <span class="name">
+        {{#if ability.system.restricted}}
+        <span class="restricted-warning" data-tooltip="DRAW_STEEL.Item.Ability.Restricted">
+          <i class="fa-solid fa-triangle-exclamation"></i>
+        </span>
+        {{/if}}
+        {{ability.name}}
+      </span>
       {{#unless @root.isPlay}}
       <a class="delete" data-action="deleteDoc">
         <i class="fa-solid fa-trash-can"></i>


### PR DESCRIPTION
Closes #118 

Summary of Changes:
- Added `restrictions` object to actor in data prep. This object has a `Set` for `type` and `dsid`. 
- In the ability, check if the ability's `type` or `_dsid` is in the `Set`s, if so return `true`, otherwise return `false`. This has a fallback for checking actor statuses in case just the status is added to an ability without the use of toggle status effect.
- Display a warning sign next to the ability name with a tooltip advising that the ability is restricted.

I wasn't sure if there was a better spot to add the `Set` application to the AE class. I didn't add a way to track which sources are restricting an ability, but if that's desired, could add a `source` property on `restrictions`. In the AE, could check if the key is a restriction change and then add the name of the AE to the `source` `Set`. 

Let me know your thoughts.

![Screenshot 2025-01-22 233833](https://github.com/user-attachments/assets/ee98af0b-7095-4e17-a118-3b389e89f20b)
