### PR TITLE
Update ability tab to present more information and use the ability embed

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -591,7 +591,8 @@
           "Maneuver": "Maneuver",
           "FreeManeuver": "Free Maneuver",
           "Triggered": "Triggered Action",
-          "FreeTriggered": "Free Triggered Action"
+          "FreeTriggered": "Free Triggered Action",
+          "Villain": "Villain Action"
         },
         "Category": {
           "Heroic": "Heroic Ability",
@@ -925,7 +926,8 @@
           "Button": "Confirm Kit Swap",
           "Header": "Choose which kit to replace with the {kit} kit."
         }
-      }
+      },
+      "PostToChat": "Post Item To Chat"
     },
     "Effect": {
       "Name": "Effect",

--- a/lang/en.json
+++ b/lang/en.json
@@ -666,7 +666,8 @@
         },
         "Restricted": "A condition or ability effect is restricting the usage of this ability.",
         "AddTierEffect": "Add Tier Effect",
-        "RemoveTierEffect": "Remove Tier Effect"
+        "RemoveTierEffect": "Remove Tier Effect",
+        "Order": "Order"
       },
       "Ancestry": {
         "FIELDS": {}

--- a/lang/en.json
+++ b/lang/en.json
@@ -926,8 +926,7 @@
           "Button": "Confirm Kit Swap",
           "Header": "Choose which kit to replace with the {kit} kit."
         }
-      },
-      "PostToChat": "Post Item To Chat"
+      }
     },
     "Effect": {
       "Name": "Effect",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,7 +9,8 @@
       "Add": "+ Add {itemName}",
       "Play": "Play",
       "Edit": "Edit",
-      "Resources": "Resources"
+      "Resources": "Resources",
+      "Other": "Other"
     },
     "Source": {
       "FIELDS": {

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -296,6 +296,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       };
     }
 
+    // Adding here instead of the initial context declaration so that the "other" category appears last on the character sheet
     context["other"] = {
       label: game.i18n.localize("DRAW_STEEL.Sheet.Other"),
       abilities: [],

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -477,7 +477,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   }
 
   /**
-   * Renders an embedded document's sheet
+   * Renders an embedded document's sheet in play or edit mode based on the actor sheet view mode
    *
    * @this DrawSteelActorSheet
    * @param {PointerEvent} event   The originating click event
@@ -485,8 +485,12 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @protected
    */
   static async _viewDoc(event, target) {
-    const doc = this._getEmbeddedDocument(target);
-    doc.sheet.render(true);
+    const item = this._getEmbeddedDocument(target);
+    if (!item) {
+      console.error("Could not find item");
+      return;
+    }
+    await item.sheet.render({force: true, mode: this.#mode});
   }
 
   /**
@@ -603,9 +607,13 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    */
   static async _postItemToChat(event, target) {
     const item = this._getEmbeddedDocument(target);
-    const embed = await item.system.toEmbed({});
-    ChatMessage.create({
-      content: embed.outerHTML
+    if (!item) {
+      console.error("Could not find item");
+      return;
+    }
+    await DrawSteelChatMessage.create({
+      content: `@Embed[${item.uuid} caption=false]`,
+      speaker: DrawSteelChatMessage.getSpeaker({actor: this.actor})
     });
   }
 

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -341,7 +341,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   async _onFirstRender(context, options) {
     await super._onFirstRender(context, options);
     // TODO: Change to ContextMenu.create in v13 with jQuery: false
-    new ContextMenu(this.element, "button[data-document-class]", this._getItemButtonContextOptions());
+    new ContextMenu(this.element, "[data-document-class]", this._getItemButtonContextOptions());
   }
 
   /**

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -28,7 +28,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       toggleEffect: this._toggleEffect,
       roll: this._onRoll,
       useAbility: this._useAbility,
-      toggleItemEmbed: this._toggleItemEmbed,
+      toggleItemEmbed: this._toggleItemEmbed
     },
     // Custom property that's merged into `this.options`
     dragDrop: [{dragSelector: ".draggable", dropSelector: null}],
@@ -594,7 +594,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
     const part = target.closest("[data-application-part]").dataset.applicationPart;
     this.render({parts: [part]});
-  };
   }
 
   /** Helper Functions */

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -29,7 +29,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       roll: this._onRoll,
       useAbility: this._useAbility,
       toggleItemEmbed: this._toggleItemEmbed,
-      postItemToChat: this._postItemToChat
     },
     // Custom property that's merged into `this.options`
     dragDrop: [{dragSelector: ".draggable", dropSelector: null}],
@@ -595,26 +594,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
     const part = target.closest("[data-application-part]").dataset.applicationPart;
     this.render({parts: [part]});
-  }
-
-  /**
-   * Post the item to chat
-   *
-   * @this DrawSteelActorSheet
-   * @param {PointerEvent} event   The originating click event
-   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-   * @protected
-   */
-  static async _postItemToChat(event, target) {
-    const item = this._getEmbeddedDocument(target);
-    if (!item) {
-      console.error("Could not find item");
-      return;
-    }
-    await DrawSteelChatMessage.create({
-      content: `@Embed[${item.uuid} caption=false]`,
-      speaker: DrawSteelChatMessage.getSpeaker({actor: this.actor})
-    });
+  };
   }
 
   /** Helper Functions */

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -484,12 +484,12 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @protected
    */
   static async _viewDoc(event, target) {
-    const item = this._getEmbeddedDocument(target);
-    if (!item) {
-      console.error("Could not find item");
+    const doc = this._getEmbeddedDocument(target);
+    if (!doc) {
+      console.error("Could not find document");
       return;
     }
-    await item.sheet.render({force: true, mode: this.#mode});
+    await doc.sheet.render({force: true, mode: this.#mode});
   }
 
   /**

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -937,6 +937,9 @@ DRAW_STEEL.abilities = {
     freeTriggered: {
       label: "DRAW_STEEL.Item.Ability.Type.FreeTriggered",
       triggered: true
+    },
+    villain: {
+      label: "DRAW_STEEL.Item.Ability.Type.Villain"
     }
   },
   /**

--- a/src/scss/components/_actor-sheet.scss
+++ b/src/scss/components/_actor-sheet.scss
@@ -183,3 +183,28 @@ section.tab {
     line-height: 24px;
   }
 }
+
+.tab.abilities .item-list-container {
+
+  .item-cost,
+  .item-distance,
+  .item-target {
+    width: 100px;
+  }
+
+  .item-row {
+    .item-name {
+      cursor: pointer;
+
+      &:hover .label {
+        text-shadow: 0 0 8px var(--color-shadow-primary);
+      }
+
+      .name {
+        .keywords {
+          font-size: var(--font-size-12);
+        }
+      }
+    }
+  }
+}

--- a/src/scss/components/_actor-sheet.scss
+++ b/src/scss/components/_actor-sheet.scss
@@ -192,6 +192,10 @@ section.tab {
     width: 100px;
   }
 
+  .item-order {
+    width: 50px;
+  }
+
   .item-row {
     .item-name {
       cursor: pointer;

--- a/src/scss/components/_items.scss
+++ b/src/scss/components/_items.scss
@@ -39,7 +39,7 @@
   }
 
   .item-header {
-    background-color: rgb(40, 35, 47);
+    background-color: var(--draw-steel-c-item-header-bg);
     border-radius: 5px 5px 0px 0px;
     position: sticky;
     top: 0px;
@@ -71,7 +71,7 @@
 
     .item {
       &:nth-child(even) {
-        background-color: rgba(255, 255, 255, .04);
+        background-color: var(--draw-steel-c-item-alternating-bg);
       }
 
       .item-row {

--- a/src/scss/components/_items.scss
+++ b/src/scss/components/_items.scss
@@ -55,7 +55,7 @@
 
   .item-controls {
     display: flex;
-    width: 60px;
+    width: 25px;
     justify-content: space-evenly;
   }
 

--- a/src/scss/components/_items.scss
+++ b/src/scss/components/_items.scss
@@ -41,8 +41,13 @@
   .item-header {
     background-color: rgb(40, 35, 47);
     border-radius: 5px 5px 0px 0px;
-    font-size: var(--font-size-15);
-    font-weight: bold;
+    position: sticky;
+    top: 0px;
+
+    .item-name {
+      font-weight: bold;
+      font-size: var(--font-size-16);
+    }
   }
 
   .item-name {

--- a/src/scss/components/_items.scss
+++ b/src/scss/components/_items.scss
@@ -28,3 +28,65 @@
     }
   }
 }
+.item-list-container {
+  margin: 10px 0px;
+
+  .item-row,
+  .item-header {
+    display: flex;
+    align-items: center;
+    text-align: center;
+  }
+
+  .item-header {
+    background-color: rgb(40, 35, 47);
+    border-radius: 5px 5px 0px 0px;
+    font-size: var(--font-size-15);
+    font-weight: bold;
+  }
+
+  .item-name {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    text-align: left;
+    padding: 5px 0px 5px 5px;
+  }
+
+  .item-controls {
+    display: flex;
+    width: 60px;
+    justify-content: space-evenly;
+  }
+
+  .item-list2 {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    .item {
+      &:nth-child(even) {
+        background-color: rgba(255, 255, 255, .04);
+      }
+
+      .item-row {
+        .item-name {
+          gap: 5px;
+
+          .name {
+            .label {
+              font-weight: bold;
+              font-size: var(--font-size-15);
+            }
+          }
+
+          img {
+            width: 30px;
+            height: 30px;
+            border: none;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/scss/utils/_colors.scss
+++ b/src/scss/utils/_colors.scss
@@ -8,7 +8,7 @@
   --draw-steel-c-groove: #eeede0;
   --draw-steel-c-success: green;
   --draw-steel-c-failure: red;
-  --draw-steel-c-item-header-bg: var(--draw-steel-c-beige);
+  --draw-steel-c-item-header-bg: #bebbab;
   --draw-steel-c-item-alternating-bg: rgba(0, 0, 0, .05);
 }
 

--- a/src/scss/utils/_colors.scss
+++ b/src/scss/utils/_colors.scss
@@ -8,6 +8,8 @@
   --draw-steel-c-groove: #eeede0;
   --draw-steel-c-success: green;
   --draw-steel-c-failure: red;
+  --draw-steel-c-item-header-bg: var(--draw-steel-c-beige);
+  --draw-steel-c-item-alternating-bg: rgba(0, 0, 0, .05);
 }
 
 .theme-dark {
@@ -18,6 +20,8 @@
   --draw-steel-c-white: #000000;
   --draw-steel-c-black: #ffffff;
   --draw-steel-c-groove: #11121f;
+  --draw-steel-c-item-header-bg: #28232f;
+  --draw-steel-c-item-alternating-bg: rgba(255, 255, 255, .05);
 }
 
 $c-white: var(--draw-steel-c-white);

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -14,11 +14,13 @@
       <div class="item-column item-distance">{{abilityType.fields.distance.label}}</div>
       <div class="item-column item-target">{{abilityType.fields.target.label}}</div>
       <div class="item-column item-controls">
+        {{#unless (eq @key "other")}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}
+        {{/unless}}
       </div>
     </div>
     <ol class="item-list2 abilities-list">

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -41,18 +41,6 @@
           <div class="item-column item-distance">{{abilityContext.formattedLabels.distance}}</div>
           <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
           <div class="item-column item-controls">
-            <a data-action="viewDoc">
-              <i class="fa-solid {{ifThen @root.isPlay "fa-fw fa-eye" "fa-pen-to-square"}}"></i>
-            </a>
-            {{#if @root.isPlay}}
-            <a data-action="postItemToChat" data-tooltip="DRAW_STEEL.Item.base.share" data-tooltip-direction="UP">
-              <i class="fa-solid fa-fw fa-share-from-square"></i>
-            </a>
-            {{else}}
-            <a data-action="deleteDoc">
-              <i class="fa-solid fa-trash-can"></i>
-            </a>
-            {{/if}}
             <a data-action="toggleItemEmbed">
               <i class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}"></i>
             </a>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -1,12 +1,16 @@
 {{! Abilities Tab }}
 <section class="tab abilities {{tab.cssClass}}" data-group="primary" data-tab="abilities">
-  {{#each abilityTypes as |abilityType|}}
+  {{#each abilities as |abilityType|}}
   <section class="item-list-container">
     <div class="item-header">
       <div class="item-column item-name">{{abilityType.label}}</div>
-      <div class="item-column item-cost">{{@root.abilityFields.resource.label}}</div>
-      <div class="item-column item-distance">{{@root.abilityFields.distance.label}}</div>
-      <div class="item-column item-target">{{@root.abilityFields.target.label}}</div>
+      {{#if (eq @key "villain")}}
+      <div class="item-column item-order">{{localize "DRAW_STEEL.Item.Ability.Order"}}</div>
+      {{else}}
+      <div class="item-column item-cost">{{abilityType.fields.resource.label}}</div>
+      {{/if}}
+      <div class="item-column item-distance">{{abilityType.fields.distance.label}}</div>
+      <div class="item-column item-target">{{abilityType.fields.target.label}}</div>
       <div class="item-column item-controls">
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip="{{addItemTooltip}}">
@@ -16,28 +20,32 @@
       </div>
     </div>
     <ol class="item-list2 abilities-list">
-      {{#each @root.abilities as |ability|}}
-      {{#if (eq ability.system.type @../key)}}
-      {{#with (lookup @root.abilitiesContext ability.id) as |abilityContext|}}
-      <li class="item ability draggable" data-item-id="{{ability.id}}" data-document-class="Item">
+      {{#each abilityType.abilities as |abilityContext|}}
+      <li class="item ability draggable" data-item-id="{{abilityContext.ability.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name" data-action="useAbility">
-            <img class="item-image" src="{{ability.img}}" alt="{{ability.name}}">
-            {{#if ability.system.restricted}}
+            <img class="item-image" src="{{abilityContext.ability.img}}" alt="{{abilityContext.ability.name}}">
+            {{#if abilityContext.ability.system.restricted}}
             <div class="restricted-warning" data-tooltip="DRAW_STEEL.Item.Ability.Restricted">
               <i class="fa-solid fa-triangle-exclamation"></i>
             </div>
             {{/if}}
             <div class="name">
-              <div class="label">{{ability.name}}</div>
+              <div class="label">{{abilityContext.ability.name}}</div>
               <div class="keywords">{{abilityContext.formattedLabels.keywords}}</div>
             </div>
           </div>
+          {{#if (eq @../key "villain")}}
+          <div class="item-column item-order">
+            {{abilityContext.order}}
+          </div>
+          {{else}}
           <div class="item-column item-cost">
-            {{#if ability.system.resource}}
-            {{ability.system.resource}} {{@root.system.coreResource.name}}
+            {{#if abilityContext.ability.system.resource}}
+            {{abilityContext.ability.system.resource}} {{@root.system.coreResource.name}}
             {{/if}}
           </div>
+          {{/if}}
           <div class="item-column item-distance">{{abilityContext.formattedLabels.distance}}</div>
           <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
           <div class="item-column item-controls">
@@ -50,8 +58,6 @@
           {{#if abilityContext.expanded}}{{{abilityContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>
-      {{/with}}
-      {{/if}}
       {{/each}}
     </ol>
   </section>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -41,14 +41,14 @@
           <div class="item-column item-distance">{{abilityContext.formattedLabels.distance}}</div>
           <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
           <div class="item-column item-controls">
+            <a data-action="viewDoc">
+              <i class="fa-solid {{ifThen @root.isPlay "fa-fw fa-eye" "fa-pen-to-square"}}"></i>
+            </a>
             {{#if @root.isPlay}}
-            <a data-action="postItemToChat" data-tooltip="DRAW_STEEL.Item.PostToChat" data-tooltip-direction="UP">
-              <i class="fa-solid fa-message"></i>
+            <a data-action="postItemToChat" data-tooltip="DRAW_STEEL.Item.base.share" data-tooltip-direction="UP">
+              <i class="fa-solid fa-fw fa-share-from-square"></i>
             </a>
             {{else}}
-            <a data-action="viewDoc">
-              <i class="fa-solid fa-pen-to-square"></i>
-            </a>
             <a data-action="deleteDoc">
               <i class="fa-solid fa-trash-can"></i>
             </a>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -1,6 +1,8 @@
 {{! Abilities Tab }}
 <section class="tab abilities {{tab.cssClass}}" data-group="primary" data-tab="abilities">
   {{#each abilities as |abilityType|}}
+  {{!-- Don't show the "Other" category if there's no other abilities --}}
+  {{#if (or (ne @key "other") (and (eq @key "other") (gte abilityType.abilities.length 1)))}}
   <section class="item-list-container">
     <div class="item-header">
       <div class="item-column item-name">{{abilityType.label}}</div>
@@ -61,5 +63,6 @@
       {{/each}}
     </ol>
   </section>
+  {{/if}}
   {{/each}}
 </section>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -1,28 +1,71 @@
 {{! Abilities Tab }}
 <section class="tab abilities {{tab.cssClass}}" data-group="primary" data-tab="abilities">
-  <div class="item-header flexrow">
-    <a data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true">
-      {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")}}
-    </a>
-  </div>
-  <div class="item-list">
-    {{#each abilities as |ability index|}}
-    <button type="button" class="item flexrow draggable {{#if ability.system.restricted}}restricted{{/if}}" data-action="{{ifThen @root.isPlay "useAbility" "viewDoc"}}" data-document-class="Item" data-item-id="{{ability.id}}">
-      <img class="img" src="{{ability.img}}" alt="{{ability.name}}">
-      <span class="name">
-        {{#if ability.system.restricted}}
-        <span class="restricted-warning" data-tooltip="DRAW_STEEL.Item.Ability.Restricted">
-          <i class="fa-solid fa-triangle-exclamation"></i>
-        </span>
-        {{/if}}
-        {{ability.name}}
-      </span>
-      {{#unless @root.isPlay}}
-      <a class="delete" data-action="deleteDoc">
-        <i class="fa-solid fa-trash-can"></i>
-      </a>
-      {{/unless}}
-    </button>
-    {{/each}}
-  </div>
+  {{#each abilityTypes as |abilityType|}}
+  <section class="item-list-container">
+    <div class="item-header">
+      <div class="item-column item-name">{{abilityType.label}}</div>
+      <div class="item-column item-cost">{{@root.abilityFields.resource.label}}</div>
+      <div class="item-column item-distance">{{@root.abilityFields.distance.label}}</div>
+      <div class="item-column item-target">{{@root.abilityFields.target.label}}</div>
+      <div class="item-column item-controls">
+        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip="{{addItemTooltip}}">
+          <i class="fa-solid fa-plus"></i>
+        </a>
+        {{/with}}
+      </div>
+    </div>
+    <ol class="item-list2 abilities-list">
+      {{#each @root.abilities as |ability|}}
+      {{#if (eq ability.system.type @../key)}}
+      {{#with (lookup @root.abilitiesContext ability.id) as |abilityContext|}}
+      <li class="item ability draggable" data-item-id="{{ability.id}}" data-document-class="Item">
+        <div class="item-row">
+          <div class="item-column item-name" data-action="useAbility">
+            <img class="item-image" src="{{ability.img}}" alt="{{ability.name}}">
+            {{#if ability.system.restricted}}
+            <div class="restricted-warning" data-tooltip="DRAW_STEEL.Item.Ability.Restricted">
+              <i class="fa-solid fa-triangle-exclamation"></i>
+            </div>
+            {{/if}}
+            <div class="name">
+              <div class="label">{{ability.name}}</div>
+              <div class="keywords">{{abilityContext.formattedLabels.keywords}}</div>
+            </div>
+          </div>
+          <div class="item-column item-cost">
+            {{#if ability.system.resource}}
+            {{ability.system.resource}} {{@root.system.coreResource.name}}
+            {{/if}}
+          </div>
+          <div class="item-column item-distance">{{abilityContext.formattedLabels.distance}}</div>
+          <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
+          <div class="item-column item-controls">
+            {{#if @root.isPlay}}
+            <a data-action="postItemToChat" data-tooltip="DRAW_STEEL.Item.PostToChat" data-tooltip-direction="UP">
+              <i class="fa-solid fa-message"></i>
+            </a>
+            {{else}}
+            <a data-action="viewDoc">
+              <i class="fa-solid fa-pen-to-square"></i>
+            </a>
+            <a data-action="deleteDoc">
+              <i class="fa-solid fa-trash-can"></i>
+            </a>
+            {{/if}}
+            <a data-action="toggleItemEmbed">
+              <i class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}"></i>
+            </a>
+          </div>
+        </div>
+        <div class="item-embed">
+          {{#if abilityContext.expanded}}{{{abilityContext.embed.outerHTML}}}{{/if}}
+        </div>
+      </li>
+      {{/with}}
+      {{/if}}
+      {{/each}}
+    </ol>
+  </section>
+  {{/each}}
 </section>


### PR DESCRIPTION
I wanted to update the ability section to have more info. I took inspiration from the 5e sheet.

- Closes #202, I added the villain action as an ability type. This is so that the NPC sheets will show a section for that type.
- I factored out the label formatting for keywords, distance, and targets so that those could be used on the actor sheet without having to pull in the entire ability sheet context.
- The embeds are only generated when the item would be expanded. Figured it was wasteful to generate a bunch of HTML that wasn't being shown.
- Should probably change the section header color to stand out more against the alternating item background color
- If this approach is acceptable, once approved, I'll make the same changes to the features tab

<img src="https://github.com/user-attachments/assets/0d3b2375-b91c-4638-991b-a210f7d01264" width="200">
<img src="https://github.com/user-attachments/assets/05ed8ff9-60e4-41c3-bd1d-f54c1f3d85db" width="200">