### PR TITLE
Update ruler labels for 13.338 api changes

### DIFF
--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -16,21 +16,6 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
 
   /* -------------------------------------------------- */
 
-  /**
-   * The current ruler data path, segmentized.
-   * @returns {object[][]}    Waypoints split into segments.
-   */
-  get segmentizedFoundPath() {
-    const path = this._rulerData[game.user.id]?.foundPath ?? [];
-    const segments = path.reduce((acc, waypoint) => {
-      acc.at(-1).push(waypoint);
-      if (!waypoint.intermediate) acc.push([]);
-      return acc;
-    }, [[]]);
-    segments.pop();
-    return segments;
-  }
-
   /** @inheritdoc*/
   _drawBar(number, bar, data) {
     if (data.attribute !== "stamina") return super._drawBar(number, bar, data);

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -3,63 +3,41 @@
  */
 export default class DrawSteelTokenRuler extends foundry.canvas.placeables.tokens.TokenRuler {
   /** @inheritdoc */
-  _getWaypointLabel(waypoint) {
-    if ((waypoint.stage === "passed") || !waypoint.previous || (waypoint.previous.stage === "passed")) {
-      return super._getWaypointLabel(waypoint);
-    }
-
-    let { text, alpha, scale } = super._getWaypointLabel(waypoint);
-    const segments = this.token.segmentizedFoundPath;
-
-    for (const [i, segment] of segments.entries()) {
-      // Enemies you started nearby.
-      const startedNear = segments[i - 1]?.endpointEnemies ?? new Set();
-
-      // Enemies you ended near.
-      const endpointEnemies = new Set(this.token.document.getHostileTokensFromPoints([segment.at(-1)]));
-
-      // All tokens you passed by (and started near).
-      const passedBy = new Set(this.token.document.getHostileTokensFromPoints(segment)).union(startedNear);
-
-      // The number of strikes is equal to the number of tokens you passed by but did not end near.
-      const strikes = passedBy.difference(endpointEnemies).size;
-
-      Object.assign(segment, {
-        endpointEnemies, strikes,
-        count: strikes + (segments[i - 1]?.count ?? 0),
-      });
-    }
-
-    segments.shift(); // Dont care about the first singleton.
-
-    let index = segments.length - 1;
-    let next = waypoint;
-    while (next.next) {
-      next = next.next;
-      index--;
-    }
-
-    text = [
-      text,
-      segments[index]?.count ? `⚔ ${segments[index].count}` : null,
-    ].filterJoin(" ");
-    return { text, alpha, scale };
-  }
+  static WAYPOINT_TEMPLATE = "systems/draw-steel/templates/hud/waypoint-labels.hbs";
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  refresh(state) {
-    super.refresh(state);
+  _prepareWaypointData(waypoints) {
+    const result = super._prepareWaypointData(waypoints);
 
-    const points = state.plannedMovement?.[game.user.id]?.foundPath ?? [];
-    const tokens = this.token.document.getHostileTokensFromPoints(points);
+    const segments = this.token.document.getCompleteMovementPath(waypoints).reduce((acc, waypoint) => {
+      acc.at(-1).push(waypoint);
+      if (!waypoint.intermediate) acc.push([]);
+      return acc;
+    }, [[]]);
+    segments.pop(); // Empty last array
 
-    for (const { object: token } of tokens) {
-      // TODO: add a PIXI element near hostile tokens.
-      // const {x, y} = token.center;
-      // const circle = new PIXI.Circle(x, y, 10);
-      // this.token.layer._rulerPaths.addChild(circle);
+    for (const [i, segment] of segments.entries()) {
+      const startedNear = segments[i - 1]?.endPointEnemies ?? new Set();
+      const endPointEnemies = new Set(this.token.document.getHostileTokensFromPoints([segment.at(-1)]));
+      const passedBy = new Set(this.token.document.getHostileTokensFromPoints(segment)).union(startedNear);
+      const strikes = passedBy.difference(endPointEnemies).size;
+      Object.assign(segment, {
+        endPointEnemies, strikes,
+        count: strikes + (segments[i - 1]?.count ?? 0),
+      });
+
+      if (i > 0) {
+        Object.assign(result[i - 1], {
+          strikes: {
+            total: segment.count,
+            delta: segment.strikes,
+          },
+        });
+      }
     }
+
+    return result;
   }
 }

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -38,18 +38,4 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
     }
     return Array.from(tokens);
   }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  async _preUpdateMovement(movement, operation = {}) {
-    const nextSegment = movement.passed;
-    const tokens = this.getHostileTokensFromPoints(nextSegment);
-
-    if (tokens.length) {
-      // TODO: Prompt to confirm the movement.
-      const allowed = true;
-      if (allowed === false) return false;
-    }
-  }
 }

--- a/src/styles/system/applications/_applications.mjs
+++ b/src/styles/system/applications/_applications.mjs
@@ -2,6 +2,8 @@ import "./apps/monster-metadata.css";
 import "./apps/power-roll-dialog.css";
 import "./apps/targeted-condition-prompt.css";
 
+import "./canvas/measurement.css";
+
 import "./components/effects.css";
 import "./components/embeds.css";
 import "./components/forms.css";

--- a/src/styles/system/applications/canvas/measurement.css
+++ b/src/styles/system/applications/canvas/measurement.css
@@ -1,0 +1,9 @@
+/* Token Drag Ruler labels */
+#measurement .waypoint-label .total-strikes {
+  color: var(--color-text-emphatic);
+  font-size: var(--font-size-24);
+}
+#measurement .waypoint-label .delta-strikes {
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-16);
+}

--- a/templates/hud/waypoint-labels.hbs
+++ b/templates/hud/waypoint-labels.hbs
@@ -1,0 +1,28 @@
+<div class="waypoint-label {{cssClass}}" style="--position-x: {{position.x}}px; --position-y: {{position.y}}px; --ui-scale: {{uiScale}}">
+  {{#if action.icon}}
+  <i class="icon {{action.icon}}"></i>
+  {{else if action.label}}
+  <label class="action-label">{{action.label}}</label>
+  {{/if}}
+  <span class="total-cost">{{totalCost}} {{units}}</span>
+  {{#if deltaCost}}
+  <span class="delta-cost">({{deltaCost}})</span>
+  {{/if}}
+  {{#if hasElevation}}
+  <i class="icon fa-solid {{elevationIcon}}"></i>
+  <span class="total-elevation">{{totalElevation}} {{units}}</span>
+  {{#if deltaElevation}}
+  <span class="delta-elevation">({{deltaElevation}})</span>
+  {{/if}}
+  {{/if}}
+  {{#if strikes}}
+  <i class="icon fa-solid fa-swords"></i>
+  <span class="total-strikes">{{strikes.total}}</span>
+  {{#if strikes.delta}}
+  <span class="delta-strikes">(+{{strikes.delta}})</span>
+  {{/if}}
+  {{/if}}
+  {{#if secret}}
+  <i class="icon fa-solid fa-eye-slash"></i>
+  {{/if}}
+</div>


### PR DESCRIPTION
- Removes so-far unused code in the token and token document classes.
- Adds a copy of the ruler-label template file with additions of the Strikes.
- Adjusts the code to use the new `_prepareWaypointData` method (the old method no longer exists).