### PR TITLE
Automate grabbed and restrained conditions

### DIFF
--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -157,7 +157,10 @@ DRAW_STEEL.conditions = {
     name: "DRAW_STEEL.Effect.Conditions.Grabbed.name",
     img: "systems/draw-steel/assets/icons/hand-grabbing-fill.svg",
     rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.aWBP2vfXXM3fzuVn",
-    targeted: true
+    targeted: true,
+    restrictions: {
+      dsid: new Set(["knockback"])
+    }
   },
   prone: {
     name: "DRAW_STEEL.Effect.Conditions.Prone.name",
@@ -167,7 +170,10 @@ DRAW_STEEL.conditions = {
   restrained: {
     name: "DRAW_STEEL.Effect.Conditions.Restrained.name",
     img: "icons/svg/net.svg",
-    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.6IfH6beu8LjK08Oj"
+    rule: "Compendium.draw-steel.journals.JournalEntry.hDhdILCi65wpBgPZ.JournalEntryPage.6IfH6beu8LjK08Oj",
+    restrictions: {
+      dsid: new Set(["stand-up"])
+    }
   },
   slowed: {
     name: "DRAW_STEEL.Effect.Conditions.Slowed.name",

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -99,10 +99,15 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
 
     this.stamina.winded = Math.floor(this.stamina.max / 2);
 
-    // Reduce all movement speeds when slowed
-    if (this.parent.statuses.has("slowed")) {
+    // Set movement speeds when affected by grabbed, restrained, or slowed
+    if (this.parent.statuses.has("grabbed") || this.parent.statuses.has("restrained") || this.parent.statuses.has("slowed")) {
       for (const movement in this.movement) {
-        if (this.movement[movement] > this.statuses.slowed.speed) this.movement[movement] = this.statuses.slowed.speed;
+        // If slowed, set all speeds to slowed speed
+        if (this.parent.statuses.has("slowed") && (this.movement[movement] > this.statuses.slowed.speed)) this.movement[movement] = this.statuses.slowed.speed;
+
+        // If grabbed or restrained, set non-teleport speeds to 0
+        const isGrabbedOrRestrained = this.parent.statuses.has("grabbed") || this.parent.statuses.has("restrained");
+        if (isGrabbedOrRestrained && (movement !== "teleport")) this.movement[movement] = 0;
       }
     }
   }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -100,13 +100,14 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     this.stamina.winded = Math.floor(this.stamina.max / 2);
 
     // Set movement speeds when affected by grabbed, restrained, or slowed
-    if (this.parent.statuses.has("grabbed") || this.parent.statuses.has("restrained") || this.parent.statuses.has("slowed")) {
+    const isSlowed = this.parent.statuses.has("slowed");
+    const isGrabbedOrRestrained = this.parent.statuses.has("grabbed") || this.parent.statuses.has("restrained");
+    if (isSlowed || isGrabbedOrRestrained) {
       for (const movement in this.movement) {
         // If slowed, set all speeds to slowed speed
-        if (this.parent.statuses.has("slowed") && (this.movement[movement] > this.statuses.slowed.speed)) this.movement[movement] = this.statuses.slowed.speed;
+        if (isSlowed && (this.movement[movement] > this.statuses.slowed.speed)) this.movement[movement] = this.statuses.slowed.speed;
 
         // If grabbed or restrained, set non-teleport speeds to 0
-        const isGrabbedOrRestrained = this.parent.statuses.has("grabbed") || this.parent.statuses.has("restrained");
         if (isGrabbedOrRestrained && (movement !== "teleport")) this.movement[movement] = 0;
       }
     }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -463,12 +463,12 @@ export default class AbilityModel extends BaseItemModel {
   get restricted() {
     if (!this.actor) return false;
 
-    // Checking if active effects have restricted this type
+    // Checking if active effects have restricted this ability based on type or _dsid
     const restrictions = this.actor.system.restrictions;
     if (restrictions.type.has(this.type)) return true;
     if (restrictions.dsid.has(this._dsid)) return true;
 
-    // Checking if statuses have restricted this type
+    // Checking if statuses have restricted this ability based on type or _dsid
     for (const effect of CONFIG.statusEffects) {
       if (!this.actor.statuses.has(effect.id) || !effect.restrictions) continue;
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -468,8 +468,13 @@ export default class AbilityModel extends BaseItemModel {
     if (restrictions.type.has(this.type)) return true;
     if (restrictions.dsid.has(this._dsid)) return true;
 
-    // Checking if statuses have restricted this type. In case the main condition isn't toggled, but the status is added to an effect
-    if (this.actor.statuses.has("dazed") && CONFIG.statusEffects.find(e => e.id === "dazed")?.restrictions.type.has(this.type)) return true;
+    // Checking if statuses have restricted this type
+    for (const effect of CONFIG.statusEffects) {
+      if (!this.actor.statuses.has(effect.id) || !effect.restrictions) continue;
+
+      if (effect.restrictions.type?.has(this.type)) return true;
+      if (effect.restrictions.dsid?.has(this._dsid)) return true;
+    }
 
     return false;
   }


### PR DESCRIPTION
Closes #120, Closes #119 

I updated the status check in the ability `restricted` to a for loop instead of a check for each condition individually. It means we only just have to update the CONFIG if there's ever changes to what a condition restricts. It also means modules could add new restrictions on the CONFIG.statusEffects object and those will work too.