### PR TITLE
Add modifiers to grabbed and restrained

### DIFF
--- a/src/module/_types.d.ts
+++ b/src/module/_types.d.ts
@@ -41,5 +41,6 @@ export interface PowerRollPromptOptions {
   data: Record<string, unknown>;
   skills: string[];
   targets: PowerRollTargets[],
-  ability?: string
+  ability?: string,
+  characteristic?: string
 }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -238,7 +238,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     const formula = `2d10 + @${characteristic}`;
     const data = this.parent.getRollData();
     const flavor = `${game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${characteristic}.full`)} ${game.i18n.localize(PowerRoll.TYPES[type].label)}`;
-    return PowerRoll.prompt({type, formula, data, flavor, modifiers: {edges: options.edges, banes: options.banes}, actor: this.parent});
+    return PowerRoll.prompt({type, formula, data, flavor, modifiers: {edges: options.edges, banes: options.banes}, actor: this.parent, characteristic});
   }
 
   /**

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -372,6 +372,8 @@ export default class AbilityModel extends BaseItemModel {
       options.modifiers.banes ??= 0;
       options.modifiers.edges ??= 0;
 
+      this.getActorModifiers(options);
+
       // Get the power rolls made per target, or if no targets, then just one power roll
       const powerRolls = await PowerRoll.prompt({
         type: "ability",
@@ -432,8 +434,11 @@ export default class AbilityModel extends BaseItemModel {
    * @param {Partial<AbilityUseOptions>} options Options for the dialog
    */
   getActorModifiers(options) {
-    if (!options.actor) return;
+    if (!this.actor) return;
     //TODO: CONDITION CHECKS
+
+    // Restrained conditions check
+    if (this.actor.statuses.has("restrained")) options.modifiers.banes += 1;
   }
 
   /**
@@ -452,6 +457,12 @@ export default class AbilityModel extends BaseItemModel {
     // Frightened condition checks
     if (DrawSteelActiveEffect.isStatusSource(this.actor, target, "frightened")) modifiers.banes += 1; // Attacking the target frightening the actor
     if (DrawSteelActiveEffect.isStatusSource(target, this.actor, "frightened")) modifiers.edges += 1; // Attacking the target the actor has frightened
+
+    // Grabbed condition check - targeting a non-source adds a bane
+    if (DrawSteelActiveEffect.isNotStatusSource(this.actor, target, "grabbed")) modifiers.banes += 1; 
+
+    // Restrained condition check - targetting restrained gets an edge
+    if (target.statuses.has("restrained")) modifiers.edges += 1;
 
     return modifiers;
   }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -34,16 +34,29 @@ export class DrawSteelActiveEffect extends ActiveEffect {
   }
 
   /**
-   * Determine if a source actor is imposing the statusId on the affected actor.
+   * Determine if the affected actor has the status and if the source is the one imposing it
    * @param {DrawSteelActor} affected The actor affected by the status
    * @param {DrawSteelActor} source The actor imposing the status
-   * @param {string} statusId
+   * @param {string} statusId A status id from the CONFIG object
    * @returns {boolean}
    */
-  static isStatusSource(affected, source, statusId) {
+  static isStatusSource(affected, source, statusId, reverseSourceCheck=false) {
     const isAffectedByStatusId = affected.statuses.has(statusId);
     const isAffectedBySource = !!affected.system.statuses?.[statusId]?.sources.has(source.uuid);
     return isAffectedByStatusId && isAffectedBySource;
+  }
+
+  /**
+   * Determine if the affected actor has the status and if the source is not the one imposing it
+   * @param {DrawSteelActor} affected The actor affected by the status
+   * @param {DrawSteelActor} source The actor imposing the status
+   * @param {string} statusId A status id from the CONFIG object
+   * @returns {boolean}
+   */
+  static isNotStatusSource(affected, source, statusId) {
+    const isAffectedByStatusId = affected.statuses.has(statusId);
+    const isNotAffectedBySource = !affected.system.statuses?.[statusId]?.sources.has(source.uuid);
+    return isAffectedByStatusId && isNotAffectedBySource;
   }
 
   /**

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -40,7 +40,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
    * @param {string} statusId A status id from the CONFIG object
    * @returns {boolean}
    */
-  static isStatusSource(affected, source, statusId, reverseSourceCheck=false) {
+  static isStatusSource(affected, source, statusId) {
     const isAffectedByStatusId = affected.statuses.has(statusId);
     const isAffectedBySource = !!affected.system.statuses?.[statusId]?.sources.has(source.uuid);
     return isAffectedByStatusId && isAffectedBySource;

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -304,6 +304,9 @@ export class PowerRoll extends DSRoll {
   static getActorModifiers(options) {
     if (!options.actor) return;
 
-    if (options.actor?.statuses.has("weakened")) options.modifiers.banes += 1;
+    if (options.actor.statuses.has("weakened")) options.modifiers.banes += 1;
+
+    // Restrained might and agility tests take a bane
+    if(options.actor.statuses.has("restrained") && (options.type === "test") && ["might", "agility"].includes(options.characteristic)) options.modifiers.banes += 1;
   }
 }


### PR DESCRIPTION
Closes #207 

Applying the modifiers for grabbed and restrained. Added `characteristic` to the `options` on the `rollCharacteristic` method.

I added an `isNotStatusSource` to the AE class. I couldn't just use `!isStatusSource` because it would trigger even if the actor didn't have the status effect. I thought about adding an optional fourth parameter to reverse the status source check, but that seemed like the return would be confusing if `isStatusSource` returned true when they weren't the source. If you have a better idea on handling that, let me know. 