### PR TITLE
Various V13 changes

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -51,9 +51,6 @@ Hooks.once("init", function () {
     CONFIG.statusEffects.push({id, ...value});
   }
 
-  // Necessary until foundry makes this default behavior in v13
-  CONFIG.ActiveEffect.legacyTransferral = false;
-
   // Register sheet application classes
   Actors.unregisterSheet("core", ActorSheet);
   Actors.registerSheet(DS_CONST.systemID, applications.DrawSteelCharacterSheet, {

--- a/lang/en.json
+++ b/lang/en.json
@@ -325,7 +325,7 @@
         }
       },
       "DamageNotification": {
-        "ImmunityReducedToZero": "The actor's immunities have reduced the damage to zero."
+        "ImmunityReducedToZero": "{name}'s immunities have reduced the damage to zero."
       }
     },
     "Combat": {

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -21,7 +21,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       height: 600
     },
     actions: {
-      editImage: this._onEditImage,
       toggleMode: this._toggleMode,
       viewDoc: this._viewDoc,
       createDoc: this._createDoc,
@@ -465,40 +464,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------------- */
   /*   Actions                                          */
   /* -------------------------------------------------- */
-
-  /**
-   * Handle changing a Document's image.
-   * TODO: Copied from v13 implementation, can be removed after
-   * @this DrawSteelActorSheet
-   * @param {PointerEvent} _event   The originating click event
-   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-   * @returns {Promise}
-   * @protected
-   */
-  static async _onEditImage(_event, target) {
-    if (target.nodeName !== "IMG") {
-      throw new Error("The editImage action is available only for IMG elements.");
-    }
-    const attr = target.dataset.edit;
-    const current = foundry.utils.getProperty(this.document._source, attr);
-    const defaultArtwork = this.document.constructor.getDefaultArtwork?.(this.document._source) ?? {};
-    const defaultImage = foundry.utils.getProperty(defaultArtwork, attr);
-    const fp = new FilePicker({
-      current,
-      type: "image",
-      redirectToRoot: defaultImage ? [defaultImage] : [],
-      callback: path => {
-        target.src = path;
-        if (this.options.form.submitOnChange) {
-          const submit = new Event("submit");
-          this.element.dispatchEvent(submit);
-        }
-      },
-      top: this.position.top + 40,
-      left: this.position.left + 10
-    });
-    await fp.browse();
-  }
 
   /**
    * Toggle Edit vs. Play mode

--- a/src/module/apps/item-sheet.mjs
+++ b/src/module/apps/item-sheet.mjs
@@ -13,7 +13,6 @@ export class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
   static DEFAULT_OPTIONS = {
     classes: ["draw-steel", "item"],
     actions: {
-      editImage: this._onEditImage,
       toggleMode: this._toggleMode,
       updateSource: this._updateSource,
       editHTML: this._editHTML,
@@ -316,40 +315,6 @@ export class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------------- */
   /*   Actions                                          */
   /* -------------------------------------------------- */
-
-  /**
-   * Handle changing a Document's image.
-   * TODO: Copied from v13 implementation, can be removed after
-   * @this DrawSteelItemSheet
-   * @param {PointerEvent} _event   The originating click event
-   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-   * @returns {Promise}
-   * @protected
-   */
-  static async _onEditImage(_event, target) {
-    if (target.nodeName !== "IMG") {
-      throw new Error("The editImage action is available only for IMG elements.");
-    }
-    const attr = target.dataset.edit;
-    const current = foundry.utils.getProperty(this.document._source, attr);
-    const defaultArtwork = this.document.constructor.getDefaultArtwork?.(this.document._source) ?? {};
-    const defaultImage = foundry.utils.getProperty(defaultArtwork, attr);
-    const fp = new FilePicker({
-      current,
-      type: "image",
-      redirectToRoot: defaultImage ? [defaultImage] : [],
-      callback: path => {
-        target.src = path;
-        if (this.options.form.submitOnChange) {
-          const submit = new Event("submit");
-          this.element.dispatchEvent(submit);
-        }
-      },
-      top: this.position.top + 40,
-      left: this.position.left + 10
-    });
-    await fp.browse();
-  }
 
   /**
    * Toggle Edit vs. Play mode

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -271,8 +271,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     damage = Math.max(0, damage + weaknessAmount - immunityAmount);
 
     if (damage === 0) {
-      // TODO: V13 allows the format option to be passed. Notification could be updated to include the damaged actor's name
-      ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", {localize: true});
+      ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", {format: {name: this.parent.name}});
       return this.parent;
     }
 

--- a/src/module/data/migrations.mjs
+++ b/src/module/data/migrations.mjs
@@ -5,8 +5,7 @@ import {systemID} from "../constants.mjs";
  * Run and awaited in the `ready` hook before `ds.ready` is called.
  */
 export async function migrateWorld() {
-  // TODO: In v13 simplify to the new getter
-  if (!game.users.activeGM?.isSelf) {
+  if (!game.user.isActiveGM) {
     console.log("Not the active GM");
     return;
   }

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -41,7 +41,7 @@ export class DrawSteelActiveEffect extends ActiveEffect {
    * @returns {boolean | null}
    */
   static isStatusSource(affected, source, statusId) {
-    if(!affected.statuses.has(statusId)) return null;
+    if (!affected.statuses.has(statusId)) return null;
 
     return !!affected.system.statuses?.[statusId]?.sources.has(source.uuid);
   }
@@ -117,23 +117,5 @@ export class DrawSteelActiveEffect extends ActiveEffect {
     if (isSetChange) delta = new Set([delta]);
 
     super._applyOverride(actor, change, current, delta, changes);
-  }
-
-  /**
-   * TODO: REMOVE IN V13
-   * Fix bug where _applyUpgrade can set value to undefined
-   * @override
-   */
-  _applyUpgrade(actor, change, current, delta, changes) {
-    let update = current;
-    const ct = foundry.utils.getType(current);
-    switch (ct) {
-      case "boolean":
-      case "number":
-        if ((change.mode === CONST.ACTIVE_EFFECT_MODES.UPGRADE) && (delta > current)) update = delta;
-        else if ((change.mode === CONST.ACTIVE_EFFECT_MODES.DOWNGRADE) && (delta < current)) update = delta;
-        break;
-    }
-    changes[change.key] = update;
   }
 }

--- a/src/module/helpers/sockets.mjs
+++ b/src/module/helpers/sockets.mjs
@@ -54,9 +54,7 @@ export default class DrawSteelSocketHandler {
     const settingName = "heroTokens";
     const heroTokens = game.settings.get(systemID, settingName).value;
     if (heroTokens < tokenSpendConfiguration.tokens) {
-      // TODO: Refactor in v13 to use notification formatting
-      const message = game.i18n.format("DRAW_STEEL.Setting.HeroTokens.WarnDirectorBadSpend", {name: sendingUsername});
-      ui.notifications.error(message);
+      ui.notifications.error("DRAW_STEEL.Setting.HeroTokens.WarnDirectorBadSpend", {format: {name: sendingUsername}});
       return;
     }
     await game.settings.set(systemID, settingName, {value: heroTokens - tokenSpendConfiguration.tokens});

--- a/src/module/helpers/sockets.mjs
+++ b/src/module/helpers/sockets.mjs
@@ -43,8 +43,7 @@ export default class DrawSteelSocketHandler {
    * @param {string} payload.flavor
    */
   async spendHeroToken({userId, spendType, flavor}) {
-    // TODO: Refactor in v13 to just call isActiveGM
-    if (!game.users.activeGM?.isSelf) return;
+    if (!game.user.isActiveGM) return;
     const sendingUser = game.users.get(userId);
     const sendingUsername = sendingUser?.name ?? userId;
     const tokenSpendConfiguration = ds.CONFIG.hero.tokenSpends[spendType];


### PR DESCRIPTION
These are some relatively minor, non-controversial changes.

- Update a couple instances of notications to use the new format option.
- Update a couple uses of `game.users.activeGM.isSelf` to `game.user.isActiveGM`
- Remove the `editImage` method from actor/item sheets
- Remove setting the active effect legacy transferral flag to false
- Remove the active effects `_applyUpgrade` override