### PR TITLE
Add power roll section to item sheet embed.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1178,7 +1178,8 @@
           "Bonuses": "Bonuses/Penalties",
           "Label": "{number} {mod}"
         },
-        "BaseRoll": "Base Power Roll"
+        "BaseRoll": "Base Power Roll",
+        "RollPlusCharacteristics": "Power Roll + {characteristics}"
       },
       "Project": {
         "Label": "Project Roll",

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -335,6 +335,13 @@ export default class AbilityModel extends BaseItemModel {
 
     context.characteristics = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label }));
 
+    const characteristicsFormatter = game.i18n.getListFormatter({ type: "disjunction" });
+    const characteristicList = this.powerRoll.characteristics.map(characteristic => {
+      const localizedCharacteristic = ds.CONFIG.characteristics[characteristic]?.label ?? characteristic;
+      return (characteristic === this.powerRoll.characteristic) ? `<em>${localizedCharacteristic}</em>` : localizedCharacteristic;
+    });
+    context.powerRollCharacteristicsList = characteristicsFormatter.format(Array.from(characteristicList));
+
     context.powerRollEffectOptions = Object.entries(this.schema.fields.powerRoll.fields.tier1.element.types).map(([value, { label }]) => ({ value, label }));
 
     // Add the data for subtabs for the power roll tiers

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -33,6 +33,9 @@
 </section>
 {{#if (or tier1 tier2 tier3)}}
 <section class="powerResult">
+  <p>
+    <strong>{{{localize "DRAW_STEEL.Roll.Power.RollPlusCharacteristics" characteristics=powerRollCharacteristicsList}}}</strong>
+  </p>
   {{#if tier1}}
   <p>
     <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier1"}}:</strong> {{{system.powerRoll.tier1.display}}}

--- a/templates/item/partials/ability.hbs
+++ b/templates/item/partials/ability.hbs
@@ -69,8 +69,9 @@
   {{/each}}
 </fieldset>
 {{/inline}}
+
 {{#if isPlay}}
-{{> "systems/draw-steel/templates/item/embeds/ability.hbs"}}
+{{> "systems/draw-steel/templates/item/embeds/ability.hbs" tier1=system.powerRoll.enabled tier2=system.powerRoll.enabled tier3=system.powerRoll.enabled}}
 {{else}}
 {{formGroup systemFields.description.fields.flavor value=system.description.flavor}}
 {{formGroup systemFields.keywords value=system.keywords options=config.abilities.keywords.optgroups}}


### PR DESCRIPTION
Addresses the [issue mentioned in discord](https://discordapp.com/channels/332362513368875008/1342298358664138805/1356322133042659519) where the power roll tiers weren't being added to the item sheet embed.

I also added the `Power Roll + Characteristics` to the embed as well with the characteristic that would be used emphasized.

![ability-embed-updates](https://github.com/user-attachments/assets/c3f8f1f8-ab72-4395-aaf0-60480df40994)
