### PR TITLE
Remove top level potencyCharacteristic and add hint to display

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -440,9 +440,6 @@
             "characteristics": {
               "label": "Characteristics"
             },
-            "potencyCharacteristic": {
-              "label": "Potency Characteristic"
-            },
             "tier": {
               "type": {
                 "label" : "Effect Type"
@@ -460,7 +457,8 @@
                 }
               },
               "display": {
-                "label": "Display Text"
+                "label": "Display Text",
+                "hint": "{{potency}} will be replaced with the derived potency info (i.e M<2). {{damage}} will be replaced with the derived damage number based on kits and other effects."
               },
               "damage": {
                 "label": "Damage",

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -103,7 +103,10 @@ export default class AbilityModel extends BaseItemModel {
       Object.entries(schema.types).forEach(([type, typeSchema]) => {
         schema.types[type].label = game.i18n.localize(`${baseLabel}.${type}.label`);
         Object.entries(typeSchema.fields).forEach(([field, fieldSchema]) => {
-          if (["type", "display"].includes(field)) fieldSchema.label = game.i18n.localize(`${baseLabel}.${field}.label`);
+          if (["type", "display"].includes(field)) {
+            fieldSchema.label = game.i18n.localize(`${baseLabel}.${field}.label`);
+            if (field === "display") fieldSchema.hint = game.i18n.localize(`${baseLabel}.${field}.hint`);
+          }
           else fieldSchema.label = game.i18n.localize(`${baseLabel}.${type}.${field}.label`);
         });
       });
@@ -115,7 +118,6 @@ export default class AbilityModel extends BaseItemModel {
       enabled: new fields.BooleanField(),
       formula: new FormulaField({blank: false, initial: "@chr"}),
       characteristics: new fields.SetField(setOptions()),
-      potencyCharacteristic: new fields.StringField(),
       tier1: new fields.ArrayField(powerRollSchema({initialPotency: "@potency.weak"})),
       tier2: new fields.ArrayField(powerRollSchema({initialPotency: "@potency.average"})),
       tier3: new fields.ArrayField(powerRollSchema({initialPotency: "@potency.strong"}))

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -107,7 +107,6 @@
 {{#if system.powerRoll.enabled}}
 {{formGroup systemFields.powerRoll.fields.characteristics value=system.powerRoll.characteristics options=characteristics}}
 {{formGroup systemFields.powerRoll.fields.formula value=system.powerRoll.formula placeholder=systemFields.powerRoll.fields.formula.initial}}
-{{formGroup systemFields.powerRoll.fields.potencyCharacteristic value=system.powerRoll.potencyCharacteristic options=characteristics blank=""}}
 {{> "templates/generic/tab-navigation.hbs" tabs=subtabs}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier1 value=system.powerRoll.tier1}}
 {{> powerRoll field=systemFields.powerRoll.fields.tier2 value=system.powerRoll.tier2}}


### PR DESCRIPTION
I forgot to remove the `powerRoll.potencyCharacteristic` field during the ability effects refactor since it's no longer used.

I also added a hint to the display field to advise on the use of `{{potency}}` and `{{damage}}` replacements