### PR TITLE
Include bonuses in power rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1144,6 +1144,7 @@
           "Edges": "Edges",
           "Bane": "Bane",
           "Banes": "Banes",
+          "Bonuses": "Bonuses/Penalties",
           "Label": "{number} {mod}"
         },
         "BaseRoll": "Base Power Roll"

--- a/src/module/_types.d.ts
+++ b/src/module/_types.d.ts
@@ -25,6 +25,7 @@ export interface AdvancementTypeConfiguration {
 export interface PowerRollModifiers {
   edges: number;
   banes: number;
+  bonuses: number;
 }
 
 export interface PowerRollTargets {

--- a/src/module/apps/power-roll-dialog.mjs
+++ b/src/module/apps/power-roll-dialog.mjs
@@ -14,6 +14,9 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
   /** @override */
   static DEFAULT_OPTIONS = {
     classes: ["draw-steel", "power-roll-dialog"],
+    position: {
+      width: 400
+    },
     tag: "form",
     form: {
       closeOnSubmit: true
@@ -79,7 +82,8 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
 
       target.combinedModifiers = {
         edges: Math.clamp(target.modifiers.edges + context.modifiers.edges, 0, PowerRoll.MAX_EDGE),
-        banes: Math.clamp(target.modifiers.banes + context.modifiers.banes, 0, PowerRoll.MAX_BANE)
+        banes: Math.clamp(target.modifiers.banes + context.modifiers.banes, 0, PowerRoll.MAX_BANE),
+        bonuses: target.modifiers.bonuses + context.modifiers.bonuses
       };
     }
   }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -472,6 +472,7 @@ export default class AbilityModel extends BaseItemModel {
       options.modifiers ??= {};
       options.modifiers.banes ??= 0;
       options.modifiers.edges ??= 0;
+      options.modifiers.bonuses ??= 0;
 
       this.getActorModifiers(options);
 
@@ -561,7 +562,8 @@ export default class AbilityModel extends BaseItemModel {
   getTargetModifiers(target) {
     const modifiers = {
       banes: 0,
-      edges: 0
+      edges: 0,
+      bonuses: 0
     };
 
     //TODO: ALL CONDITION CHECKS

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -20,13 +20,28 @@ export class PowerRoll extends DSRoll {
     if (!PowerRoll.VALID_TYPES.has(this.options.type)) throw new Error("Power rolls must be an ability or test");
     this.options.edges = Math.clamp(this.options.edges, 0, this.constructor.MAX_EDGE);
     this.options.banes = Math.clamp(this.options.banes, 0, this.constructor.MAX_BANE);
-    if (!options.appliedModifier && (Math.abs(this.netBoon) === 1)) {
-      const operation = new foundry.dice.terms.OperatorTerm({operator: (this.netBoon > 0 ? "+" : "-")});
-      const number = new foundry.dice.terms.NumericTerm({
-        number: 2,
-        flavor: game.i18n.localize(this.netBoon > 0 ? "DRAW_STEEL.Roll.Power.Modifier.Edge" : "DRAW_STEEL.Roll.Power.Modifier.Bane")
-      });
-      this.terms.push(operation, number);
+    if (!options.appliedModifier) {
+
+      // Add edges/banes to formula
+      if (Math.abs(this.netBoon === 1)) {
+        const operation = new foundry.dice.terms.OperatorTerm({operator: (this.netBoon > 0 ? "+" : "-")});
+        const number = new foundry.dice.terms.NumericTerm({
+          number: 2,
+          flavor: game.i18n.localize(this.netBoon > 0 ? "DRAW_STEEL.Roll.Power.Modifier.Edge" : "DRAW_STEEL.Roll.Power.Modifier.Bane")
+        });
+        this.terms.push(operation, number);
+      }
+
+      // add bonuses to formula
+      if (this.options.bonuses) {
+        const operation = new foundry.dice.terms.OperatorTerm({operator: (this.options.bonuses > 0 ? "+" : "-")});
+        const number = new foundry.dice.terms.NumericTerm({
+          number: Math.abs(this.options.bonuses),
+          flavor: game.i18n.localize("DRAW_STEEL.Roll.Power.Modifier.Bonuses")
+        });
+        this.terms.push(operation, number);
+      }
+
       this.resetFormula();
       this.options.appliedModifier = true;
     }
@@ -36,7 +51,8 @@ export class PowerRoll extends DSRoll {
     type: "test",
     criticalThreshold: 19,
     banes: 0,
-    edges: 0
+    edges: 0,
+    bonuses: 0
   });
 
   static CHAT_TEMPLATE = systemPath("templates/rolls/power.hbs");
@@ -119,8 +135,10 @@ export class PowerRoll extends DSRoll {
     const type = options.type ?? "test";
     const evaluation = options.evaluation ?? "message";
     const formula = options.formula ?? "2d10";
+    options.modifiers ??= {};
     options.modifiers.edges ??= 0;
     options.modifiers.banes ??= 0;
+    options.modifiers.bonuses ??= 0;
     options.actor ??= DrawSteelChatMessage.getSpeakerActor(DrawSteelChatMessage.getSpeaker());
     if (!this.VALID_TYPES.has(type)) throw new Error("The `type` parameter must be 'ability' or 'test'");
     if (!["none", "evaluate", "message"].includes(evaluation)) throw new Error("The `evaluation` parameter must be 'none', 'evaluate', or 'message'");

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -14,13 +14,28 @@ export class ProjectRoll extends DSRoll {
     });
     this.options.edges = Math.clamp(this.options.edges, 0, this.constructor.MAX_EDGE);
     this.options.banes = Math.clamp(this.options.banes, 0, this.constructor.MAX_BANE);
-    if (!options.appliedModifier && this.netBoon) {
-      const operation = new foundry.dice.terms.OperatorTerm({operator: (this.netBoon > 0 ? "+" : "-")});
-      const number = new foundry.dice.terms.NumericTerm({
-        number: Math.min(4, 2 * Math.abs(this.netBoon)),
-        flavor: game.i18n.localize(`DRAW_STEEL.Roll.Power.Modifier.${this.netBoon > 0 ? "Edge" : "Bane"}`)
-      });
-      this.terms.push(operation, number);
+
+    if (!options.appliedModifier) {
+      // Add edges/banes to formula
+      if (this.netBoon) {
+        const operation = new foundry.dice.terms.OperatorTerm({operator: (this.netBoon > 0 ? "+" : "-")});
+        const number = new foundry.dice.terms.NumericTerm({
+          number: Math.min(4, 2 * Math.abs(this.netBoon)),
+          flavor: game.i18n.localize(`DRAW_STEEL.Roll.Power.Modifier.${this.netBoon > 0 ? "Edge" : "Bane"}`)
+        });
+        this.terms.push(operation, number);
+      }
+
+      // Add bonuses to formula
+      if (this.options.bonuses !== 0) {
+        const operation = new foundry.dice.terms.OperatorTerm({operator: (this.options.bonuses > 0 ? "+" : "-")});
+        const number = new foundry.dice.terms.NumericTerm({
+          number: Math.abs(this.options.bonuses),
+          flavor: game.i18n.localize("DRAW_STEEL.Roll.Power.Modifier.Bonuses")
+        });
+        this.terms.push(operation, number);
+      }
+
       this.resetFormula();
       this.options.appliedModifier = true;
     }
@@ -29,7 +44,8 @@ export class ProjectRoll extends DSRoll {
   static DEFAULT_OPTIONS = Object.freeze({
     criticalThreshold: 19,
     banes: 0,
-    edges: 0
+    edges: 0,
+    bonuses: 0
   });
 
   static CHAT_TEMPLATE = systemPath("templates/rolls/project.hbs");

--- a/src/scss/components/_power-roll-dialog.scss
+++ b/src/scss/components/_power-roll-dialog.scss
@@ -9,7 +9,6 @@
   .modifiers {
     display: flex;
     flex-direction: row;
-    flex: 1;
     gap: 5px;
     margin-bottom: 10px;
 

--- a/templates/rolls/power-roll-dialog.hbs
+++ b/templates/rolls/power-roll-dialog.hbs
@@ -14,6 +14,10 @@
           {{selectOptions modChoices selected=modifiers.banes}}
         </select>
       </label>
+      <label>
+        <span>{{localize "DRAW_STEEL.Roll.Power.Modifier.Bonuses"}}</span>
+        {{numberInput modifiers.bonuses name="modifiers.bonuses" step=1}}
+      </label>
     </div>
   </div>
   {{#each targets as |target|}}
@@ -33,6 +37,11 @@
           {{selectOptions @root.modChoices selected=target.modifiers.banes}}
         </select>
         <span class="total-banes">{{localize "DRAW_STEEL.Roll.Power.Prompt.Total" number=target.combinedModifiers.banes}}</span>
+      </label>
+      <label>
+        <span>{{localize "DRAW_STEEL.Roll.Power.Modifier.Bonuses"}}</span>
+        {{numberInput target.modifiers.bonuses name=(concat "targets." @index ".modifiers.bonuses") step=1}}
+        <span class="total-bonuses">{{localize "DRAW_STEEL.Roll.Power.Prompt.Total" number=target.combinedModifiers.bonuses}}</span>
       </label>
     </div>
   </div>


### PR DESCRIPTION
Closes #276 

I was starting to work on including skills in the `PowerRollDialog` for test rolls and adding their bonuses to the roll, but there's no where to include bonuses in our rolls. This required enough changes that I felt like splitting this into its own PR was the better choice.

- Add bonuses field to the dialog
- Updated the power and project rolls to add the bonuses to the formula similar to how edges/banes are handled
- Updated the various places where edges/banes had defaults set, to also set default bonuses

![updated-dialog](https://github.com/user-attachments/assets/10f589f2-4634-4322-a348-bb9a8446bf20)
