### PR TITLE
Update Actor Sheet dragDrop handling for v13

### DIFF
--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -354,7 +354,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
   /**
    * Actions performed after a first render of the Application.
-   * Post-render steps are not awaited by the render process.
    * @param {ApplicationRenderContext} context      Prepared context data
    * @param {RenderOptions} options                 Provided render options
    * @protected
@@ -482,7 +481,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
   /**
    * Actions performed after any render of the Application.
-   * Post-render steps are not awaited by the render process.
    * @param {ApplicationRenderContext} context      Prepared context data
    * @param {RenderOptions} options                 Provided render options
    * @protected
@@ -660,8 +658,12 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------------- */
 
   /**
-   * Core doesn't sort active effects, so if target is this actor, sort the effects
-   * @override
+   * Handle a dropped Active Effect on the Actor Sheet.
+   * The default implementation creates an Active Effect embedded document on the Actor.
+   * @param {DragEvent} event       The initiating drop event
+   * @param {ActiveEffect} effect   The dropped ActiveEffect document
+   * @returns {Promise<void>}
+   * @protected
    */
   async _onDropActiveEffect(event, effect) {
     if (!this.actor.isOwner || !effect) return;

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -674,6 +674,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    *
    * @param {DragEvent} event
    * @param {ActiveEffect} effect
+   * @returns {Promise<void>}
    */
   async _onSortActiveEffect(event, effect) {
     /** @type {HTMLElement} */
@@ -726,7 +727,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
     }
 
     // Update on the main actor
-    return this.actor.updateEmbeddedDocuments("ActiveEffect", directUpdates);
+    this.actor.updateEmbeddedDocuments("ActiveEffect", directUpdates);
   }
 
   /** @override */
@@ -740,7 +741,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         return item;
       })
     );
-    return this.actor.createEmbeddedDocuments("Item", droppedItemData);
+    this.actor.createEmbeddedDocuments("Item", droppedItemData);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/apps/actor-sheet/base.mjs
+++ b/src/module/apps/actor-sheet/base.mjs
@@ -32,8 +32,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       useAbility: this._useAbility,
       toggleItemEmbed: this._toggleItemEmbed
     },
-    // Custom property that's merged into `this.options`
-    dragDrop: [{dragSelector: ".draggable", dropSelector: null}],
     form: {
       submitOnChange: true
     }
@@ -490,8 +488,8 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @protected
    * @override
    */
-  _onRender(context, options) {
-    this.#dragDrop.forEach((d) => d.bind(this.element));
+  async _onRender(context, options) {
+    await super._onRender(context, options);
     this.#disableOverrides();
   }
 
@@ -662,90 +660,13 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------------- */
 
   /**
-   * Define whether a user is able to begin a dragstart workflow for a given drag selector
-   * @param {string} selector       The candidate HTML selector for dragging
-   * @returns {boolean}             Can the current user drag this selector?
-   * @protected
+   * Core doesn't sort active effects, so if target is this actor, sort the effects
+   * @override
    */
-  _canDragStart(selector) {
-    // game.user fetches the current user
-    return this.isEditable;
-  }
-
-  /**
-   * Define whether a user is able to conclude a drag-and-drop workflow for a given drop selector
-   * @param {string} selector       The candidate HTML selector for the drop target
-   * @returns {boolean}             Can the current user drop on this selector?
-   * @protected
-   */
-  _canDragDrop(selector) {
-    // game.user fetches the current user
-    return this.isEditable;
-  }
-
-  /**
-   * Callback actions which occur at the beginning of a drag start workflow.
-   * @param {DragEvent} event       The originating DragEvent
-   * @protected
-   */
-  _onDragStart(event) {
-    const docRow = event.currentTarget.closest("[data-document-class]");
-    if ("link" in event.target.dataset) return;
-
-    // Chained operation
-    let dragData = this._getEmbeddedDocument(docRow)?.toDragData();
-
-    if (!dragData) return;
-
-    // Set data transfer
-    event.dataTransfer.setData("text/plain", JSON.stringify(dragData));
-  }
-
-  /**
-   * Callback actions which occur when a dragged element is over a drop target.
-   * @param {DragEvent} event       The originating DragEvent
-   * @protected
-   */
-  _onDragOver(event) {}
-
-  /**
-   * Callback actions which occur when a dragged element is dropped on a target.
-   * @param {DragEvent} event       The originating DragEvent
-   * @protected
-   */
-  async _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
-    const actor = this.actor;
-    const allowed = Hooks.call("dropActorSheetData", actor, this, data);
-    if (allowed === false) return;
-
-    // Handle different data types
-    switch (data.type) {
-      case "ActiveEffect":
-        return this._onDropActiveEffect(event, data);
-      case "Actor":
-        return this._onDropActor(event, data);
-      case "Item":
-        return this._onDropItem(event, data);
-      case "Folder":
-        return this._onDropFolder(event, data);
-    }
-  }
-
-  /**
-   * Handle the dropping of ActiveEffect data onto an Actor Sheet
-   * @param {DragEvent} event                  The concluding DragEvent which contains drop data
-   * @param {object} data                      The data transfer extracted from the event
-   * @returns {Promise<ActiveEffect|boolean>}  The created ActiveEffect object or false if it couldn't be created.
-   * @protected
-   */
-  async _onDropActiveEffect(event, data) {
-    const aeCls = getDocumentClass("ActiveEffect");
-    const effect = await aeCls.fromDropData(data);
-    if (!this.actor.isOwner || !effect) return false;
-    if (effect.target === this.actor)
-      return this._onSortActiveEffect(event, effect);
-    return aeCls.create(effect, {parent: this.actor});
+  async _onDropActiveEffect(event, effect) {
+    if (!this.actor.isOwner || !effect) return;
+    if (effect.target === this.actor) await this._onSortActiveEffect(event, effect);
+    else await super._onDropActiveEffect(event, effect);
   }
 
   /**
@@ -808,47 +729,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
     return this.actor.updateEmbeddedDocuments("ActiveEffect", directUpdates);
   }
 
-  /**
-   * Handle dropping of an Actor data onto another Actor sheet
-   * @param {DragEvent} event            The concluding DragEvent which contains drop data
-   * @param {object} data                The data transfer extracted from the event
-   * @returns {Promise<object|boolean>}  A data object which describes the result of the drop, or false if the drop was
-   *                                     not permitted.
-   * @protected
-   */
-  async _onDropActor(event, data) {
-    if (!this.actor.isOwner) return false;
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Handle dropping of an item reference or item data onto an Actor Sheet
-   * @param {DragEvent} event            The concluding DragEvent which contains drop data
-   * @param {object} data                The data transfer extracted from the event
-   * @returns {Promise<Item[]|boolean>}  The created or updated Item instances, or false if the drop was not permitted.
-   * @protected
-   */
-  async _onDropItem(event, data) {
-    if (!this.actor.isOwner) return false;
-    const item = await DrawSteelItem.fromDropData(data);
-
-    // Handle item sorting within the same Actor
-    if (this.actor.uuid === item.parent?.uuid)
-      return this._onSortItem(event, item);
-
-    // Create the owned item
-    return this._onDropItemCreate(item, event);
-  }
-
-  /**
-   * Handle dropping of a Folder on an Actor Sheet.
-   * The core sheet currently supports dropping a Folder of Items to create all items as owned items.
-   * @param {DragEvent} event     The concluding DragEvent which contains drop data
-   * @param {object} data         The data transfer extracted from the event
-   * @returns {Promise<Item[]>}
-   * @protected
-   */
+  /** @override */
   async _onDropFolder(event, data) {
     if (!this.actor.isOwner) return [];
     const folder = await Folder.implementation.fromDropData(data);
@@ -859,94 +740,8 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         return item;
       })
     );
-    return this._onDropItemCreate(droppedItemData, event);
+    return this.actor.createEmbeddedDocuments("Item", droppedItemData);
   }
-
-  /**
-   * Handle the final creation of dropped Item data on the Actor.
-   * This method is factored out to allow downstream classes the opportunity to override item creation behavior.
-   * @param {object[]|object} itemData      The item data requested for creation
-   * @param {DragEvent} event               The concluding DragEvent which provided the drop data
-   * @returns {Promise<Item[]>}
-   * @private
-   */
-  async _onDropItemCreate(itemData, event) {
-    itemData = itemData instanceof Array ? itemData : [itemData];
-    return this.actor.createEmbeddedDocuments("Item", itemData);
-  }
-
-  /**
-   * Handle a drop event for an existing embedded Item to sort that Item relative to its siblings
-   * @param {Event} event
-   * @param {Item} item
-   * @private
-   */
-  _onSortItem(event, item) {
-    // Get the drag source and drop target
-    const items = this.actor.items;
-    const dropTarget = event.target.closest("[data-item-id]");
-    if (!dropTarget) return;
-    const target = items.get(dropTarget.dataset.itemId);
-
-    // Don't sort on yourself
-    if (item.id === target.id) return;
-
-    // Identify sibling items based on adjacent HTML elements
-    const siblings = [];
-    for (let el of dropTarget.parentElement.children) {
-      const siblingId = el.dataset.itemId;
-      if (siblingId && (siblingId !== item.id))
-        siblings.push(items.get(el.dataset.itemId));
-    }
-
-    // Perform the sort
-    const sortUpdates = SortingHelpers.performIntegerSort(item, {
-      target,
-      siblings
-    });
-    const updateData = sortUpdates.map((u) => {
-      const update = u.update;
-      update._id = u.target._id;
-      return update;
-    });
-
-    // Perform the update
-    return this.actor.updateEmbeddedDocuments("Item", updateData);
-  }
-
-  /** The following pieces set up drag handling and are unlikely to need modification  */
-
-  /**
-   * Returns an array of DragDrop instances
-   * @type {DragDrop[]}
-   */
-  get dragDrop() {
-    return this.#dragDrop;
-  }
-
-  /**
-   * Create drag-and-drop workflow handlers for this Application
-   * @returns {DragDrop[]}     An array of DragDrop handlers
-   * @private
-   */
-  #createDragDropHandlers() {
-    return this.options.dragDrop.map((d) => {
-      d.permissions = {
-        dragstart: this._canDragStart.bind(this),
-        drop: this._canDragDrop.bind(this)
-      };
-      d.callbacks = {
-        dragstart: this._onDragStart.bind(this),
-        dragover: this._onDragOver.bind(this),
-        drop: this._onDrop.bind(this)
-      };
-      return new DragDrop(d);
-    });
-  }
-
-  // This is marked as private because there's no real need
-  // for subclasses or external hooks to mess with it directly
-  #dragDrop = this.#createDragDropHandlers();
 
   /* -------------------------------------------------- */
   /*   Actor Override Handling                         */

--- a/src/module/apps/item-sheet.mjs
+++ b/src/module/apps/item-sheet.mjs
@@ -256,12 +256,11 @@ export class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
 
   /**
    * Actions performed after any render of the Application.
-   * Post-render steps are not awaited by the render process.
    * @param {ApplicationRenderContext} context      Prepared context data
    * @param {RenderOptions} options                 Provided render options
    * @protected
    */
-  _onRender(context, options) {
+  async _onRender(context, options) {
     this.#dragDrop.forEach((d) => d.bind(this.element));
 
     // Bubble editor active class state to containing formGroup


### PR DESCRIPTION
Related to #233. I _think_ this is the last piece from that issue.

- Core didn't have a sort active effect method or an implementation of folder dropping, so i left ours in there.
- The methods in core have a return of `Promise<void>`, so I updated the remaining of ours to match that.