### PR TITLE
Adjustments to the kit section of the features tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### Changed
 - Updated the view of the features tab to match the style of the abilities tab
+- The kit section will only be visible if the actor's class allows kits or there's kits on the actor.
+- Made the kit swap dialog more clear on why you need to swap kits.
 
 
 ## 0.6 Initial Release

--- a/lang/en.json
+++ b/lang/en.json
@@ -973,7 +973,7 @@
         "Swap": {
           "Title": "Choose Kit to Replace",
           "Button": "Confirm Kit Swap",
-          "Header": "Choose which kit to replace with the {kit} kit."
+          "Header": "{actor} already has the maximum number kits and must replace one. Choose which kit to replace with the {kit} kit."
         },
         "PreferredKit": {
           "Label": "Preferred Kit",

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -95,7 +95,7 @@ export default class KitModel extends BaseItemModel {
     if (!Number.isNumeric(kitLimit) || (kits.length < kitLimit)) return;
 
     // Generate the HTML for the dialog
-    let radioButtons = `<strong>${game.i18n.format("DRAW_STEEL.Item.Kit.Swap.Header", {kit: this.parent.name})}</strong>`;
+    let radioButtons = `<strong>${game.i18n.format("DRAW_STEEL.Item.Kit.Swap.Header", {kit: this.parent.name, actor: this.parent.actor.name})}</strong>`;
     for (const kit of kits) {
       radioButtons += `
         <div class="form-group">

--- a/templates/actor/character/features.hbs
+++ b/templates/actor/character/features.hbs
@@ -10,9 +10,10 @@
   {{> "systems/draw-steel/templates/actor/shared/features-list.hbs"}}
 
   {{! Kits List}}
+  {{#if (or system.class.system.kits kits.length)}}
   <section class="item-list-container kit-list-container">
     <div class="item-header">
-      <div class="item-column item-name">{{localize "TYPES.Item.kit"}}</div>
+      <div class="item-column item-name">{{localize "TYPES.Item.kit"}} ({{kits.length}} / {{ifThen system.class.system.kits system.class.system.kits 0}})</div>
       <div class="item-column item-melee-bonus">{{kitFields.bonuses.fields.melee.fields.damage.label}}</div>
       <div class="item-column item-ranged-bonus">{{kitFields.bonuses.fields.ranged.fields.damage.label}}</div>
       <div class="item-column item-controls">
@@ -51,4 +52,5 @@
       {{/each}}
     </ol>
   </section>
+  {{/if}}
 </section>


### PR DESCRIPTION
- Show how many kits are allowed on the kit header so the player knows how many they can have without digging into the class info
- Only show the kit section if the class allows them or if there are currently kits on the actor to prevent them being inaccessible. 
- Update the kit swap dialog to be a little more clear on why you are having to replace a kit. 

![updated kit section](https://github.com/user-attachments/assets/81a1c855-fd86-4e51-bc51-84bfd3b4a9a8)
