### PR TITLE
Add stamina minimum used for constructing token bar

### DIFF
--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -37,10 +37,11 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
 
     const stamina = Number(data.value);
 
-    // Creates a normalized range of 0 to (max stamina + winded) used for calculating the token bar percentage
-    const winded = this.actor.system.stamina.winded;
-    const totalStamina = data.max + winded;
-    const adjustedValue = stamina + winded;
+    // Creates a normalized range of 0 to (max stamina - min stamina) used for calculating the token bar percentage
+    // Needed to handle character's negative stamina
+    const minimumStamina = this.actor.system.stamina.min;
+    const totalStamina = data.max - minimumStamina;
+    const adjustedValue = stamina - minimumStamina;
     const barPct = Math.clamp(adjustedValue, 0, totalStamina) / totalStamina;
 
     // Determine sizing
@@ -58,7 +59,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
       if (number === 0) color = Color.fromRGB([1 - (colorPct / 2), colorPct, 0]);
       else color = Color.fromRGB([0.5 * colorPct, 0.7 * colorPct, 0.5 + (colorPct / 2)]);
     } else {
-      const colorPct = Math.clamp(adjustedValue, 0, winded) / winded;
+      const colorPct = Math.clamp(adjustedValue, 0, Math.abs(minimumStamina)) / Math.abs(minimumStamina);
       if (number === 0) color = Color.fromRGB([colorPct + (1 - colorPct) * 0.2, 0, 0]);
       else color = Color.fromRGB([0, 0, 0.5 - ((1 - colorPct) * 0.4)]);
     }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -94,6 +94,8 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
       type: new Set(),
       dsid: new Set(),
     };
+
+    this.stamina.min = 0;
   }
 
   /** @inheritdoc */

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -136,6 +136,9 @@ export default class CharacterModel extends BaseActorModel {
     this.potency.strong += highestCharacteristic;
 
     super.prepareDerivedData();
+
+    // Winded is set in the base classes derived data, so this needs to run after
+    this.stamina.min = -this.stamina.winded;
   }
 
   /** @inheritdoc */

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -52,7 +52,7 @@ export default class DrawSteelActor extends foundry.documents.Actor {
     if (update === current) return this;
 
     // Determine the updates to make to the actor data
-    const updates = { "system.stamina.value": Math.clamp(update, -this.system.stamina.winded, this.system.stamina.max) };
+    const updates = { "system.stamina.value": Math.clamp(update, this.system.stamina.min, this.system.stamina.max) };
 
     // Allow a hook to override these changes
     const allowed = Hooks.call("modifyTokenAttribute", { attribute, value, isDelta, isBar }, updates, this);


### PR DESCRIPTION
I didn't catch this in the initial PR, but the way I did it before monsters could go to negative winded stamina.

- Added a derived `stamina.min`. Non-characters will be 0 and characters will be negative winded.
   - Use this new minimum value instead of defaulting to negative winded.

Maybe later, we can clamp stamina to the min/max values