### PR TITLE
Fix token hud not allowing negative stamina and adjust token bar for negative stamina

### DIFF
--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -30,4 +30,54 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     segments.pop();
     return segments;
   }
+
+  /**
+     * Draw a single resource bar, given provided data
+     * @param {number} number       The Bar number
+     * @param {PIXI.Graphics} bar   The Bar container
+     * @param {Object} data         Resource data for this bar
+     * @protected
+     */
+  _drawBar(number, bar, data) {
+    if (data.attribute !== "stamina") return super._drawBar(number, bar, data);
+
+    const stamina = Number(data.value);
+
+    // Creates a normalized range of 0 to (max stamina + winded) used for calculating the token bar percentage
+    const winded = this.actor.system.stamina.winded;
+    const totalStamina = data.max + winded;
+    const adjustedValue = stamina + winded;
+    const barPct = Math.clamp(adjustedValue, 0, totalStamina) / totalStamina;
+
+    // Determine sizing
+    const { width, height } = this.document.getSize();
+    const s = canvas.dimensions.uiScale;
+    const bw = width;
+    const bh = 8 * (this.document.height >= 2 ? 1.5 : 1) * s;
+
+    // Determine the color to use
+    // Stamina >= 0 should use core colors - green to red or light blue to blue
+    // Stamina < 0 should use red to dark red or blue to dark blue
+    let color;
+    if (stamina >= 0) {
+      const colorPct = Math.clamp(stamina, 0, data.max) / data.max;
+      if (number === 0) color = Color.fromRGB([1 - (colorPct / 2), colorPct, 0]);
+      else color = Color.fromRGB([0.5 * colorPct, 0.7 * colorPct, 0.5 + (colorPct / 2)]);
+    } else {
+      const colorPct = Math.clamp(adjustedValue, 0, winded) / winded;
+      if (number === 0) color = Color.fromRGB([colorPct + (1 - colorPct) * 0.2, 0, 0]);
+      else color = Color.fromRGB([0, 0, 0.5 - ((1 - colorPct) * 0.4)]);
+    }
+
+    // Draw the bar
+    bar.clear();
+    bar.lineStyle(s, 0x000000, 1.0);
+    bar.beginFill(0x000000, 0.5).drawRoundedRect(0, 0, bw, bh, 3 * s);
+    bar.beginFill(color, 1.0).drawRoundedRect(0, 0, barPct * bw, bh, 2 * s);
+
+    // Set position
+    const posY = number === 0 ? height - bh : 0;
+    bar.position.set(0, posY);
+    return true;
+  }
 }

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -31,13 +31,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     return segments;
   }
 
-  /**
-     * Draw a single resource bar, given provided data
-     * @param {number} number       The Bar number
-     * @param {PIXI.Graphics} bar   The Bar container
-     * @param {Object} data         Resource data for this bar
-     * @protected
-     */
+  /** @inheritdoc*/
   _drawBar(number, bar, data) {
     if (data.attribute !== "stamina") return super._drawBar(number, bar, data);
 

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -35,15 +35,7 @@ export default class DrawSteelActor extends Actor {
     throw new Error(`Actors of type ${this.type} cannot roll characteristics`);
   }
 
-  /**
-   * Handle how changes to a Token attribute bar are applied to the Actor.
-   * This allows for game systems to override this behavior and deploy special logic.
-   * @param {string} attribute    The attribute path
-   * @param {number} value        The target attribute value
-   * @param {boolean} isDelta     Whether the number represents a relative change (true) or an absolute change (false)
-   * @param {boolean} isBar       Whether the new value is part of an attribute bar, or just a direct value
-   * @returns {Promise<documents.Actor>}  The updated Actor document
-   */
+  /** @inheritdoc*/
   async modifyTokenAttribute(attribute, value, isDelta = false, isBar = true) {
     if (attribute !== "stamina") return super.modifyTokenAttribute(attribute, value, isDelta, isBar);
 

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -34,4 +34,28 @@ export default class DrawSteelActor extends Actor {
     if (this.system.rollCharacteristic instanceof Function) return this.system.rollCharacteristic(characteristic, options);
     throw new Error(`Actors of type ${this.type} cannot roll characteristics`);
   }
+
+  /**
+   * Handle how changes to a Token attribute bar are applied to the Actor.
+   * This allows for game systems to override this behavior and deploy special logic.
+   * @param {string} attribute    The attribute path
+   * @param {number} value        The target attribute value
+   * @param {boolean} isDelta     Whether the number represents a relative change (true) or an absolute change (false)
+   * @param {boolean} isBar       Whether the new value is part of an attribute bar, or just a direct value
+   * @returns {Promise<documents.Actor>}  The updated Actor document
+   */
+  async modifyTokenAttribute(attribute, value, isDelta = false, isBar = true) {
+    if (attribute !== "stamina") return super.modifyTokenAttribute(attribute, value, isDelta, isBar);
+
+    const current = this.system.stamina.value;
+    const update = isDelta ? current + value : value;
+    if (update === current) return this;
+
+    // Determine the updates to make to the actor data
+    const updates = { "system.stamina.value": Math.clamp(update, -this.system.stamina.winded, this.system.stamina.max) };
+
+    // Allow a hook to override these changes
+    const allowed = Hooks.call("modifyTokenAttribute", { attribute, value, isDelta, isBar }, updates, this);
+    return allowed !== false ? this.update(updates) : this;
+  }
 }


### PR DESCRIPTION
Closes #236 

- Allows negative values in the token hud for stamina
- Updates the token bar to account for negative values
   - I kept it so that stamina values 0 to max use the standard core colors and anything lower than 0 uses a darker version of the 0 stamina color
- Unfortunately, both overridden methods require copying a lot of core code.

![token bars](https://github.com/user-attachments/assets/26ce836f-fefc-4eb2-b371-4f022d4dcdf6)
