### PR TITLE
Fix kit stability not being adding to hero stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,5 +30,7 @@
 - The kit section will only be visible if the actor's class allows kits or there's kits on the actor.
 - Made the kit swap dialog more clear on why you need to swap kits.
 
+### Fixed
+- Fixed kit stability not increasing character stability
 
 ## 0.6 Initial Release

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -97,7 +97,7 @@ export default class CharacterModel extends BaseActorModel {
       const bonuses = kit.system.bonuses;
       kitBonuses.stamina = Math.max(kitBonuses.stamina, bonuses.stamina);
       kitBonuses.speed = Math.max(kitBonuses.speed, bonuses.speed);
-      kitBonuses.stamina = Math.max(kitBonuses.stamina, bonuses.stamina);
+      kitBonuses.stability = Math.max(kitBonuses.stability, bonuses.stability);
 
       const abiBonuses = ["melee.distance", "ranged.distance"];
 


### PR DESCRIPTION
Kit stability wasn't being added. Stamina was listed twice instead.