### PR TITLE
Update actor sheet header layout and styling

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -13,7 +13,8 @@
       "Edit": "Edit",
       "Resources": "Resources",
       "Other": "Other",
-      "TakeRespite": "Take Respite"
+      "TakeRespite": "Take Respite",
+      "LevelUp": "Level Up Available"
     },
     "Source": {
       "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -12,7 +12,8 @@
       "Play": "Play",
       "Edit": "Edit",
       "Resources": "Resources",
-      "Other": "Other"
+      "Other": "Other",
+      "TakeRespite": "Take Respite"
     },
     "Source": {
       "FIELDS": {
@@ -263,8 +264,8 @@
           "DialogTitle": "Update Monster Metadata"
         },
         "EVLabel": {
-          "Minion": "EV {value} for eight minions",
-          "Other": "EV {value}"
+          "Label": "EV",
+          "Minion": "{value} for eight minions"
         },
         "KEYWORDS": {
           "Abyssal": "Abyssal",

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -17,8 +17,11 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   static DEFAULT_OPTIONS = {
     classes: ["draw-steel", "actor"],
     position: {
-      width: 600,
+      width: 850,
       height: 600,
+    },
+    window: {
+      resizable: true,
     },
     actions: {
       toggleMode: this._toggleMode,
@@ -29,6 +32,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       roll: this._onRoll,
       useAbility: this._useAbility,
       toggleItemEmbed: this._toggleItemEmbed,
+      takeRespite: this._takeRespite,
     },
     form: {
       submitOnChange: true,
@@ -683,6 +687,10 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
     const part = target.closest("[data-application-part]").dataset.applicationPart;
     this.render({ parts: [part] });
+  }
+
+  static async _takeRespite(event, target) {
+    await this.actor.system.takeRespite();
   }
 
   /** Helper Functions */

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -32,7 +32,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       roll: this._onRoll,
       useAbility: this._useAbility,
       toggleItemEmbed: this._toggleItemEmbed,
-      takeRespite: this._takeRespite,
     },
     form: {
       submitOnChange: true,
@@ -687,10 +686,6 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
 
     const part = target.closest("[data-application-part]").dataset.applicationPart;
     this.render({ parts: [part] });
-  }
-
-  static async _takeRespite(event, target) {
-    await this.actor.system.takeRespite();
   }
 
   /** Helper Functions */

--- a/src/module/applications/sheets/character.mjs
+++ b/src/module/applications/sheets/character.mjs
@@ -11,6 +11,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
     actions: {
       gainSurges: this._gainSurges,
       rollProject: this._rollProject,
+      takeRespite: this._takeRespite,
     },
   };
 
@@ -195,6 +196,16 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
   static async _rollProject(event, target) {
     const project = this._getEmbeddedDocument(target);
     await project.system.roll();
+  }
+
+  /**
+   * Take a respite, converting victories to XP and resetting stamina and recoveries to max
+   * @this DrawSteelCharacterSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   */
+  static async _takeRespite(event, target) {
+    await this.actor.system.takeRespite();
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -262,7 +262,7 @@ export default class CharacterModel extends BaseActorModel {
    * Returns the total xp required for the next level
    */
   get nextLevelXP() {
-    if (!this.class) return 0;
+    if (this.level >= ds.CONFIG.hero.xp_track.length) return 0;
     return ds.CONFIG.hero.xp_track[this.level];
   }
 

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -259,11 +259,18 @@ export default class CharacterModel extends BaseActorModel {
   }
 
   /**
+   * Returns the total xp required for the next level
+   */
+  get nextLevelXP() {
+    if (!this.class) return 0;
+    return ds.CONFIG.hero.xp_track[this.level];
+  }
+
+  /**
    * Returns the number of victories required to ascend to the next level
    */
   get victoriesMax() {
-    if (!this.class) return 0;
-    return ds.CONFIG.hero.xp_track[this.class.system.level];
+    return Math.max(0, this.nextLevelXP - this.hero.xp);
   }
 
   /** @inheritdoc */

--- a/src/styles/system/applications/components/forms.css
+++ b/src/styles/system/applications/components/forms.css
@@ -27,7 +27,12 @@
           border: 0;
           text-shadow: none;
           display: inline-block;
+        }
+        input {
           height: 100%;
+        }
+        h2 {
+          max-height: 100%;
         }
         h2 {
           vertical-align: middle;

--- a/src/styles/system/applications/components/forms.css
+++ b/src/styles/system/applications/components/forms.css
@@ -1,27 +1,24 @@
 .draw-steel {
 
   .sheet-header {
-    flex: 0 0 100px;
-    overflow: hidden;
     display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
     margin-bottom: 10px;
+    gap: 10px;
 
     .profile-img {
       flex: 0 0 100px;
       height: 100px;
-      margin-right: 10px;
-      border: none;
     }
 
     .header-center {
       height: 100%;
+      /* 235px is the width of the image, header-right, and the gaps */
       max-width: calc(100% - 235px);
+      flex-grow: 1;
+      justify-content: center;
       .document-name {
-        height: 60px;
-        line-height: 60px;
+        max-height: 65px;
+        line-height: 65px;
         input, h2 {
           font-family: var(--font-h2);
           font-size: var(--font-h2-size);
@@ -30,29 +27,12 @@
           border: 0;
           text-shadow: none;
           display: inline-block;
-        }
-        input {
           height: 100%;
         }
         h2 {
           vertical-align: middle;
-
-          /* Light theme fixes
-          .theme-light & {
-            color: var(--color-dark-2);
-          } */
+          overflow: hidden;
         }
-      }
-      .origins {
-        height: 40px;
-        div {
-          text-align: center;
-        }
-        .filled {
-          font-weight: 700;
-
-        }
-        /* .unfilled { } */
       }
     }
 

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -32,53 +32,83 @@
 
   .sheet-header {
     .header-right {
-      padding-left: 5px;
-      flex: 0 0 200px;
-      height: 100px;
-      .class {
-        flex: 1;
-        .click-element {
-          height: 100%;
-          [data-action='deleteDoc'] {
-            flex: 0 0 20px;
+
+    }
+  }
+
+  .sheet-header {
+    .profile-img {
+      width: 125px;
+      height: 125px;
+    }
+    .header-center {
+      /* 305px is the width of the image, header-right, and the gaps */
+      max-width: calc(100% - 305px);
+      gap: 5px;
+      .tags {
+        gap: 5px;
+        .tag {
+          background: var(--draw-steel-c-faint);
+          border: 1px solid var(--draw-steel-c-beige);
+          color: var(--draw-steel-c-dark);
+          border-radius: 5px;
+          padding: 5px;
+          font-size: var(--font-size-13);
+          font-weight: 600;
+          flex-grow: 0;
+          text-wrap: nowrap;
+          font-variant-caps: small-caps;
+          span a[data-action="deleteDoc"] {
+            margin-left: 5px;
+          }
+          a.unfilled {
+            font-weight: normal;
           }
         }
-        .label {
-          display: inline-block;
-          line-height: 50px;
-          height: 100%;
-          font-size: var(--font-h3-size);
-          &.unfilled {
-            width: 100%;
-            text-align: center;
-          }
+        a[data-action="editMonsterMetadata"] {
+          text-align: right;
         }
       }
-      .victories {
-        flex: 0 0 30px;
-        line-height: 30px;
+    }
+    .header-right {
+      width: 160px;
+      div.mode-toggle  {
+        flex-grow: 1;
+        align-items: start;
+      }
+      &:has(.actor-source) {
+        div.mode-toggle  {
+          flex-grow: 0;
+        }
+      }
+      .actor-source {
+        margin-top: 5px;
+        font-family: var(--font-h6);
+        font-size: var(--font-size-16);
+        flex-grow: 1;
+        align-items: start;
+        text-align: center;
+      }
+      div.actor-data > div {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        margin-top: 5px;
+        font-size: var(--font-size-15);
         input {
-          height: 30px;
-          width: 40px;
+          width: 50%;
+        }
+        &:has(input) label {
+          width: 50%;
+        }
+        .value {
+          text-align: right;
+          flex-grow: 1;
         }
       }
-      .item-img {
-        display: inline-block;
-        border: none;
-        height: 36px;
-        flex: 0 0 36px;
-      }
-      .monster-data {
-        gap: 3px;
-        .actor-source {
-          margin-top: 5px;
-          font-family: var(--font-h6);
-          font-size: var(--font-size-18);
-        }
-        .malice {
-          text-align: center;
-          flex: 0 0 40px;
-        }
+      div.take-respite  {
+        text-align: center;
+        margin-top: 5px;
       }
     }
   }

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -75,6 +75,22 @@
           flex-grow: 0;
         }
       }
+      dl {
+        display: flex;
+        flex-flow: row wrap;
+        dt, dd {
+          margin: 0;
+          color: inherit;
+        }
+        dt {
+          text-shadow: none;
+          flex-basis: 40px
+        }
+        dd {
+          flex: 1 0 110px;
+          text-align: right;
+        }
+      }
       .actor-source {
         margin-top: 5px;
         font-family: var(--font-h6);
@@ -83,7 +99,8 @@
         align-items: start;
         text-align: center;
       }
-      div.actor-data > div {
+      div.actor-data > div,
+      .malice {
         display: flex;
         align-items: center;
         gap: 5px;

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -117,6 +117,9 @@
           flex-grow: 1;
         }
       }
+      dt, label {
+        font-weight: bold;
+      }
       div.take-respite  {
         text-align: center;
         margin-top: 5px;

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -31,12 +31,6 @@
   }
 
   .sheet-header {
-    .header-right {
-
-    }
-  }
-
-  .sheet-header {
     .profile-img {
       width: 125px;
       height: 125px;

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -55,7 +55,7 @@
     {{> "systems/draw-steel/templates/parts/mode-toggle.hbs"}}
     <div class="actor-data character-data">
       <div class="level">
-        <label>{{localize "DRAW_STEEL.Item.Class.FIELDS.level.label"}}:</label>
+        <label>{{localize "DRAW_STEEL.Item.Class.FIELDS.level.label"}}</label>
         <span class="value">{{system.level}}</span>
         {{#if (and (gte system.hero.xp system.nextLevelXP) system.class)}}
         <span class="level-up" data-tooltip="Level Up Available">
@@ -64,7 +64,7 @@
         {{/if}}
       </div>
       <div class="xp">
-        <label>{{systemFields.hero.fields.xp.label}}:</label>
+        <label>{{systemFields.hero.fields.xp.label}}</label>
         {{#if isPlay}}
         <span class="value">
           <span class="resource-curent">{{system.hero.xp}}</span>
@@ -76,7 +76,7 @@
         {{/if}}
       </div>
       <div class="victories">
-        <label>{{systemFields.hero.fields.victories.label}}:</label>
+        <label>{{systemFields.hero.fields.victories.label}}</label>
         {{#if isPlay}}
         <span class="value">
           <span class="resource-current">{{system.hero.victories}}</span>

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -67,7 +67,7 @@
         <label>{{systemFields.hero.fields.xp.label}}:</label>
         {{#if isPlay}}
         <span class="value">
-          {{system.hero.xp}}
+          <span class="resource-curent">{{system.hero.xp}}</span>
           <span class="resource-divider"> / </span>
           <span class="resource-max">{{system.nextLevelXP}}</span>
         </span>
@@ -79,13 +79,9 @@
         <label>{{systemFields.hero.fields.victories.label}}:</label>
         {{#if isPlay}}
         <span class="value">
-          <span class="resource-current">
-            {{system.hero.victories}}
-          </span>
+          <span class="resource-current">{{system.hero.victories}}</span>
           <span class="resource-divider"> / </span>
-          <span class="resource-max">
-            {{system.victoriesMax}}
-          </span>
+          <span class="resource-max">{{system.victoriesMax}}</span>
         </span>
         {{else}}
         {{formInput systemFields.hero.fields.victories value=systemSource.hero.victories}}

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -58,7 +58,7 @@
         <label>{{localize "DRAW_STEEL.Item.Class.FIELDS.level.label"}}</label>
         <span class="value">{{system.level}}</span>
         {{#if (and (gte system.hero.xp system.nextLevelXP) system.class)}}
-        <span class="level-up" data-tooltip="Level Up Available">
+        <span class="level-up" data-tooltip="DRAW_STEEL.Sheet.LevelUp">
           <i class="fa-solid fa-up-long"></i>
         </span>
         {{/if}}

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -1,3 +1,23 @@
+{{!-- Partial for header tags --}}
+{{#*inline "headerTag"}}
+{{#if originDoc}}
+<span data-document-class="Item" data-item-id="{{lookup originDoc "id"}}">
+  <a class="filled" data-action="viewDoc">
+    {{lookup originDoc "name"}}
+  </a>
+  {{#unless isPlay}}
+  <a data-action="deleteDoc">
+    <i class="fa-solid fa-trash-can"></i>
+  </a>
+  {{/unless}}
+</span>
+{{else}}
+<a class="unfilled" data-action="createDoc" data-document-class="Item" data-type="{{originType}}" data-render-sheet="true">
+  {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize (concat "TYPES.Item." originType))}}
+</a>
+{{/if}}
+{{/inline}}
+
 {{! Sheet Header }}
 <header class="sheet-header">
   {{! <!-- eslint-disable-next-line @html-eslint/attrs-newline --> }}
@@ -5,127 +25,80 @@
     class="profile-img"
     src="{{actor.img}}"
     alt="{{actor.name}}"
-    data-edit="img"
-    {{#if isPlay}}
-    data-action="showPortraitArtwork"
-    {{else}}
-    {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
-    data-action="editImage"
-    {{/if}}
+    data-action="{{ifThen isPlay "showPortraitArtwork" "editImage"}}"
     title="{{actor.name}}"
-    height="100"
-    width="100"
-  />
+  >
   <div class="header-center flexcol">
     <div class="document-name">
       {{#if isPlay}}
       <h2>{{wordBreaker actor.name}}</h2>
       {{else}}
-      {{formInput
-      fields.name
-      value=actor._source.name
-      placeholder=(localize "Name")
-      }}
+      {{formInput fields.name value=source.name placeholder=(localize "Name")}}
       {{/if}}
     </div>
-    <div class="origins flexrow">
-      <div class="ancestry">
-        {{#if actor.system.ancestry}}
-        <span data-document-class="Item" data-item-id="{{actor.system.ancestry.id}}">
-          <a class="filled" data-action="viewDoc">
-            {{{wordBreaker actor.system.ancestry.name}}}
-          </a>
-          {{#unless isPlay}}
-          <a data-action="deleteDoc">
-            <i class="fa-solid fa-trash-can"></i>
-          </a>
-          {{/unless}}
-        </span>
-        {{else}}
-        <a class="unfilled" data-action="createDoc" data-document-class="Item" data-type="ancestry" data-render-sheet="true">
-          {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ancestry")}}
-        </a>
-        {{/if}}
+    <div class="origins tags flexrow">
+      <div class="ancestry tag">
+        {{> headerTag originDoc=actor.system.ancestry originType="ancestry"}}
       </div>
-      <div class="culture">
-        {{#if actor.system.culture}}
-        <span data-document-class="Item" data-item-id="{{actor.system.culture.id}}">
-          <a class="filled" data-action="viewDoc">
-            {{{wordBreaker actor.system.culture.name}}}
-          </a>
-          {{#unless isPlay}}
-          <a data-action="deleteDoc">
-            <i class="fa-solid fa-trash-can"></i>
-          </a>
-          {{/unless}}
-        </span>
-        {{else}}
-        <a class="unfilled" data-action="createDoc" data-document-class="Item" data-type="culture" data-render-sheet="true">
-          {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.culture")}}
-        </a>
-        {{/if}}
+      <div class="culture tag">
+        {{> headerTag originDoc=actor.system.culture originType="culture"}}
       </div>
-      <div class="career">
-        {{#if actor.system.career}}
-        <span data-document-class="Item" data-item-id="{{actor.system.career.id}}">
-          <a class="filled" data-action="viewDoc">
-            {{{wordBreaker actor.system.career.name}}}
-          </a>
-          {{#unless isPlay}}
-          <a data-action="deleteDoc">
-            <i class="fa-solid fa-trash-can"></i>
-          </a>
-          {{/unless}}
-        </span>
-        {{else}}
-        <a class="unfilled" data-action="createDoc" data-document-class="Item" data-type="career" data-render-sheet="true">
-          {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.career")}}
-        </a>
-        {{/if}}
+      <div class="career tag">
+        {{> headerTag originDoc=actor.system.career originType="career"}}
+      </div>
+      <div class="class tag">
+        {{> headerTag originDoc=actor.system.class originType="class"}}
       </div>
     </div>
   </div>
   <div class="header-right flexcol">
     {{> "systems/draw-steel/templates/parts/mode-toggle.hbs"}}
-    <div class="class">
-      {{#if actor.system.class}}
-      <span class="click-element flexrow" data-document-class="Item" data-item-id="{{actor.system.class.id}}">
-        <a class="flexrow" data-action="viewDoc">
-          <img class="item-img" src="{{actor.system.class.img}}" alt="{{actor.system.class.name}}">
-          <span class="label filled">
-            {{actor.system.class.name}} {{actor.system.class.system.level}}
-          </span>
-        </a>
-        {{#unless isPlay}}
-        <a data-action="deleteDoc">
-          <i class="fa-solid fa-trash-can"></i>
-        </a>
-        {{/unless}}
-      </span>
-      {{else}}
-      <a class="click-element" data-action="createDoc" data-document-class="Item" data-type="class" data-render-sheet="true">
-        <span class="label unfilled">
-          {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.class")}}
+    <div class="actor-data character-data">
+      <div class="level">
+        <label>{{localize "DRAW_STEEL.Item.Class.FIELDS.level.label"}}:</label>
+        <span class="value">{{system.level}}</span>
+        {{#if (and (gte system.hero.xp system.nextLevelXP) system.class)}}
+        <span class="level-up" data-tooltip="Level Up Available">
+          <i class="fa-solid fa-up-long"></i>
         </span>
+        {{/if}}
+      </div>
+      <div class="xp">
+        <label>{{systemFields.hero.fields.xp.label}}:</label>
+        {{#if isPlay}}
+        <span class="value">
+          {{system.hero.xp}}
+          <span class="resource-divider"> / </span>
+          <span class="resource-max">{{system.nextLevelXP}}</span>
+        </span>
+        {{else}}
+        {{formInput systemFields.hero.fields.xp value=systemSource.hero.xp}}
+        {{/if}}
+      </div>
+      <div class="victories">
+        <label>{{systemFields.hero.fields.victories.label}}:</label>
+        {{#if isPlay}}
+        <span class="value">
+          <span class="resource-current">
+            {{system.hero.victories}}
+          </span>
+          <span class="resource-divider"> / </span>
+          <span class="resource-max">
+            {{system.victoriesMax}}
+          </span>
+        </span>
+        {{else}}
+        {{formInput systemFields.hero.fields.victories value=systemSource.hero.victories}}
+        {{/if}}
+      </div>
+    </div>
+    {{#if isPlay}}
+    <div class="take-respite">
+      <a data-action="takeRespite">
+        <i class="fa-solid fa-bed"></i>
+        {{localize "DRAW_STEEL.Sheet.TakeRespite"}}
       </a>
-      {{/if}}
     </div>
-    <div class="victories">
-      <label>{{systemFields.hero.fields.victories.label}}</label>
-      {{#if isPlay}}
-      <span class="resource-current">
-        {{system.hero.victories}}
-      </span>
-      <span class="resource-divider"> / </span>
-      <span class="resource-max">
-        {{system.victoriesMax}}
-      </span>
-      {{else}}
-      {{formInput
-      systemFields.hero.fields.victories
-      value=systemSource.hero.victories
-      }}
-      {{/if}}
-    </div>
+    {{/if}}
   </div>
 </header>

--- a/templates/actor/npc/header.hbs
+++ b/templates/actor/npc/header.hbs
@@ -59,9 +59,7 @@
     <div class="actor-data monster-data">
       <div class="level">
         <label>{{systemFields.monster.fields.level.label}}: </label>
-        <span class="value">
-          {{systemSource.monster.level}}
-        </span>
+        <span class="value">{{systemSource.monster.level}}</span>
       </div>
       <div class="ev">
         <label>{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}:</label>

--- a/templates/actor/npc/header.hbs
+++ b/templates/actor/npc/header.hbs
@@ -5,66 +5,78 @@
     class="profile-img"
     src="{{actor.img}}"
     alt="{{actor.name}}"
-    data-edit="img"
-    {{#if isPlay}}
-    data-action="showPortraitArtwork"
-    {{else}}
-    {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
-    data-action="editImage"
-    {{/if}}
+    data-action="{{ifThen isPlay "showPortraitArtwork" "editImage"}}"
     title="{{actor.name}}"
-    height="100"
-    width="100"
-  />
+  >
   <div class="header-center flexcol">
     <div class="document-name">
       {{#if isPlay}}
       <h2>{{{wordBreaker actor.name}}}</h2>
       {{else}}
-      {{formInput
-      fields.name
-      value=actor._source.name
-      placeholder=(localize "Name")
-      }}
+      {{formInput fields.name value=source.name placeholder=(localize "Name") }}
       {{/if}}
     </div>
-    <div class="keywords">
-      {{monsterKeywords}}
+    <div class="tags flexrow">
+      {{!-- Keyword Tags --}}
+      {{#each system.monster.keywords as |keyword|}}
+      <div class="tag">
+        {{lookup (lookup @root.config.monsters.keywords keyword) "label"}}
+      </div>
+      {{/each}}
+      {{#unless system.monster.keywords}}
+      {{/unless}}
+
+      {{!-- Organization/Role Tags --}}
+      {{#if system.monster.organization}}
+      <div class="tag">
+        {{lookup (lookup config.monsters.organizations system.monster.organization) "label"}}
+      </div>
+      {{/if}}
+      {{#if system.monster.role}}
+      <div class="tag">
+        {{lookup (lookup config.monsters.roles system.monster.role) "label"}}
+      </div>
+      {{/if}}
+      {{#unless isPlay}}
+      <a data-action="editMonsterMetadata">
+        <i class="fa-solid fa-gear"></i>
+      </a>
+      {{/unless}}
     </div>
   </div>
   <div class="header-right flexcol">
     {{> "systems/draw-steel/templates/parts/mode-toggle.hbs"}}
-    <div class="monster-data flexrow">
-      <div class="monster-metadata">
-        <div class="actor-source">
-          {{#if isPlay}}
-          {{system.source.label}}
+    <div class="actor-source">
+      {{#if isPlay}}
+      {{system.source.label}}
+      {{else}}
+      <a data-action="updateSource">
+        <i class="fa-solid fa-book"></i>
+        {{actor.system.source.label}}
+      </a>
+      {{/if}}
+    </div>
+    <div class="actor-data monster-data">
+      <div class="level">
+        <label>{{systemFields.monster.fields.level.label}}: </label>
+        <span class="value">
+          {{systemSource.monster.level}}
+        </span>
+      </div>
+      <div class="ev">
+        <label>{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}:</label>
+        <span class="value">
+          {{#if (eq system.monster.organization "minion")}}
+          {{localize "DRAW_STEEL.Actor.NPC.EVLabel.Minion" value=systemSource.monster.ev}}
           {{else}}
-          <a data-action="updateSource">
-            <i class="fa-solid fa-book"></i>
-            {{actor.system.source.label}}
-          </a>
+          {{systemSource.monster.ev}}
           {{/if}}
-        </div>
-        <div class="monster-info">
-          {{#unless isPlay}}
-          <a data-action="editMonsterMetadata">
-            <i class="fa-solid fa-gear"></i>
-          </a>
-          {{/unless}}
-          {{systemFields.monster.fields.level.label}} {{system.monster.level}}
-          {{organizationLabel}} {{rolesLabel}}
-        </div>
-        <div class="ev">
-          {{evLabel}}
-        </div>
+        </span>
       </div>
       {{#if showMalice}}
-      <div class="malice form-group stacked">
-        <label>{{malice.label}}</label>
-        <div class="form-fields">
-          <input type="number" step="1" data-setting="malice" value="{{malice.value}}">
-        </div>
+      <div class="malice">
+        <label>{{malice.label}}:</label>
+        <input type="number" step="1" data-setting="malice" value="{{malice.value}}">
       </div>
       {{/if}}
     </div>

--- a/templates/actor/npc/header.hbs
+++ b/templates/actor/npc/header.hbs
@@ -56,27 +56,24 @@
       </a>
       {{/if}}
     </div>
-    <div class="actor-data monster-data">
-      <div class="level">
-        <label>{{systemFields.monster.fields.level.label}}: </label>
-        <span class="value">{{systemSource.monster.level}}</span>
-      </div>
-      <div class="ev">
-        <label>{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}:</label>
-        <span class="value">
-          {{#if (eq system.monster.organization "minion")}}
-          {{localize "DRAW_STEEL.Actor.NPC.EVLabel.Minion" value=systemSource.monster.ev}}
-          {{else}}
-          {{systemSource.monster.ev}}
-          {{/if}}
-        </span>
-      </div>
-      {{#if showMalice}}
-      <div class="malice">
-        <label>{{malice.label}}:</label>
-        <input type="number" step="1" data-setting="malice" value="{{malice.value}}">
-      </div>
-      {{/if}}
+    <dl>
+      <dt class="level">{{systemFields.monster.fields.level.label}}:</dt>
+      <dd class="level">{{systemSource.monster.level}}</dd>
+
+      <dt class="ev">{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}:</dt>
+      <dd class="ev">
+        {{#if (eq system.monster.organization "minion")}}
+        {{localize "DRAW_STEEL.Actor.NPC.EVLabel.Minion" value=systemSource.monster.ev}}
+        {{else}}
+        {{systemSource.monster.ev}}
+        {{/if}}
+      </dd>
+    </dl>
+    {{#if showMalice}}
+    <div class="malice">
+      <label>{{malice.label}}:</label>
+      <input type="number" step="1" data-setting="malice" value="{{malice.value}}">
     </div>
+    {{/if}}
   </div>
 </header>

--- a/templates/actor/npc/header.hbs
+++ b/templates/actor/npc/header.hbs
@@ -57,7 +57,7 @@
       {{/if}}
     </div>
     <dl>
-      <dt class="level">{{systemFields.monster.fields.level.label}}:</dt>
+      <dt class="level">{{systemFields.monster.fields.level.label}}</dt>
       <dd class="level">{{systemSource.monster.level}}</dd>
 
       <dt class="ev">{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}:</dt>
@@ -71,7 +71,7 @@
     </dl>
     {{#if showMalice}}
     <div class="malice">
-      <label>{{malice.label}}:</label>
+      <label>{{malice.label}}</label>
       <input type="number" step="1" data-setting="malice" value="{{malice.value}}">
     </div>
     {{/if}}


### PR DESCRIPTION
This is the updated version of the stuff I had posted in the discord. Let me know your thoughts and what changes I should make to improve it.

The new functionality would be the XP input and the take respite button.

Actor Sheet
![updated-character-header-play](https://github.com/user-attachments/assets/0410d4fc-d25a-45ee-b1c1-01260f97cde0)
![updated-character-header-edit](https://github.com/user-attachments/assets/5f26561b-e18c-4a4a-a624-f69b052d09ff)

Monster Sheet
![updated-monster-header-play](https://github.com/user-attachments/assets/50053061-7735-4c06-9dfd-2b514be20405)
![updated-monster-header-play-malice](https://github.com/user-attachments/assets/004f6d8c-af6c-42ba-b277-250b5f4e08bb)
![updated-monster-header-edit](https://github.com/user-attachments/assets/f3f1524c-1f19-4a30-8c50-b75f7ecc3df6)

Closes #352
Closes #305 
Closes #283 
Closes #263
Related to #137

