### PR TITLE
Add a project item

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -28,7 +28,7 @@ Hooks.once("init", function () {
   }
 
   helpers.registerHandlebars();
-  const templates = ["templates/item/embeds/ability.hbs", "templates/item/embeds/kit.hbs"].map(t => DS_CONST.systemPath(t));
+  const templates = ["templates/item/embeds/ability.hbs", "templates/item/embeds/kit.hbs", "templates/item/embeds/project.hbs"].map(t => DS_CONST.systemPath(t));
 
   // Assign data models & setup templates
   for (const [doc, models] of Object.entries(data)) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -986,6 +986,34 @@
           "MakePreferred": "Make Preferred Kit"
         },
         "StaminaEmbed": "{number} per echelon"
+      },
+      "Project": {
+        "FIELDS": {
+          "prerequisites": {
+            "label": "Item Prerequisites"
+          },
+          "projectSource": {
+            "label": "Project Source"
+          },
+          "rollCharacteristic": {
+            "label": "Project Roll Characteristics"
+          },
+          "goal": {
+            "label": "Project Goal"
+          },
+          "yield": {
+            "item": {
+              "label": "Yield Item UUID"
+            },
+            "amount": {
+              "label": "Yield Amount"
+            },
+            "display": {
+              "label": "Yield Display"
+            }
+          }
+        },
+        "CraftItemName": "Craft {name}"
       }
     },
     "Effect": {
@@ -1297,7 +1325,8 @@
       "culture": "Culture",
       "feature": "Feature",
       "equipment": "Equipment",
-      "kit": "Kit"
+      "kit": "Kit",
+      "project": "Project"
     }
   },
   "USER": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -808,11 +808,11 @@
           "keywords": {
             "label": "Keywords"
           },
-          "prerequisites": {
-            "label": "Item Prerequisites"
-          },
           "project": {
             "label": "Project",
+            "prerequisites": {
+            "label": "Item Prerequisites"
+          },
             "source": {
               "label": "Project Source"
             },

--- a/lang/en.json
+++ b/lang/en.json
@@ -823,7 +823,12 @@
               "label": "Project Goal"
             },
             "yield": {
-              "label": "Project Yield"
+              "amount": {
+                "label": "Yield Amount"
+              },
+              "display": {
+                "label": "Yield Display"
+              }
             }
           }
         },

--- a/lang/en.json
+++ b/lang/en.json
@@ -811,8 +811,8 @@
           "project": {
             "label": "Project",
             "prerequisites": {
-            "label": "Item Prerequisites"
-          },
+              "label": "Item Prerequisites"
+            },
             "source": {
               "label": "Project Source"
             },
@@ -1000,6 +1000,9 @@
           },
           "goal": {
             "label": "Project Goal"
+          },
+          "progress": {
+            "label": "Project Progress"
           },
           "yield": {
             "item": {

--- a/src/module/data/item/_module.mjs
+++ b/src/module/data/item/_module.mjs
@@ -1,5 +1,5 @@
 export {default as AbilityModel} from "./ability.mjs";
-export {default as AdvancementModel} from "./advancement.mjs"
+export {default as AdvancementModel} from "./advancement.mjs";
 export {default as AncestryModel} from "./ancestry.mjs";
 export {default as BaseItemModel} from "./base.mjs";
 export {default as CareerModel} from "./career.mjs";
@@ -9,3 +9,4 @@ export {default as CultureModel} from "./culture.mjs";
 export {default as FeatureModel} from "./feature.mjs";
 export {default as EquipmentModel} from "./equipment.mjs";
 export {default as KitModel} from "./kit.mjs";
+export {default as ProjectModel} from "./project.mjs";

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -1,4 +1,5 @@
 import {systemPath} from "../../constants.mjs";
+import FormulaField from "../fields/formula-field.mjs";
 import {setOptions} from "../helpers.mjs";
 import BaseItemModel from "./base.mjs";
 
@@ -36,7 +37,10 @@ export default class EquipmentModel extends BaseItemModel {
       source: new fields.StringField({required: true}),
       rollCharacteristic: new fields.SetField(setOptions()),
       goal: new fields.NumberField(),
-      yield: new fields.StringField({required: true})
+      yield: new fields.SchemaField({
+        amount: new FormulaField({initial: "1"}),
+        display: new fields.StringField({required: true})
+      })
     });
 
     return schema;

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -31,9 +31,8 @@ export default class EquipmentModel extends BaseItemModel {
 
     schema.keywords = new fields.SetField(setOptions());
 
-    schema.prerequisites = new fields.StringField({required: true});
-
     schema.project = new fields.SchemaField({
+      prerequisites: new fields.StringField({required: true}),
       source: new fields.StringField({required: true}),
       rollCharacteristic: new fields.SetField(setOptions()),
       goal: new fields.NumberField(),

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -1,0 +1,98 @@
+import {systemPath} from "../../constants.mjs";
+import FormulaField from "../fields/formula-field.mjs";
+import {setOptions} from "../helpers.mjs";
+import BaseItemModel from "./base.mjs";
+
+const fields = foundry.data.fields;
+
+/**
+ * Projects are activities (crafting, research, or other) characters can accomplish during downtime.
+ */
+export default class ProjectModel extends BaseItemModel {
+  /** @override */
+  static metadata = Object.freeze({
+    ...super.metadata,
+    type: "project",
+    detailsPartial: [systemPath("templates/item/partials/project.hbs")]
+  });
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = [
+    "DRAW_STEEL.Source",
+    "DRAW_STEEL.Item.base",
+    "DRAW_STEEL.Item.Project"
+  ];
+
+  /** @override */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.prerequisites = new fields.StringField();
+    schema.projectSource = new fields.StringField();
+    schema.rollCharacteristic = new fields.SetField(setOptions());
+    schema.goal = new fields.NumberField({integer: true, positive: true});
+    schema.progress = new fields.NumberField({integer: true});
+    schema.yield = new fields.SchemaField({
+      item: new fields.DocumentUUIDField(),
+      amount: new FormulaField({initial: "1"}),
+      display: new fields.StringField()
+    });
+
+    return schema;
+  }
+
+  /** @override */
+  async _preCreate(data, options, user) {
+    const allowed = await super._preCreate(data, options, user);
+    if (allowed === false) return false;
+
+    // If creating with item UUID, transfer the item project data to the project item
+    const itemUUID = data.system?.yield?.item;
+    const yieldItem = await fromUuid(itemUUID);
+    if (yieldItem?.type === "equipment") {
+      const {prerequisites, rollCharacteristic, goal, source} = yieldItem.system.project;
+      this.updateSource({
+        prerequisites,
+        rollCharacteristic,
+        goal,
+        projectSource: source,
+        yield: {
+          item: itemUUID,
+          display: yieldItem.system.project.yield
+        }
+      });
+      const name = game.i18n.format("DRAW_STEEL.Item.Project.CraftItemName", {name: yieldItem.name});
+      this.parent.updateSource({name});
+    }
+  }
+
+  /**
+   * @override
+   * @param {DocumentHTMLEmbedConfig} config
+   * @param {EnrichmentOptions} options
+   */
+  async toEmbed(config, options = {}) {
+    const context = {
+      system: this,
+      systemFields: this.schema.fields,
+      config: ds.CONFIG
+    };
+    this.getSheetContext(context);
+
+    const embed = document.createElement("div");
+    embed.classList.add("project");
+    embed.insertAdjacentHTML("afterbegin", `<h5>${this.parent.name}</h5>`);
+    const projectBody = await renderTemplate(systemPath("templates/item/embeds/project.hbs"), context);
+    embed.insertAdjacentHTML("beforeend", projectBody);
+    return embed;
+  }
+
+  /** @override */
+  async getSheetContext(context) {
+    context.characteristics = Object.entries(ds.CONFIG.characteristics).map(([value, {label}]) => ({value, label}));
+
+    const characteristicFormatter = game.i18n.getListFormatter({type: "disjunction"});
+    const characteristicList = Array.from(this.rollCharacteristic).map(c => ds.CONFIG.characteristics[c]?.label ?? c);
+    context.formattedCharacteristics = characteristicFormatter.format(characteristicList);
+  }
+}

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -27,11 +27,11 @@ export default class ProjectModel extends BaseItemModel {
   static defineSchema() {
     const schema = super.defineSchema();
 
-    schema.prerequisites = new fields.StringField();
-    schema.projectSource = new fields.StringField();
+    schema.prerequisites = new fields.StringField({required: true});
+    schema.projectSource = new fields.StringField({required: true});
     schema.rollCharacteristic = new fields.SetField(setOptions());
-    schema.goal = new fields.NumberField({integer: true, positive: true});
-    schema.progress = new fields.NumberField({integer: true});
+    schema.goal = new fields.NumberField({required: true, integer: true, positive: true, initial: 1});
+    schema.progress = new fields.NumberField({required: true, integer: true, min: 0, initial: 0});
     schema.yield = new fields.SchemaField({
       item: new fields.DocumentUUIDField(),
       amount: new FormulaField({initial: "1"}),

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -94,5 +94,7 @@ export default class ProjectModel extends BaseItemModel {
     const characteristicFormatter = game.i18n.getListFormatter({type: "disjunction"});
     const characteristicList = Array.from(this.rollCharacteristic).map(c => ds.CONFIG.characteristics[c]?.label ?? c);
     context.formattedCharacteristics = characteristicFormatter.format(characteristicList);
+
+    if (this.yield.item) context.itemLink = await TextEditor.enrichHTML(`@UUID[${this.yield.item}]`);
   }
 }

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -58,7 +58,8 @@ export default class ProjectModel extends BaseItemModel {
         projectSource: source,
         yield: {
           item: itemUUID,
-          display: yieldItem.system.project.yield
+          amount: yieldItem.system.project.yield.amount,
+          display: yieldItem.system.project.yield.display
         }
       });
       const name = game.i18n.format("DRAW_STEEL.Item.Project.CraftItemName", {name: yieldItem.name});

--- a/system.json
+++ b/system.json
@@ -46,6 +46,9 @@
       },
       "kit": {
         "htmlFields": ["description.value", "description.gm"]
+      },
+      "project": {
+        "htmlFields": ["description.value", "description.gm"]
       }
     }
   },

--- a/templates/item/embeds/project.hbs
+++ b/templates/item/embeds/project.hbs
@@ -1,0 +1,15 @@
+<section class="project-info">
+  <p class="prerequisites">
+    <strong>{{systemFields.prerequisites.label}}:</strong> {{system.prerequisites}}
+  </p>
+  <p class="source">
+    <strong>{{systemFields.projectSource.label}}:</strong> {{system.projectSource}}
+  </p>
+  <p class="characteristics">
+    <strong>{{systemFields.rollCharacteristic.label}}:</strong> {{formattedCharacteristics}}
+  </p>
+  <p class="goal">
+    <strong>{{systemFields.goal.label}}:</strong> {{system.goal}} {{#if system.yield.display}}({{system.yield.display}}){{/if}}
+  </p>
+  {{!-- TODO: Add content link to the item --}}
+</section>

--- a/templates/item/embeds/project.hbs
+++ b/templates/item/embeds/project.hbs
@@ -16,4 +16,6 @@
     <strong>{{localize "DOCUMENT.Item"}}:</strong> {{{itemLink}}}
   </p>
   {{/if}}
+
+  {{{enrichedDescription}}}
 </section>

--- a/templates/item/embeds/project.hbs
+++ b/templates/item/embeds/project.hbs
@@ -11,5 +11,9 @@
   <p class="goal">
     <strong>{{systemFields.goal.label}}:</strong> {{system.goal}} {{#if system.yield.display}}({{system.yield.display}}){{/if}}
   </p>
-  {{!-- TODO: Add content link to the item --}}
+  {{#if itemLink}}
+  <p class="item-link">
+    <strong>{{localize "DOCUMENT.Item"}}:</strong> {{{itemLink}}}
+  </p>
+  {{/if}}
 </section>

--- a/templates/item/partials/equipment.hbs
+++ b/templates/item/partials/equipment.hbs
@@ -2,9 +2,9 @@
 {{formGroup systemFields.kind value=system.kind options=kinds disabled=isPlay}}
 {{formGroup systemFields.echelon value=system.echelon options=echelons disabled=isPlay}}
 {{formGroup systemFields.keywords value=system.keywords options=keywords disabled=isPlay}}
-{{formGroup systemFields.prerequisites value=system.prerequisites disabled=isPlay}}
 <fieldset>
   <legend>{{systemFields.project.label}}</legend>
+  {{formGroup systemFields.project.fields.prerequisites value=system.project.prerequisites disabled=isPlay}}
   {{formGroup systemFields.project.fields.source value=system.project.source disabled=isPlay}}
   {{formGroup systemFields.project.fields.rollCharacteristic value=system.project.rollCharacteristic options=characteristics disabled=isPlay}}
   {{formGroup systemFields.project.fields.goal value=system.project.goal disabled=isPlay}}

--- a/templates/item/partials/equipment.hbs
+++ b/templates/item/partials/equipment.hbs
@@ -8,5 +8,6 @@
   {{formGroup systemFields.project.fields.source value=system.project.source disabled=isPlay}}
   {{formGroup systemFields.project.fields.rollCharacteristic value=system.project.rollCharacteristic options=characteristics disabled=isPlay}}
   {{formGroup systemFields.project.fields.goal value=system.project.goal disabled=isPlay}}
-  {{formGroup systemFields.project.fields.yield value=system.project.yield disabled=isPlay}}
+  {{formGroup systemFields.project.fields.yield.fields.amount value=system.project.yield.amount disabled=isPlay}}
+  {{formGroup systemFields.project.fields.yield.fields.display value=system.project.yield.display disabled=isPlay}}
 </fieldset>

--- a/templates/item/partials/project.hbs
+++ b/templates/item/partials/project.hbs
@@ -1,0 +1,14 @@
+{{#if isPlay}}
+{{> "systems/draw-steel/templates/item/embeds/project.hbs"}}
+{{else}}
+<fieldset>
+  <legend>{{localize "TYPES.Item.project"}}</legend>
+  {{formGroup systemFields.prerequisites value=system.prerequisites}}
+  {{formGroup systemFields.projectSource value=system.projectSource}}
+  {{formGroup systemFields.rollCharacteristic value=system.rollCharacteristic options=characteristics}}
+  {{formGroup systemFields.goal value=system.goal}}
+  {{formGroup systemFields.yield.fields.item value=system.yield.item}}
+  {{formGroup systemFields.yield.fields.amount value=system.yield.amount}}
+  {{formGroup systemFields.yield.fields.display value=system.yield.display}}
+</fieldset>
+{{/if}}

--- a/templates/item/partials/project.hbs
+++ b/templates/item/partials/project.hbs
@@ -7,6 +7,9 @@
   {{formGroup systemFields.projectSource value=system.projectSource}}
   {{formGroup systemFields.rollCharacteristic value=system.rollCharacteristic options=characteristics}}
   {{formGroup systemFields.goal value=system.goal}}
+  {{#if item.isOwned}}
+  {{formGroup systemFields.progress value=system.progress}}
+  {{/if}}
   {{formGroup systemFields.yield.fields.item value=system.yield.item}}
   {{formGroup systemFields.yield.fields.amount value=system.yield.amount}}
   {{formGroup systemFields.yield.fields.display value=system.yield.display}}


### PR DESCRIPTION
Closes #248

- Adds a project item and its embed
   - If the initial creation data includes the item UUID, all of the item's project info is transferred to the project item and the name will be updated to "Craft {item name}"
   - The interactivity with characters will happen when it gets added to the character sheet as part of #249 
- Moved the equipment's item prerequisite to the project schema since the prereq is project related. If you need me to migrate this, I might need some help because I'm not sure how to do migrations.

![project-item](https://github.com/user-attachments/assets/24254fbc-3f62-4c8b-955b-172e17184a3c)
