### PR TITLE
Add roll mode buttons to power roll dialog

### DIFF
--- a/src/module/_types.d.ts
+++ b/src/module/_types.d.ts
@@ -4,6 +4,8 @@ import "./documents/_types";
 import { DrawSteelActor } from "./documents/actor.mjs";
 
 import Advancement from "./documents/advancement/advancement.mjs";
+import { DrawSteelChatMessage } from "./documents/chat-message.mjs";
+import { PowerRoll } from "./rolls/power.mjs";
 
 export interface AdvancementTypeConfiguration {
   /**
@@ -44,4 +46,9 @@ export interface PowerRollPromptOptions {
   targets: PowerRollTargets[],
   ability?: string,
   characteristic?: string
+}
+
+export interface PowerRollPrompt {
+  rollMode: keyof typeof CONFIG["Dice"]["rollModes"];
+  powerRolls: Array<PowerRoll | DrawSteelChatMessage | object>;
 }

--- a/src/module/apps/_types.d.ts
+++ b/src/module/apps/_types.d.ts
@@ -25,6 +25,7 @@ declare module "./item-sheet.mjs" {
 interface PowerRollDialogModifiers {
   edges: number;
   banes: number;
+  bonuses: number;
   ability?: string;
   target?: string;
 }

--- a/src/module/apps/_types.d.ts
+++ b/src/module/apps/_types.d.ts
@@ -31,6 +31,7 @@ interface PowerRollDialogModifiers {
 
 export interface PowerRollDialogPrompt {
   rolls: PowerRollDialogModifiers[];
+  rollMode: keyof typeof CONFIG["Dice"]["rollModes"];
   damage?: string;
 }
 

--- a/src/module/apps/power-roll-dialog.mjs
+++ b/src/module/apps/power-roll-dialog.mjs
@@ -171,7 +171,7 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
    */
   static setRollMode(event, target) {
     this.options.context.rollMode = target.dataset.rollMode;
-    this.render(true);
+    this.render();
   }
 
   /* -------------------------------------------- */

--- a/src/module/apps/power-roll-dialog.mjs
+++ b/src/module/apps/power-roll-dialog.mjs
@@ -17,6 +17,9 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     position: {
       width: 400
     },
+    actions: {
+      setRollMode: this.setRollMode
+    },
     tag: "form",
     form: {
       closeOnSubmit: true
@@ -37,12 +40,20 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
   promptValue;
 
   /** @override */
+  _initializeApplicationOptions(options) {
+    options.context.rollMode = game.settings.get("core", "rollMode");
+
+    return super._initializeApplicationOptions(options);
+  }
+
+  /** @override */
   async _prepareContext(options) {
     const context = {
       modChoices: Array.fromRange(3).reduce((obj, number) => {
         obj[number] = number;
         return obj;
       }, {}),
+      rollModes: CONFIG.Dice.rollModes,
       ...this.options.context
     };
 
@@ -148,7 +159,19 @@ export class PowerRollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     if (formData["damage-selection"]) this.promptValue.damage = formData["damage-selection"];
     if (formData.skill) this.promptValue.skill = formData.skill;
 
+    this.promptValue.rollMode = this.options.context.rollMode;
+
     super._onSubmitForm(formConfig, event);
+  }
+
+  /**
+  * @this DrawSteelItemSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   */
+  static setRollMode(event, target) {
+    this.options.context.rollMode = target.dataset.rollMode;
+    this.render(true);
   }
 
   /* -------------------------------------------- */

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -464,8 +464,6 @@ export default class AbilityModel extends BaseItemModel {
     // TODO: Figure out how to better handle invocations when this.actor is null
     await this.actor?.system.updateResource(resourceSpend * -1);
 
-    DrawSteelChatMessage.applyRollMode(messageData, "roll");
-
     if (this.powerRoll.enabled) {
       const formula = this.powerRoll.formula ? `2d10 + ${this.powerRoll.formula}` : "2d10";
       const rollData = this.parent.getRollData();
@@ -477,7 +475,7 @@ export default class AbilityModel extends BaseItemModel {
       this.getActorModifiers(options);
 
       // Get the power rolls made per target, or if no targets, then just one power roll
-      const powerRolls = await PowerRoll.prompt({
+      const promptValue = await PowerRoll.prompt({
         type: "ability",
         formula,
         data: rollData,
@@ -494,7 +492,10 @@ export default class AbilityModel extends BaseItemModel {
         }, [])
       });
 
-      if (!powerRolls) return null;
+      if (!promptValue) return null;
+      const {rollMode, powerRolls} = promptValue;
+
+      DrawSteelChatMessage.applyRollMode(messageData, rollMode);
       const baseRoll = powerRolls.findSplice(powerRoll => powerRoll.options.baseRoll);
 
       // Power Rolls grouped by tier of success

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -129,7 +129,7 @@ export class PowerRoll extends DSRoll {
   /**
    * Prompt the user with a roll configuration dialog
    * @param {Partial<PowerRollPromptOptions>} [options] Options for the dialog
-   * @return {Promise<Array<PowerRoll | DrawSteelChatMessage | object>>} Based on evaluation made can either return an array of power rolls or chat messages
+   * @return {Promise<{rollMode: keyof typeof CONFIG["Dice"]["rollModes"], powerRolls: Array<PowerRoll | DrawSteelChatMessage | object>}>} Based on evaluation made can either return an array of power rolls or chat messages
    */
   static async prompt(options = {}) {
     const type = options.type ?? "test";
@@ -187,11 +187,11 @@ export class PowerRoll extends DSRoll {
           rolls.push(await roll.evaluate());
           break;
         case "message":
-          rolls.push(await roll.toMessage({speaker}));
+          rolls.push(await roll.toMessage({speaker}, {rollMode: promptValue.rollMode}));
           break;
       }
     }
-    return rolls;
+    return {rollMode: promptValue.rollMode, powerRolls: rolls};
   }
 
   /**

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -3,7 +3,7 @@ import {systemPath} from "../constants.mjs";
 import {DrawSteelChatMessage} from "../documents/chat-message.mjs";
 import {DSRoll} from "./base.mjs";
 
-/** @import {PowerRollModifiers, PowerRollPromptOptions} from "../_types.js" */
+/** @import {PowerRollPrompt, PowerRollPromptOptions} from "../_types.js" */
 
 /**
  * Augments the Roll class with specific functionality for power rolls
@@ -129,7 +129,7 @@ export class PowerRoll extends DSRoll {
   /**
    * Prompt the user with a roll configuration dialog
    * @param {Partial<PowerRollPromptOptions>} [options] Options for the dialog
-   * @return {Promise<{rollMode: keyof typeof CONFIG["Dice"]["rollModes"], powerRolls: Array<PowerRoll | DrawSteelChatMessage | object>}>} Based on evaluation made can either return an array of power rolls or chat messages
+   * @return {Promise<PowerRollPrompt>} Based on evaluation made can either return an array of power rolls or chat messages
    */
   static async prompt(options = {}) {
     const type = options.type ?? "test";

--- a/src/scss/components/_power-roll-dialog.scss
+++ b/src/scss/components/_power-roll-dialog.scss
@@ -21,3 +21,34 @@
     }
   }
 }
+
+footer {
+  display: flex;
+  gap: 5px;
+  margin-top: 5px;
+
+  .roll-mode-buttons {
+    display: flex;
+
+    button.selected {
+      background: var(--button-hover-background-color);
+      color: var(--button-hover-text-color)
+    }
+
+    button:not(:first-of-type, :last-of-type) {
+      border-radius: 0px;
+    }
+
+    button:first-of-type {
+      border-radius: 5px 0px 0px 5px;
+    }
+
+    button:last-of-type {
+      border-radius: 0px 5px 5px 0px;
+    }
+  }
+
+  &>button {
+    flex: 1;
+  }
+}

--- a/templates/rolls/power-roll-dialog.hbs
+++ b/templates/rolls/power-roll-dialog.hbs
@@ -68,5 +68,12 @@
     <button type="submit">
       <i class="fa-solid fa-dice"></i> {{localize "DRAW_STEEL.Roll.Power.Prompt.Button"}}
     </button>
+    <div class="roll-mode-buttons">
+      {{#each rollModes as |rollMode|}}
+      <button type="button" class="{{ifThen (eq @root.rollMode @key) "selected" ""}}" data-action="setRollMode" data-roll-mode="{{@key}}" data-tooltip="{{rollMode.label}}">
+        <i class="{{rollMode.icon}}"></i>
+      </button>
+      {{/each}}
+    </div>
   </footer>
 </div>


### PR DESCRIPTION
Closes #143 

- The dialog defaults to using the users' core roll mode setting
![roll-mode-buttons](https://github.com/user-attachments/assets/0870e6d8-7bfa-473d-812e-33246f3f0678)
