### PR TITLE
156 hero token display

### DIFF
--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -22,3 +22,6 @@
 /* Sidebar Imports */
 @import url("../src/styles/system/applications/sidebar/tabs/chat.css");
 @import url("../src/styles/system/applications/sidebar/tabs/combat.css");
+
+/** UI Imports */
+@import url("../src/styles/system/applications/ui/players.css");

--- a/draw-steel.d.ts
+++ b/draw-steel.d.ts
@@ -1,5 +1,5 @@
 import "./src/module/_types";
-import "@client/global.mjs"
+import "@client/global.mjs";
 import Canvas from "@client/canvas/board.mjs";
 
 // Foundry's use of `Object.assign(globalThis) means many globally available objects are not read as such

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -95,6 +95,7 @@ Hooks.once("init", function () {
   // Register replacements for core UI elements
   Object.assign(CONFIG.ui, {
     combat: applications.sidebar.tabs.DrawSteelCombatTracker,
+    players: applications.ui.DrawSteelPlayers,
   });
 
   // Register dice rolls

--- a/lang/en.json
+++ b/lang/en.json
@@ -1218,6 +1218,10 @@
         "Label": "Malice",
         "Hint": "Malice is a resource gained by the Director. You use malice to let enemies in the game activate their most powerful abilities and throw surprises at the heroes during combat."
       },
+      "ShowPlayerMalice": {
+        "Label": "Show Malice Value To Players",
+        "Hint": "Display the current Malice value to players."
+      },
       "MigrationVersion": {
         "Label": "Migration Version",
         "Hint": "Last Performed Migration"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1196,6 +1196,10 @@
         "Hint": "Hero tokens are a group resource that is tracked by the players and kept in a pool that is accessible to all their characters.",
         "NoHeroTokens": "No Hero Tokens available",
         "WarnDirectorBadSpend": "{name} attempted to spend a hero token while none were available.",
+        "GiveToken": "Give Token",
+        "GrantedTokens": "The heroes gain {count} hero token(s).",
+        "ResetToken": "Reset Hero Tokens",
+        "StartSession": "The Director reset the number of hero tokens to {count} for the start of the session.",
         "GainSurges": {
           "label": "Gain Surges",
           "messageContent": "Spends a hero token to gain two surges.",

--- a/src/module/applications/_module.mjs
+++ b/src/module/applications/_module.mjs
@@ -1,8 +1,9 @@
-export * as sidebar from "./sidebar/_module.mjs";
 export * as apps from "./apps/_module.mjs";
 export * as hooks from "./hooks/_module.mjs";
 export * as hud from "./hud/_module.mjs";
 export * as sheets from "./sheets/_module.mjs";
+export * as ui from "./ui/_module.mjs";
+export * as sidebar from "./sidebar/_module.mjs";
 
 import * as elements from "./elements/_module.mjs";
 

--- a/src/module/applications/ui/_module.mjs
+++ b/src/module/applications/ui/_module.mjs
@@ -1,0 +1,1 @@
+export { default as DrawSteelPlayers } from "./players.mjs";

--- a/src/module/applications/ui/players.mjs
+++ b/src/module/applications/ui/players.mjs
@@ -1,9 +1,24 @@
 import { systemID, systemPath } from "../../constants.mjs";
+/** @import { HeroTokenModel } from "../../data/settings/hero-tokens.mjs"; */
 
 /**
- * An extension of the core Players display that adds
+ * An extension of the core Players display that adds controls for hero tokens and malice
  */
 export default class DrawSteelPlayers extends foundry.applications.ui.Players {
+  async _onFirstRender(context, options) {
+    await super._onFirstRender(context, options);
+
+    // Can adjust if it makes sense to have hero token controls for non-GMs (e.g. a more generic hero action)
+    if (game.user.isGM) {
+      this._createContextMenu(this._heroTokenContextMenuOptions, ".hero-tokens .context-menu", {
+        eventName: "click",
+        hookName: "getHeroTokenContextOptions",
+        parentClassHooks: false,
+        fixed: true,
+      });
+    }
+  }
+
   /** @inheritdoc */
   async _onRender(context, options) {
     await super._onRender(context, options);
@@ -12,8 +27,34 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
       heroTokens: game.settings.get(systemID, "heroTokens"),
       malice: game.settings.get(systemID, "malice"),
       showMalice: game.user.isGM || game.settings.get(systemID, "showPlayerMalice"),
+      gm: game.user.isGM,
     });
 
     this.element.insertAdjacentHTML("beforeend", metaCurrencyDisplay);
+  }
+
+  _heroTokenContextMenuOptions() {
+    return [
+      {
+        name: game.i18n.localize("DRAW_STEEL.Setting.HeroTokens.GiveToken"),
+        icon: "<i class=\"fa-solid fa-plus\"></i>",
+        condition: li => game.user.isGM,
+        callback: async li => {
+          /** @type {HeroTokenModel} */
+          const heroTokens = game.settings.get(systemID, "heroTokens");
+          await heroTokens.giveToken();
+        },
+      },
+      {
+        name: game.i18n.localize("DRAW_STEEL.Setting.HeroTokens.ResetToken"),
+        icon: "<i class=\"fa-solid fa-rotate\"></i>",
+        condition: li => game.user.isGM,
+        callback: async li => {
+          /** @type {HeroTokenModel} */
+          const heroTokens = game.settings.get(systemID, "heroTokens");
+          await heroTokens.resetTokens();
+        },
+      },
+    ];
   }
 }

--- a/src/module/applications/ui/players.mjs
+++ b/src/module/applications/ui/players.mjs
@@ -1,0 +1,19 @@
+import { systemID, systemPath } from "../../constants.mjs";
+
+/**
+ * An extension of the core Players display that adds
+ */
+export default class DrawSteelPlayers extends foundry.applications.ui.Players {
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+
+    const metaCurrencyDisplay = await foundry.applications.handlebars.renderTemplate(systemPath("templates/ui/players.hbs"), {
+      heroTokens: game.settings.get(systemID, "heroTokens"),
+      malice: game.settings.get(systemID, "malice"),
+      showMalice: game.user.isGM || game.settings.get(systemID, "showPlayerMalice"),
+    });
+
+    this.element.insertAdjacentHTML("beforeend", metaCurrencyDisplay);
+  }
+}

--- a/src/module/data/settings/hero-tokens.mjs
+++ b/src/module/data/settings/hero-tokens.mjs
@@ -17,8 +17,18 @@ export class HeroTokenModel extends foundry.abstract.DataModel {
   /** Name for the setting */
   static label = "DRAW_STEEL.Setting.HeroTokens.Label";
 
+  /** Localized name for the setting */
+  get label() {
+    return game.i18n.localize(this.constructor.label);
+  }
+
   /** Helper text for Hero Tokens */
   static hint = "DRAW_STEEL.Setting.HeroTokens.Hint";
+
+  /** Localized helper text for Hero Token */
+  get hint() {
+    return game.i18n.localize(this.constructor.hint);
+  }
 
   /**
    * Send a socket message to the Director to spend a hero token

--- a/src/module/data/settings/malice.mjs
+++ b/src/module/data/settings/malice.mjs
@@ -39,6 +39,7 @@ export class MaliceModel extends foundry.abstract.DataModel {
    * @param {string} userId     The id of the User requesting the document update
    */
   static onChange(value, options, userId) {
+    ui.players.render();
     for (const [index, app] of foundry.applications.instances) {
       if (app instanceof DrawSteelNPCSheet) {
         app.render({ parts: ["header"] });

--- a/src/module/helpers/settings.mjs
+++ b/src/module/helpers/settings.mjs
@@ -36,6 +36,7 @@ export default class DrawSteelSettingsHandler {
         type: HeroTokenModel,
         scope: "world",
         default: { value: 0 },
+        onChange: () => ui.players.render(),
       },
       malice: {
         name: MaliceModel.label,

--- a/src/module/helpers/settings.mjs
+++ b/src/module/helpers/settings.mjs
@@ -45,6 +45,14 @@ export default class DrawSteelSettingsHandler {
         default: { value: 0 },
         onChange: MaliceModel.onChange,
       },
+      showPlayerMalice: {
+        name: "DRAW_STEEL.Setting.ShowPlayerMalice.Label",
+        hint: "DRAW_STEEL.Setting.ShowPlayerMalice.Hint",
+        type: new fields.BooleanField(),
+        config: true,
+        scope: "world",
+        onChange: () => ui.players.render({ force: true }),
+      },
     };
   }
 

--- a/src/styles/system/applications/_applications.mjs
+++ b/src/styles/system/applications/_applications.mjs
@@ -17,3 +17,5 @@ import "./sheets/item-sheet.css";
 
 import "./sidebar/tabs/chat.css";
 import "./sidebar/tabs/combat.css";
+
+import "./ui/players.css";

--- a/src/styles/system/applications/ui/players.css
+++ b/src/styles/system/applications/ui/players.css
@@ -4,4 +4,8 @@
   border-radius: 8px;
   padding: 6px 8px;
   pointer-events: all;
+  .context-menu {
+    float: right;
+    border: none;
+  }
 }

--- a/src/styles/system/applications/ui/players.css
+++ b/src/styles/system/applications/ui/players.css
@@ -1,0 +1,7 @@
+#meta-currency {
+  width: 200px;
+  background: var(--background-color, var(--color-cool-5-75));
+  border-radius: 8px;
+  padding: 6px 8px;
+  pointer-events: all;
+}

--- a/templates/ui/players.hbs
+++ b/templates/ui/players.hbs
@@ -1,12 +1,13 @@
 <div id="meta-currency">
   <div class="hero-tokens">
-    <span>{{heroTokens.value}}</span>
-    <label>{{heroTokens.label}}</label>
+    <span>{{heroTokens.value}} <label>{{heroTokens.label}}</label></span>
+    {{#if gm}}
+    <button class="context-menu icon fa-solid fa-ellipsis-vertical" type="button"></button>
+    {{/if}}
   </div>
   {{#if showMalice}}
   <div class="malice">
-    <span>{{malice.value}}</span>
-    <label>{{malice.label}}</label>
+    <span>{{malice.value}} <label>{{malice.label}}</label></span>
   </div>
   {{/if}}
 </div>

--- a/templates/ui/players.hbs
+++ b/templates/ui/players.hbs
@@ -1,0 +1,12 @@
+<div class="meta-currency">
+  <div class="hero-tokens">
+    <label>{{heroTokens.label}}</label>
+    <span>{{heroTokens.value}}</span>
+  </div>
+  {{#if showMalice}}
+  <div class="malice">
+    <label>{{malice.label}}</label>
+    <span>{{malice.value}}</span>
+  </div>
+  {{/if}}
+</div>

--- a/templates/ui/players.hbs
+++ b/templates/ui/players.hbs
@@ -1,12 +1,12 @@
-<div class="meta-currency">
+<div id="meta-currency">
   <div class="hero-tokens">
-    <label>{{heroTokens.label}}</label>
     <span>{{heroTokens.value}}</span>
+    <label>{{heroTokens.label}}</label>
   </div>
   {{#if showMalice}}
   <div class="malice">
-    <label>{{malice.label}}</label>
     <span>{{malice.value}}</span>
+    <label>{{malice.label}}</label>
   </div>
   {{/if}}
 </div>


### PR DESCRIPTION
Added display for hero tokens and malice as part of/below the player list. GMs have a world setting to control if the malice count should show to players or not. The three dot menu in line with hero tokens allows for giving tokens & resetting them to the current player count. Future updates can make the reset more sophisticated by supporting some kind of "primary party" logic.

![image](https://github.com/user-attachments/assets/e9a9c111-c043-46e6-8843-c92f2b744a0f)
