### PR TITLE
Add skills to power roll dialog and include +2 bonus when skill selected

### DIFF
--- a/src/module/apps/power-roll-dialog.mjs
+++ b/src/module/apps/power-roll-dialog.mjs
@@ -50,7 +50,7 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
 
     if (context.targets) await this._prepareTargets(context);
 
-    if (context.skills && (context.skills.size > 0)) this._prepareSkillOptions(context);
+    if (context.skills?.size > 0) this._prepareSkillOptions(context);
 
     return context;
   }

--- a/src/module/apps/power-roll-dialog.mjs
+++ b/src/module/apps/power-roll-dialog.mjs
@@ -50,6 +50,8 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
 
     if (context.targets) await this._prepareTargets(context);
 
+    if (context.skills && (context.skills.size > 0)) this._prepareSkillOptions(context);
+
     return context;
   }
 
@@ -89,6 +91,19 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
   }
 
   /**
+   * Prepare the skill select options
+   * @param {object} context The context from _prepareContext
+   */
+  _prepareSkillOptions(context) {
+    const {list, groups} = ds.CONFIG.skills;
+    context.skillOptions = Array.from(context.skills).reduce((accumulator, value) => {
+      const {label, group} = list[value];
+      accumulator.push({label, group: groups[group].label, value});
+      return accumulator;
+    }, []);
+  }
+
+  /**
    * Amend the global modifiers and target specific modifiers based on changed values
    * @override
    */
@@ -99,6 +114,15 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     this.options.context.modifiers = foundry.utils.mergeObject(this.options.context.modifiers, formData.modifiers, {overwrite: true, recursive: true});
     if (this.options.context.targets) this.options.context.targets = foundry.utils.mergeObject(this.options.context.targets, formData.targets, {overwrite: true, recursive: true});
     if (formData["damage-selection"]) this.options.context.damage = formData["damage-selection"];
+
+    if ("skill" in formData) {
+      const previousSkill = this.options.context.skill ?? "";
+      const newSkill = formData.skill;
+      if ((previousSkill === "") && (newSkill !== "")) this.options.context.modifiers.bonuses += 2;
+      else if ((previousSkill !== "") && (newSkill === "")) this.options.context.modifiers.bonuses -= 2;
+
+      this.options.context.skill = newSkill;
+    }
 
     this.render(true);
   }
@@ -122,6 +146,7 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     if (formData["damage-selection"]) this.promptValue.damage = formData["damage-selection"];
+    if (formData.skill) this.promptValue.skill = formData.skill;
 
     super._onSubmitForm(formConfig, event);
   }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -1,6 +1,7 @@
 /** @import {DrawSteelCombatant} from "../../documents/combatant.mjs"; */
 /** @import AbilityModel from "../item/ability.mjs" */
 /** @import DataModel from "../../../../foundry/common/abstract/data.mjs" */
+import {DrawSteelChatMessage} from "../../documents/chat-message.mjs";
 import {PowerRoll} from "../../rolls/power.mjs";
 import {damageTypes, requiredInteger, setOptions} from "../helpers.mjs";
 import SizeModel from "../models/size.mjs";
@@ -242,6 +243,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     }
     const skills = this.hero?.skills ?? null;
 
+    const evaluation = "evaluate";
     const formula = `2d10 + @${characteristic}`;
     const data = this.parent.getRollData();
     const flavor = `${game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${characteristic}.full`)} ${game.i18n.localize(PowerRoll.TYPES[type].label)}`;
@@ -250,7 +252,12 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
       banes: options.banes ?? 0,
       bonuses: options.bonuses ?? 0
     };
-    return PowerRoll.prompt({type, formula, data, flavor, modifiers, actor: this.parent, characteristic, skills});
+
+    const rolls = await PowerRoll.prompt({type, evaluation, formula, data, flavor, modifiers, actor: this.parent, characteristic, skills});
+    return DrawSteelChatMessage.create({
+      speaker: DrawSteelChatMessage.getSpeaker({actor: this.actor}),
+      rolls
+    });
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -258,7 +258,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
     const rolls = await PowerRoll.prompt({type, evaluation, formula, data, flavor, modifiers, actor: this.parent, characteristic, skills});
     return DrawSteelChatMessage.create({
       speaker: DrawSteelChatMessage.getSpeaker({actor: this.parent}),
-      rolls
+      rolls,
+      sound: CONFIG.sounds.dice
     });
   }
 

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -240,10 +240,17 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
         rejectClose: true
       });
     }
+    const skills = this.hero?.skills ?? null;
+
     const formula = `2d10 + @${characteristic}`;
     const data = this.parent.getRollData();
     const flavor = `${game.i18n.localize(`DRAW_STEEL.Actor.characteristics.${characteristic}.full`)} ${game.i18n.localize(PowerRoll.TYPES[type].label)}`;
-    return PowerRoll.prompt({type, formula, data, flavor, modifiers: {edges: options.edges, banes: options.banes}, actor: this.parent, characteristic});
+    const modifiers = {
+      edges: options.edges ?? 0,
+      banes: options.banes ?? 0,
+      bonuses: options.bonuses ?? 0
+    };
+    return PowerRoll.prompt({type, formula, data, flavor, modifiers, actor: this.parent, characteristic, skills});
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -257,7 +257,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
 
     const rolls = await PowerRoll.prompt({type, evaluation, formula, data, flavor, modifiers, actor: this.parent, characteristic, skills});
     return DrawSteelChatMessage.create({
-      speaker: DrawSteelChatMessage.getSpeaker({actor: this.actor}),
+      speaker: DrawSteelChatMessage.getSpeaker({actor: this.parent}),
       rolls
     });
   }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -222,6 +222,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
    * @param {Array<"test" | "ability">} [options.types] Valid roll types for the characteristic
    * @param {number} [options.edges]                    Base edges for the roll
    * @param {number} [options.banes]                    Base banes for the roll
+   * @param {number} [options.bonuses]                  Base bonuses for the roll
+   * @returns {Promise<DrawSteelChatMessage>}
    */
   async rollCharacteristic(characteristic, options = {}) {
     const types = options.types ?? ["test"];

--- a/templates/rolls/power-roll-dialog.hbs
+++ b/templates/rolls/power-roll-dialog.hbs
@@ -46,11 +46,11 @@
     </div>
   </div>
   {{/each}}
-  {{#if skills}}
+  {{#if skillOptions}}
   <label>
     <span>{{localize "DRAW_STEEL.Actor.Character.FIELDS.hero.skills.label"}}</span>
-    <select name="skills">
-      {{selectOptions skills blank=(localize "None")}}
+    <select name="skill">
+      {{selectOptions skillOptions blank=(localize "None") selected=skill}}
     </select>
   </label>
   {{/if}}

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -1,4 +1,4 @@
-<div class="dice-roll">
+<div class="dice-roll" data-action="expandRoll">
   <div class="header" data-uuid="{{target.uuid}}">
     {{#if baseRoll}}
     {{localize "DRAW_STEEL.Roll.Power.BaseRoll"}}


### PR DESCRIPTION
Closes #277 

- Updated the `rollCharacteristic` method to return a `DrawSteelChatMessage`. The previous implementation was using "message" as the evaluation method which meant that the create message didn't have the base roll in it. Updating to evaluate and creating the message in `rollCharacteristic` means that the base roll is showing in the test chat messages too
- v13 made expanding the roll result a `data-action` so added that to our template to restore that functionality.

![test-roll](https://github.com/user-attachments/assets/8fa1b8df-f8a5-4dc9-aea9-d0ef343ea979)
