### PR TITLE
Update the features tab to use updated item list layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,5 @@
 ### Changed
 - Updated the view of the features tab to match the style of the abilities tab
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-### Known Issues
-
 
 ## 0.6 Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,24 @@
 ### Known Issues
 -->
 
+## 0.6.2
+
+### Added
+- Added an option to the kit's right-click context menu to set the preferred kit
+- Added an option to the ability's right click context menu to swap between melee/ranged usage on weapons with a distance of melee or ranged.
+
+### Changed
+- Updated the view of the features tab to match the style of the abilities tab
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Known Issues
+
+
 ## 0.6 Initial Release

--- a/lang/en.json
+++ b/lang/en.json
@@ -713,7 +713,11 @@
         "Restricted": "A condition or ability effect is restricting the usage of this ability.",
         "AddTierEffect": "Add Tier Effect",
         "RemoveTierEffect": "Remove Tier Effect",
-        "Order": "Order"
+        "Order": "Order",
+        "SwapUsage": {
+          "ToMelee": "Swap to Melee Usage",
+          "ToRanged": "Swap to Ranged Usage"
+        }
       },
       "Ancestry": {
         "FIELDS": {}
@@ -972,6 +976,10 @@
           "Title": "Choose Kit to Replace",
           "Button": "Confirm Kit Swap",
           "Header": "Choose which kit to replace with the {kit} kit."
+        },
+        "PreferredKit": {
+          "Label": "Preferred Kit",
+          "MakePreferred": "Make Preferred Kit"
         }
       }
     },

--- a/src/module/apps/_types.d.ts
+++ b/src/module/apps/_types.d.ts
@@ -40,12 +40,12 @@ export interface ActorSheetItemContext {
   embed?: HTMLDivElement
 }
 
-interface ActorSheetAbiltyContext extends ActorSheetItemContext {
-  formattedLabels: object;
+interface ActorSheetAbilityContext extends ActorSheetItemContext {
+  formattedLabels: Record<"keywords" | "distance" | "target", string>;
   order?: number;
 }
 
 export interface ActorSheetAbilitiesContext {
   label: string;
-  abilities: ActorSheetAbiltyContext[]
+  abilities: ActorSheetAbilityContext[]
 }

--- a/src/module/apps/_types.d.ts
+++ b/src/module/apps/_types.d.ts
@@ -37,7 +37,7 @@ export interface PowerRollDialogPrompt {
 export interface ActorSheetItemContext {
   item: documents.DrawSteelItem;
   expanded: boolean;
-  embed?: string
+  embed?: HTMLDivElement
 }
 
 interface ActorSheetAbiltyContext extends ActorSheetItemContext {

--- a/src/module/apps/_types.d.ts
+++ b/src/module/apps/_types.d.ts
@@ -33,3 +33,19 @@ export interface PowerRollDialogPrompt {
   rolls: PowerRollDialogModifiers[];
   damage?: string;
 }
+
+export interface ActorSheetItemContext {
+  item: documents.DrawSteelItem;
+  expanded: boolean;
+  embed?: string
+}
+
+interface ActorSheetAbiltyContext extends ActorSheetItemContext {
+  formattedLabels: object;
+  order?: number;
+}
+
+export interface ActorSheetAbilitiesContext {
+  label: string;
+  abilities: ActorSheetAbiltyContext[]
+}

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -407,7 +407,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    */
   async _onFirstRender(context, options) {
     await super._onFirstRender(context, options);
-    foundry.applications.ui.ContextMenu.create(this, this.element, "[data-document-class]", {hookName: "ItemButtonContext", jQuery: false});
+    foundry.applications.ui.ContextMenu.create(this, this.element, "[data-document-class]", {hookName: "ItemButtonContext", jQuery: false, fixed: true});
   }
 
   /**

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -407,6 +407,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    */
   async _onFirstRender(context, options) {
     await super._onFirstRender(context, options);
+    // TODO: Change to ContextMenu.create in v13 with jQuery: false
     new ContextMenu(this.element, "[data-document-class]", this._getItemButtonContextOptions());
   }
 

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -5,6 +5,7 @@ import {DrawSteelItem} from "../../documents/item.mjs";
 import {DrawSteelItemSheet} from "../item-sheet.mjs";
 
 /** @import {FormSelectOption} from "../../../../foundry/client-esm/applications/forms/fields.mjs" */
+/** @import {ActorSheetItemContext, ActorSheetAbilitiesContext} from "../_types.js" */
 
 const {api, sheets} = foundry.applications;
 
@@ -276,7 +277,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   /**
    * Generate the context data shared between item types
    * @param {DrawSteelItem} item
-   * @returns {import("../_types.js").ActorSheetItemContext}
+   * @returns {ActorSheetItemContext}
    */
   async _prepareItemContext(item) {
     const context = {
@@ -292,7 +293,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
   /**
    * Prepare the context for features
-   * @returns {Array<import("../_types.js").ActorSheetItemContext>}
+   * @returns {Array<ActorSheetItemContext>}
    */
   async _prepareFeaturesContext() {
     const features = this.actor.itemTypes.feature.toSorted((a, b) => a.sort - b.sort);
@@ -307,7 +308,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
   /**
    * Prepare the context for ability categories and individual abilities
-   * @returns {Record<keyof typeof ds["CONFIG"]["abilities"]["types"] | "other", import("../_types.js").ActorSheetAbilitiesContext>}
+   * @returns {Record<keyof typeof ds["CONFIG"]["abilities"]["types"] | "other", ActorSheetAbilitiesContext>}
    */
   async _prepareAbilitiesContext() {
     const context = {};

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -407,7 +407,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    */
   async _onFirstRender(context, options) {
     await super._onFirstRender(context, options);
-    foundry.applications.ui.ContextMenu.create(this, this.element, "[data-document-class]", {hookName: "ItemButtonContext", jQuery: false, fixed: true});
+    new ContextMenu(this.element, "[data-document-class]", this._getItemButtonContextOptions());
   }
 
   /**
@@ -421,11 +421,12 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       //Ability specific options
       {
         name: "DRAW_STEEL.Item.Ability.SwapUsage.ToMelee",
-        condition: (target) => {
+        icon: "",
+        condition: ([target]) => {
           let item = this._getEmbeddedDocument(target);
           return (item?.type === "ability") && (item?.system.distance.type === "meleeRanged") && (item?.system.damageDisplay === "ranged");
         },
-        callback: async (target) => {
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");
@@ -437,11 +438,12 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       },
       {
         name: "DRAW_STEEL.Item.Ability.SwapUsage.ToRanged",
-        condition: (target) => {
+        icon: "",
+        condition: ([target]) => {
           let item = this._getEmbeddedDocument(target);
           return (item?.type === "ability") && (item?.system.distance.type === "meleeRanged") && (item?.system.damageDisplay === "melee");
         },
-        callback: async (target) => {
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");
@@ -454,8 +456,9 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       // Kit specific options
       {
         name: "DRAW_STEEL.Item.Kit.PreferredKit.MakePreferred",
-        condition: (target) => this._getEmbeddedDocument(target)?.type === "kit",
-        callback: async (target) => {
+        icon: "",
+        condition: ([target]) => this._getEmbeddedDocument(target)?.type === "kit",
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");
@@ -470,7 +473,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         name: "View",
         icon: "<i class=\"fa-solid fa-fw fa-eye\"></i>",
         condition: () => this.isPlayMode,
-        callback: async (target) => {
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");
@@ -483,7 +486,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         name: "Edit",
         icon: "<i class=\"fa-solid fa-fw fa-edit\"></i>",
         condition: () => this.isEditMode,
-        callback: async (target) => {
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");
@@ -495,7 +498,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       {
         name: "DRAW_STEEL.Item.base.share",
         icon: "<i class=\"fa-solid fa-fw fa-share-from-square\"></i>",
-        callback: async (target) => {
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");
@@ -511,7 +514,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         name: "Delete",
         icon: "<i class=\"fa-solid fa-fw fa-trash\"></i>",
         condition: () => this.actor.isOwner,
-        callback: async (target) => {
+        callback: async ([target]) => {
           const item = this._getEmbeddedDocument(target);
           if (!item) {
             console.error("Could not find item");

--- a/src/module/apps/actor-sheet/character.mjs
+++ b/src/module/apps/actor-sheet/character.mjs
@@ -2,6 +2,7 @@ import {systemID, systemPath} from "../../constants.mjs";
 import KitModel from "../../data/item/kit.mjs";
 import DrawSteelActorSheet from "./base.mjs";
 /** @import {HeroTokenModel} from "../../data/settings/hero-tokens.mjs"; */
+/** @import {ActorSheetItemContext} from "../_types.js" */
 
 export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
   static DEFAULT_OPTIONS = {
@@ -75,7 +76,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
 
   /**
    * Prepare the context for features
-   * @returns {Array<import("../_types.js").ActorSheetItemContext>}
+   * @returns {Array<ActorSheetItemContext>}
    */
   async _prepareKitsContext() {
     const kits = this.actor.itemTypes.kit.toSorted((a, b) => a.sort - b.sort);

--- a/src/module/apps/actor-sheet/character.mjs
+++ b/src/module/apps/actor-sheet/character.mjs
@@ -27,6 +27,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
     },
     features: {
       template: systemPath("templates/actor/character/features.hbs"),
+      templates: ["templates/actor/shared/features-list.hbs"].map(t => systemPath(t)),
       scrollable: [""]
     },
     abilities: {

--- a/src/module/apps/actor-sheet/character.mjs
+++ b/src/module/apps/actor-sheet/character.mjs
@@ -1,4 +1,5 @@
 import {systemID, systemPath} from "../../constants.mjs";
+import KitModel from "../../data/item/kit.mjs";
 import DrawSteelActorSheet from "./base.mjs";
 /** @import {HeroTokenModel} from "../../data/settings/hero-tokens.mjs"; */
 
@@ -50,7 +51,8 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
         context.skills = this._getSkillList();
         break;
       case "features":
-        context.kits = this.actor.system.kits.sort((a, b) => a.sort - b.sort);
+        context.kits = await this._prepareKitsContext();
+        context.kitFields = KitModel.schema.fields;
         break;
     }
     return context;
@@ -68,6 +70,21 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
     }, []);
     const formatter = game.i18n.getListFormatter();
     return formatter.format(list);
+  }
+
+  /**
+   * Prepare the context for features
+   * @returns {Array<import("../_types.js").ActorSheetItemContext>}
+   */
+  async _prepareKitsContext() {
+    const kits = this.actor.itemTypes.kit.toSorted((a, b) => a.sort - b.sort);
+    const context = [];
+
+    for (const kit of kits) {
+      context.push(await this._prepareItemContext(kit));
+    }
+
+    return context;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/apps/actor-sheet/character.mjs
+++ b/src/module/apps/actor-sheet/character.mjs
@@ -27,7 +27,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
     },
     features: {
       template: systemPath("templates/actor/character/features.hbs"),
-      templates: ["templates/actor/shared/features-list.hbs"].map(t => systemPath(t)),
+      templates: ["templates/actor/character/features.hbs", "templates/actor/shared/features-list.hbs"].map(t => systemPath(t)),
       scrollable: [""]
     },
     abilities: {

--- a/src/module/apps/actor-sheet/npc.mjs
+++ b/src/module/apps/actor-sheet/npc.mjs
@@ -29,6 +29,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
     },
     features: {
       template: systemPath("templates/actor/npc/features.hbs"),
+      templates: ["templates/actor/shared/features-list.hbs"].map(t => systemPath(t)),
       scrollable: [""]
     },
     abilities: {

--- a/src/module/apps/actor-sheet/npc.mjs
+++ b/src/module/apps/actor-sheet/npc.mjs
@@ -29,7 +29,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
     },
     features: {
       template: systemPath("templates/actor/npc/features.hbs"),
-      templates: ["templates/actor/shared/features-list.hbs"].map(t => systemPath(t)),
+      templates: ["templates/actor/npc/features.hbs", "templates/actor/shared/features-list.hbs"].map(t => systemPath(t)),
       scrollable: [""]
     },
     abilities: {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -283,7 +283,7 @@ export default class AbilityModel extends BaseItemModel {
 
   /**
    * The formatted text strings for keywords, distance, and target for use in the ability embed and actor sheet.
-   * @returns {Record<string, string>}
+   * @returns {Record<"keywords" | "distance" | "target", string>}
    */
   get formattedLabels() {
     const labels = {};

--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -78,7 +78,7 @@ export default class BaseItemModel extends foundry.abstract.TypeDataModel {
    */
   async toEmbed(config, options = {}) {
 
-    options.rollData ??= this.parent.getRollData;
+    options.rollData ??= this.parent.getRollData();
     const enriched = await TextEditor.enrichHTML(this.description.value, options);
 
     const embed = document.createElement("div");

--- a/src/scss/components/_actor-sheet.scss
+++ b/src/scss/components/_actor-sheet.scss
@@ -212,3 +212,26 @@ section.tab {
     }
   }
 }
+
+.tab.features {
+
+  .feature-list-container {
+
+    .item-type,
+    .item-subtype {
+      width: 150px;
+    }
+  }
+
+  .kit-list-container {
+
+    .item-melee-bonus,
+    .item-ranged-bonus {
+      width: 150px;
+    }
+
+    .item-preferred-kit {
+      width: 30px;
+    }
+  }
+}

--- a/src/scss/components/_actor-sheet.scss
+++ b/src/scss/components/_actor-sheet.scss
@@ -219,7 +219,7 @@ section.tab {
 
     .item-type,
     .item-subtype {
-      width: 150px;
+      width: 100px;
     }
   }
 

--- a/src/scss/components/_actor-sheet.scss
+++ b/src/scss/components/_actor-sheet.scss
@@ -229,9 +229,5 @@ section.tab {
     .item-ranged-bonus {
       width: 150px;
     }
-
-    .item-preferred-kit {
-      width: 30px;
-    }
   }
 }

--- a/templates/actor/character/features.hbs
+++ b/templates/actor/character/features.hbs
@@ -56,9 +56,8 @@
       <div class="item-column item-name">{{localize "TYPES.Item.kit"}}</div>
       <div class="item-column item-melee-bonus">{{kitFields.bonuses.fields.melee.fields.damage.label}}</div>
       <div class="item-column item-ranged-bonus">{{kitFields.bonuses.fields.ranged.fields.damage.label}}</div>
-      <div class="item-column item-preferred-kit"></div>
       <div class="item-column item-controls">
-        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
+        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.kit")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="kit" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
@@ -71,17 +70,15 @@
         <div class="item-row">
           <div class="item-column item-name" data-action="useAbility">
             <img class="item-image" src="{{kitContext.item.img}}" alt="{{kitContext.item.name}}">
+            {{#if (eq @root.system.hero.preferredKit kitContext.item.id)}}
+            <i data-tooltip="{{localize "DRAW_STEEL.Item.Kit.PreferredKit.Label"}}" class="fa-solid fa-star"></i>
+            {{/if}}
             <div class="name">
               <div class="label">{{kitContext.item.name}}</div>
             </div>
           </div>
           <div class="item-column item-melee-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.melee.damage}}</div>
           <div class="item-column item-ranged-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.ranged.damage}}</div>
-          <div class="item-column item-preferred-kit">
-            {{#if (eq @root.system.hero.preferredKit kitContext.item.id)}}
-            <i data-tooltip="{{localize "DRAW_STEEL.Item.Kit.PreferredKit.Label"}}" class="fa-solid fa-star"></i>
-            {{/if}}
-          </div>
           <div class="item-column item-controls">
             <a data-action="toggleItemEmbed">
               <i class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}"></i>

--- a/templates/actor/character/features.hbs
+++ b/templates/actor/character/features.hbs
@@ -43,7 +43,6 @@
           </div>
         </div>
         <div class="item-embed">
-          {{log featureContext.embed.outerHTML}}
           {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>
@@ -79,7 +78,6 @@
           <div class="item-column item-melee-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.melee.damage}}</div>
           <div class="item-column item-ranged-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.ranged.damage}}</div>
           <div class="item-column item-preferred-kit">
-            {{log @root}}
             {{#if (eq @root.system.hero.preferredKit kitContext.item.id)}}
             <i data-tooltip="{{localize "DRAW_STEEL.Item.Kit.PreferredKit.Label"}}" class="fa-solid fa-star"></i>
             {{/if}}

--- a/templates/actor/character/features.hbs
+++ b/templates/actor/character/features.hbs
@@ -7,48 +7,7 @@
 {{! Features Tab }}
 <section class="tab features {{tab.cssClass}}" data-group="primary" data-tab="features">
   {{! Features List}}
-  <section class="item-list-container feature-list-container">
-    <div class="item-header">
-      <div class="item-column item-name">{{localize "TYPES.Item.feature"}}</div>
-      <div class="item-column item-type">{{featureFields.type.fields.value.label}}</div>
-      <div class="item-column item-type">{{featureFields.type.fields.subtype.label}}</div>
-      <div class="item-column item-controls">
-        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
-          <i class="fa-solid fa-plus"></i>
-        </a>
-        {{/with}}
-      </div>
-    </div>
-    <ol class="item-list2 feature-list">
-      {{#each features as |featureContext|}}
-      <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
-        <div class="item-row">
-          <div class="item-column item-name" data-action="useAbility">
-            <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
-            <div class="name">
-              <div class="label">{{featureContext.item.name}}</div>
-            </div>
-          </div>
-          {{#with (lookup @root.config.features.types featureContext.item.system.type.value) as |typeConfig|}}
-          {{#with (lookup typeConfig.subtypes featureContext.item.system.type.subtype) as |subtypeConfig|}}
-          <div class="item-column item-type">{{typeConfig.label}}</div>
-          <div class="item-column item-subtype">{{subtypeConfig.label}}</div>
-          {{/with}}
-          {{/with}}
-          <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}"></i>
-            </a>
-          </div>
-        </div>
-        <div class="item-embed">
-          {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
-  </section>
+  {{> "systems/draw-steel/templates/actor/shared/features-list.hbs"}}
 
   {{! Kits List}}
   <section class="item-list-container kit-list-container">

--- a/templates/actor/character/features.hbs
+++ b/templates/actor/character/features.hbs
@@ -1,39 +1,100 @@
+{{#*inline "kitDamageBonuses"}}
+{{#if (or damage.tier1 damage.tier2 damage.tier3)}}
++{{damage.tier1}} / +{{damage.tier2}} / +{{damage.tier3}}
+{{/if}}
+{{/inline}}
+
 {{! Features Tab }}
 <section class="tab features {{tab.cssClass}}" data-group="primary" data-tab="features">
-  <div class="item-header flexrow">
-    <a data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true">
-      {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")}}
-    </a>
-  </div>
-  <div class="item-list features">
-    {{#each features as |feature index|}}
-    <button type="button" class="item flexrow draggable" data-action="viewDoc" data-document-class="Item" data-item-id="{{feature.id}}">
-      <img class="img" src="{{feature.img}}" alt="{{feature.name}}">
-      <span class="name">{{feature.name}}</span>
-      {{#unless @root.isPlay}}
-      <a class="delete" data-action="deleteDoc">
-        <i class="fa-solid fa-trash-can"></i>
-      </a>
-      {{/unless}}
-    </button>
-    {{/each}}
-  </div>
-  <fieldset class="item-list kits">
-    <legend>{{localize "TYPES.Item.kit"}}</legend>
-    {{#each kits as |kit|}}
-    <button type="button" class="item flexrow draggable" data-action="viewDoc" data-document-class="Item" data-item-id="{{kit.id}}">
-      <img class="img" src="{{kit.img}}" alt="{{kit.name}}">
-      <span class="name">{{kit.name}}</span>
-      {{#unless @root.isPlay}}
-      <a class="delete" data-action="deleteDoc">
-        <i class="fa-solid fa-trash-can"></i>
-      </a>
-      {{/unless}}
-    </button>
-    {{else}}
-    <a data-action="createDoc" data-document-class="Item" data-type="kit" data-render-sheet="true">
-      {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.kit")}}
-    </a>
-    {{/each}}
-  </fieldset>
+  {{! Features List}}
+  <section class="item-list-container feature-list-container">
+    <div class="item-header">
+      <div class="item-column item-name">{{localize "TYPES.Item.feature"}}</div>
+      <div class="item-column item-type">{{featureFields.type.fields.value.label}}</div>
+      <div class="item-column item-type">{{featureFields.type.fields.subtype.label}}</div>
+      <div class="item-column item-controls">
+        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+          <i class="fa-solid fa-plus"></i>
+        </a>
+        {{/with}}
+      </div>
+    </div>
+    <ol class="item-list2 feature-list">
+      {{#each features as |featureContext|}}
+      <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
+        <div class="item-row">
+          <div class="item-column item-name" data-action="useAbility">
+            <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
+            <div class="name">
+              <div class="label">{{featureContext.item.name}}</div>
+            </div>
+          </div>
+          {{#with (lookup @root.config.features.types featureContext.item.system.type.value) as |typeConfig|}}
+          {{#with (lookup typeConfig.subtypes featureContext.item.system.type.subtype) as |subtypeConfig|}}
+          <div class="item-column item-type">{{typeConfig.label}}</div>
+          <div class="item-column item-subtype">{{subtypeConfig.label}}</div>
+          {{/with}}
+          {{/with}}
+          <div class="item-column item-controls">
+            <a data-action="toggleItemEmbed">
+              <i class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}"></i>
+            </a>
+          </div>
+        </div>
+        <div class="item-embed">
+          {{log featureContext.embed.outerHTML}}
+          {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
+        </div>
+      </li>
+      {{/each}}
+    </ol>
+  </section>
+
+  {{! Kits List}}
+  <section class="item-list-container kit-list-container">
+    <div class="item-header">
+      <div class="item-column item-name">{{localize "TYPES.Item.kit"}}</div>
+      <div class="item-column item-melee-bonus">{{kitFields.bonuses.fields.melee.fields.damage.label}}</div>
+      <div class="item-column item-ranged-bonus">{{kitFields.bonuses.fields.ranged.fields.damage.label}}</div>
+      <div class="item-column item-preferred-kit"></div>
+      <div class="item-column item-controls">
+        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="kit" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+          <i class="fa-solid fa-plus"></i>
+        </a>
+        {{/with}}
+      </div>
+    </div>
+    <ol class="item-list2 kit-list">
+      {{#each kits as |kitContext|}}
+      <li class="item feature draggable" data-item-id="{{kitContext.item.id}}" data-document-class="Item">
+        <div class="item-row">
+          <div class="item-column item-name" data-action="useAbility">
+            <img class="item-image" src="{{kitContext.item.img}}" alt="{{kitContext.item.name}}">
+            <div class="name">
+              <div class="label">{{kitContext.item.name}}</div>
+            </div>
+          </div>
+          <div class="item-column item-melee-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.melee.damage}}</div>
+          <div class="item-column item-ranged-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.ranged.damage}}</div>
+          <div class="item-column item-preferred-kit">
+            {{log @root}}
+            {{#if (eq @root.system.hero.preferredKit kitContext.item.id)}}
+            <i data-tooltip="{{localize "DRAW_STEEL.Item.Kit.PreferredKit.Label"}}" class="fa-solid fa-star"></i>
+            {{/if}}
+          </div>
+          <div class="item-column item-controls">
+            <a data-action="toggleItemEmbed">
+              <i class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}"></i>
+            </a>
+          </div>
+        </div>
+        <div class="item-embed">
+          {{#if kitContext.expanded}}{{{kitContext.embed.outerHTML}}}{{/if}}
+        </div>
+      </li>
+      {{/each}}
+    </ol>
+  </section>
 </section>

--- a/templates/actor/npc/features.hbs
+++ b/templates/actor/npc/features.hbs
@@ -1,21 +1,46 @@
 {{! Features Tab }}
 <section class="tab features {{tab.cssClass}}" data-group="primary" data-tab="features">
-  <div class="item-header flexrow">
-    <a data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true">
-      {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")}}
-    </a>
-  </div>
-  <div class="item-list features">
-    {{#each features as |feature index|}}
-    <button type="button" class="item flexrow draggable" data-action="viewDoc" data-document-class="Item" data-item-id="{{feature.id}}">
-      <img class="img" src="{{feature.img}}" alt="{{feature.name}}">
-      <span class="name">{{feature.name}}</span>
-      {{#unless @root.isPlay}}
-      <a class="delete" data-action="deleteDoc">
-        <i class="fa-solid fa-trash-can"></i>
-      </a>
-      {{/unless}}
-    </button>
-    {{/each}}
-  </div>
+  {{! Features List}}
+  <section class="item-list-container feature-list-container">
+    <div class="item-header">
+      <div class="item-column item-name">{{localize "TYPES.Item.feature"}}</div>
+      <div class="item-column item-type">{{featureFields.type.fields.value.label}}</div>
+      <div class="item-column item-type">{{featureFields.type.fields.subtype.label}}</div>
+      <div class="item-column item-controls">
+        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+          <i class="fa-solid fa-plus"></i>
+        </a>
+        {{/with}}
+      </div>
+    </div>
+    <ol class="item-list2 feature-list">
+      {{#each features as |featureContext|}}
+      <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
+        <div class="item-row">
+          <div class="item-column item-name" data-action="useAbility">
+            <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
+            <div class="name">
+              <div class="label">{{featureContext.item.name}}</div>
+            </div>
+          </div>
+          {{#with (lookup @root.config.features.types featureContext.item.system.type.value) as |typeConfig|}}
+          {{#with (lookup typeConfig.subtypes featureContext.item.system.type.subtype) as |subtypeConfig|}}
+          <div class="item-column item-type">{{typeConfig.label}}</div>
+          <div class="item-column item-subtype">{{subtypeConfig.label}}</div>
+          {{/with}}
+          {{/with}}
+          <div class="item-column item-controls">
+            <a data-action="toggleItemEmbed">
+              <i class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}"></i>
+            </a>
+          </div>
+        </div>
+        <div class="item-embed">
+          {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
+        </div>
+      </li>
+      {{/each}}
+    </ol>
+  </section>
 </section>

--- a/templates/actor/npc/features.hbs
+++ b/templates/actor/npc/features.hbs
@@ -1,46 +1,5 @@
 {{! Features Tab }}
 <section class="tab features {{tab.cssClass}}" data-group="primary" data-tab="features">
   {{! Features List}}
-  <section class="item-list-container feature-list-container">
-    <div class="item-header">
-      <div class="item-column item-name">{{localize "TYPES.Item.feature"}}</div>
-      <div class="item-column item-type">{{featureFields.type.fields.value.label}}</div>
-      <div class="item-column item-type">{{featureFields.type.fields.subtype.label}}</div>
-      <div class="item-column item-controls">
-        {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
-          <i class="fa-solid fa-plus"></i>
-        </a>
-        {{/with}}
-      </div>
-    </div>
-    <ol class="item-list2 feature-list">
-      {{#each features as |featureContext|}}
-      <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
-        <div class="item-row">
-          <div class="item-column item-name" data-action="useAbility">
-            <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
-            <div class="name">
-              <div class="label">{{featureContext.item.name}}</div>
-            </div>
-          </div>
-          {{#with (lookup @root.config.features.types featureContext.item.system.type.value) as |typeConfig|}}
-          {{#with (lookup typeConfig.subtypes featureContext.item.system.type.subtype) as |subtypeConfig|}}
-          <div class="item-column item-type">{{typeConfig.label}}</div>
-          <div class="item-column item-subtype">{{subtypeConfig.label}}</div>
-          {{/with}}
-          {{/with}}
-          <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}"></i>
-            </a>
-          </div>
-        </div>
-        <div class="item-embed">
-          {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
-  </section>
+  {{> "systems/draw-steel/templates/actor/shared/features-list.hbs"}}
 </section>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -9,10 +9,10 @@
       {{#if (eq @key "villain")}}
       <div class="item-column item-order">{{localize "DRAW_STEEL.Item.Ability.Order"}}</div>
       {{else}}
-      <div class="item-column item-cost">{{abilityType.fields.resource.label}}</div>
+      <div class="item-column item-cost">{{@root.abilityFields.resource.label}}</div>
       {{/if}}
-      <div class="item-column item-distance">{{abilityType.fields.distance.label}}</div>
-      <div class="item-column item-target">{{abilityType.fields.target.label}}</div>
+      <div class="item-column item-distance">{{@root.abilityFields.distance.label}}</div>
+      <div class="item-column item-target">{{@root.abilityFields.target.label}}</div>
       <div class="item-column item-controls">
         {{#unless (eq @key "other")}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
@@ -25,17 +25,17 @@
     </div>
     <ol class="item-list2 abilities-list">
       {{#each abilityType.abilities as |abilityContext|}}
-      <li class="item ability draggable" data-item-id="{{abilityContext.ability.id}}" data-document-class="Item">
+      <li class="item ability draggable" data-item-id="{{abilityContext.item.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name" data-action="useAbility">
-            <img class="item-image" src="{{abilityContext.ability.img}}" alt="{{abilityContext.ability.name}}">
-            {{#if abilityContext.ability.system.restricted}}
+            <img class="item-image" src="{{abilityContext.item.img}}" alt="{{abilityContext.item.name}}">
+            {{#if abilityContext.item.system.restricted}}
             <div class="restricted-warning" data-tooltip="DRAW_STEEL.Item.Ability.Restricted">
               <i class="fa-solid fa-triangle-exclamation"></i>
             </div>
             {{/if}}
             <div class="name">
-              <div class="label">{{abilityContext.ability.name}}</div>
+              <div class="label">{{abilityContext.item.name}}</div>
               <div class="keywords">{{abilityContext.formattedLabels.keywords}}</div>
             </div>
           </div>
@@ -45,8 +45,8 @@
           </div>
           {{else}}
           <div class="item-column item-cost">
-            {{#if abilityContext.ability.system.resource}}
-            {{abilityContext.ability.system.resource}} {{@root.system.coreResource.name}}
+            {{#if abilityContext.item.system.resource}}
+            {{abilityContext.item.system.resource}} {{@root.system.coreResource.name}}
             {{/if}}
           </div>
           {{/if}}

--- a/templates/actor/shared/features-list.hbs
+++ b/templates/actor/shared/features-list.hbs
@@ -1,0 +1,42 @@
+<section class="item-list-container feature-list-container">
+  <div class="item-header">
+    <div class="item-column item-name">{{localize "TYPES.Item.feature"}}</div>
+    <div class="item-column item-type">{{featureFields.type.fields.value.label}}</div>
+    <div class="item-column item-type">{{featureFields.type.fields.subtype.label}}</div>
+    <div class="item-column item-controls">
+      {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
+      <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+        <i class="fa-solid fa-plus"></i>
+      </a>
+      {{/with}}
+    </div>
+  </div>
+  <ol class="item-list2 feature-list">
+    {{#each features as |featureContext|}}
+    <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
+      <div class="item-row">
+        <div class="item-column item-name" data-action="useAbility">
+          <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
+          <div class="name">
+            <div class="label">{{featureContext.item.name}}</div>
+          </div>
+        </div>
+        {{#with (lookup @root.config.features.types featureContext.item.system.type.value) as |typeConfig|}}
+        {{#with (lookup typeConfig.subtypes featureContext.item.system.type.subtype) as |subtypeConfig|}}
+        <div class="item-column item-type">{{typeConfig.label}}</div>
+        <div class="item-column item-subtype">{{subtypeConfig.label}}</div>
+        {{/with}}
+        {{/with}}
+        <div class="item-column item-controls">
+          <a data-action="toggleItemEmbed">
+            <i class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}"></i>
+          </a>
+        </div>
+      </div>
+      <div class="item-embed">
+        {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
+      </div>
+    </li>
+    {{/each}}
+  </ol>
+</section>


### PR DESCRIPTION
This accomplishes a few things

- Update the features tab to use same layout/styling as the abilities tab
   - Closes #153 
- Adds buttons specific to kits and abilities to the context menu
   - Kit has the option to make the kit the preferred kit on the actor
   - Abilities have the option to swap between melee/ranged usage for abilities that have `distance.type` of `meleeRanged`
- Updated typing for the `_prepareAbilitiesContext` method. Please let me know if I did that right.

With these changes I don't think there is any of the old `.item-list` elements anymore. Are you okay if I remove the old CSS and then I can rename `item-list2` to `item-list`?



![updated-features-tab](https://github.com/user-attachments/assets/7c5a2f32-735b-4d6d-bf14-7578b5a1f9c0)

