### PR TITLE
Removed interactivity for unowned combatants

### DIFF
--- a/templates/combat/turn.hbs
+++ b/templates/combat/turn.hbs
@@ -40,8 +40,12 @@
 
   {{!-- Initiative --}}
   <div class="token-initiative">
+    {{#if isOwner}}
     <a class="activate-combatant" data-action="activateCombatant" data-tooltip="DRAW_STEEL.Combat.Initiative.Actions.{{activateTooltip}}">
       {{initiativeCount}} <i class="fa-solid {{initiativeSymbol}}"></i>
     </a>
+    {{else}}
+    <span class="activate-combatant">{{initiativeCount}} <i class="fa-solid {{initiativeSymbol}}"></i></span>
+    {{/if}}
   </div>
 </li>


### PR DESCRIPTION
Removed the interactivity on unowned turns by switching to a span with no data-action

Closes #335

Closes #321