### PR TITLE
Use description list element in actor header and item embeds

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -280,7 +280,7 @@ export default class AbilityModel extends BaseItemModel {
     if (config.tier1) context.tier1 = true;
     if (config.tier2) context.tier2 = true;
     if (config.tier3) context.tier3 = true;
-    this.getSheetContext(context);
+    await this.getSheetContext(context);
     const abilityBody = await foundry.applications.handlebars.renderTemplate(systemPath("templates/item/embeds/ability.hbs"), context);
     embed.insertAdjacentHTML("beforeend", abilityBody);
     return embed;
@@ -307,7 +307,7 @@ export default class AbilityModel extends BaseItemModel {
   }
 
   /** @inheritdoc */
-  getSheetContext(context) {
+  async getSheetContext(context) {
     const config = ds.CONFIG.abilities;
     const formattedLabels = this.formattedLabels;
 

--- a/src/module/data/item/class.mjs
+++ b/src/module/data/item/class.mjs
@@ -60,7 +60,7 @@ export default class ClassModel extends AdvancementModel {
   }
 
   /** @inheritdoc */
-  getSheetContext(context) {
+  async getSheetContext(context) {
     context.characteristics = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label }));
     context.kitOptions = Array.fromRange(3).map(number => ({ label: number, value: number }));
   }

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -49,7 +49,7 @@ export default class EquipmentModel extends BaseItemModel {
   }
 
   /** @inheritdoc */
-  getSheetContext(context) {
+  async getSheetContext(context) {
     context.categories = Object.entries(ds.CONFIG.equipment.categories).map(([value, { label }]) => ({ value, label }));
 
     context.kinds = Object.entries(ds.CONFIG.equipment.kinds).map(([value, { label }]) => ({ value, label }));

--- a/src/module/data/item/feature.mjs
+++ b/src/module/data/item/feature.mjs
@@ -38,7 +38,7 @@ export default class FeatureModel extends BaseItemModel {
   }
 
   /** @inheritdoc */
-  getSheetContext(context) {
+  async getSheetContext(context) {
     const featureConfig = ds.CONFIG.features;
 
     context.featureTypes = Object.entries(featureConfig.types).map(([value, entry]) => ({ value, label: entry.label }));

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -107,7 +107,7 @@ export default class KitModel extends BaseItemModel {
         relativeTo: this.parent,
       },
     );
-    this.getSheetContext(context);
+    await this.getSheetContext(context);
     //TODO: Once kits provide a signature item, add the ability embed or link to the item
     const kitBody = await foundry.applications.handlebars.renderTemplate(systemPath("templates/item/embeds/kit.hbs"), context);
     embed.insertAdjacentHTML("beforeend", kitBody);
@@ -159,7 +159,7 @@ export default class KitModel extends BaseItemModel {
   }
 
   /** @inheritdoc */
-  getSheetContext(context) {
+  async getSheetContext(context) {
     context.weaponOptions = Object.entries(ds.CONFIG.equipment.weapon).map(([value, { label }]) => ({ value, label }));
     context.armorOptions = Object.entries(ds.CONFIG.equipment.armor).map(([value, { label }]) => ({ value, label }))
       .filter(entry => ds.CONFIG.equipment.armor[entry.value].kitEquipment);

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -96,7 +96,7 @@ export default class ProjectModel extends BaseItemModel {
       systemFields: this.schema.fields,
       config: ds.CONFIG,
     };
-    this.getSheetContext(context);
+    await this.getSheetContext(context);
 
     const embed = document.createElement("div");
     embed.classList.add("project");

--- a/src/module/helpers/macros.mjs
+++ b/src/module/helpers/macros.mjs
@@ -24,7 +24,7 @@ export async function createDocMacro(data, slot) {
       name = item.name;
       break;
     default:
-      command = `await Hotbar.toggleDocumentSheet("${item.uuid}");`;
+      command = `await foundry.applications.ui.Hotbar.toggleDocumentSheet("${item.uuid}");`;
       name = `${game.i18n.localize("Display")} ${item.name}`;
       break;
   }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -16,6 +16,7 @@
     }
 
     .powerResult {
+      margin-top: 1rem;
       .potency {
         color: red
       }

--- a/src/styles/system/applications/components/forms.css
+++ b/src/styles/system/applications/components/forms.css
@@ -74,4 +74,20 @@
       }
     }
   }
+
+  /* Description Lists */
+  dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px;
+    margin: 10px 0px;
+    dt, dd {
+      margin: 0;
+      color: inherit;
+    }
+    dt {
+      text-shadow: none;
+      font-weight: bold;
+    }
+  }
 }

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -75,22 +75,6 @@
           flex-grow: 0;
         }
       }
-      dl {
-        display: flex;
-        flex-flow: row wrap;
-        dt, dd {
-          margin: 0;
-          color: inherit;
-        }
-        dt {
-          text-shadow: none;
-          flex-basis: 40px
-        }
-        dd {
-          flex: 1 0 110px;
-          text-align: right;
-        }
-      }
       .actor-source {
         margin-top: 5px;
         font-family: var(--font-h6);
@@ -105,20 +89,16 @@
         align-items: center;
         gap: 5px;
         margin-top: 5px;
-        font-size: var(--font-size-15);
-        input {
-          width: 50%;
+        label,
+        .form-fields {
+          flex: 0 0 50%;
         }
-        &:has(input) label {
-          width: 50%;
-        }
-        .value {
-          text-align: right;
-          flex-grow: 1;
+        label {
+          font-weight: bold;
         }
       }
-      dt, label {
-        font-weight: bold;
+      dd {
+        text-align: right;
       }
       div.take-respite  {
         text-align: center;

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -53,41 +53,40 @@
   </div>
   <div class="header-right flexcol">
     {{> "systems/draw-steel/templates/parts/mode-toggle.hbs"}}
-    <div class="actor-data character-data">
-      <div class="level">
-        <label>{{localize "DRAW_STEEL.Item.Class.FIELDS.level.label"}}</label>
-        <span class="value">{{system.level}}</span>
+
+    <dl>
+      <dt class="level">{{localize "DRAW_STEEL.Item.Class.FIELDS.level.label"}}</dt>
+      <dd class="level">
+        {{system.level}}
         {{#if (and (gte system.hero.xp system.nextLevelXP) system.class)}}
         <span class="level-up" data-tooltip="DRAW_STEEL.Sheet.LevelUp">
           <i class="fa-solid fa-up-long"></i>
         </span>
         {{/if}}
-      </div>
-      <div class="xp">
-        <label>{{systemFields.hero.fields.xp.label}}</label>
-        {{#if isPlay}}
-        <span class="value">
-          <span class="resource-curent">{{system.hero.xp}}</span>
-          <span class="resource-divider"> / </span>
-          <span class="resource-max">{{system.nextLevelXP}}</span>
-        </span>
-        {{else}}
-        {{formInput systemFields.hero.fields.xp value=systemSource.hero.xp}}
-        {{/if}}
-      </div>
-      <div class="victories">
-        <label>{{systemFields.hero.fields.victories.label}}</label>
-        {{#if isPlay}}
-        <span class="value">
-          <span class="resource-current">{{system.hero.victories}}</span>
-          <span class="resource-divider"> / </span>
-          <span class="resource-max">{{system.victoriesMax}}</span>
-        </span>
-        {{else}}
-        {{formInput systemFields.hero.fields.victories value=systemSource.hero.victories}}
-        {{/if}}
-      </div>
+      </dd>
+
+      {{#if isPlay}}
+      <dt class="xp">{{systemFields.hero.fields.xp.label}}</dt>
+      <dd class="xp">
+        <span class="resource-curent">{{system.hero.xp}}</span>
+        <span class="resource-divider"> / </span>
+        <span class="resource-max">{{system.nextLevelXP}}</span>
+      </dd>
+
+      <dt>{{systemFields.hero.fields.victories.label}}</dt>
+      <dd>
+        <span class="resource-current">{{system.hero.victories}}</span>
+        <span class="resource-divider"> / </span>
+        <span class="resource-max">{{system.victoriesMax}}</span>
+      </dd>
+      {{/if}}
+    </dl>
+    {{#unless isPlay}}
+    <div class="actor-data character-data">
+      {{formGroup systemFields.hero.fields.xp value=systemSource.hero.xp classes="xp"}}
+      {{formGroup systemFields.hero.fields.victories value=systemSource.hero.victories classes="victories"}}
     </div>
+    {{/unless}}
     {{#if isPlay}}
     <div class="take-respite">
       <a data-action="takeRespite">

--- a/templates/actor/npc/header.hbs
+++ b/templates/actor/npc/header.hbs
@@ -60,7 +60,7 @@
       <dt class="level">{{systemFields.monster.fields.level.label}}</dt>
       <dd class="level">{{systemSource.monster.level}}</dd>
 
-      <dt class="ev">{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}:</dt>
+      <dt class="ev">{{localize "DRAW_STEEL.Actor.NPC.EVLabel.Label"}}</dt>
       <dd class="ev">
         {{#if (eq system.monster.organization "minion")}}
         {{localize "DRAW_STEEL.Actor.NPC.EVLabel.Minion" value=systemSource.monster.ev}}

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -58,7 +58,7 @@
             </a>
           </div>
         </div>
-        <div class="item-embed">
+        <div class="item-embed content-embed">
           {{#if abilityContext.expanded}}{{{abilityContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -9,54 +9,50 @@
     <em>{{system.description.flavor}}</em>
   </p>
   {{/if}}
-  <div class="info-row usage">
-    <p class="keywords">
-      <strong>{{systemFields.keywords.label}}:</strong> {{keywordList}}
-    </p>
-    <p class="type">
-      <strong>{{systemFields.type.label}}:</strong> {{lookup (lookup config.abilities.types system.type) "label"}}
-    </p>
-  </div>
-  <div class="info-row targeting">
-    <p class="distance">
-      <strong>{{systemFields.distance.label}}:</strong> {{distanceLabel}}
-    </p>
-    <p class="target">
-      <strong>{{systemFields.target.label}}:</strong> {{targetLabel}}
-    </p>
-  </div>
-  {{#if triggeredAction}}
-  <p class="trigger">
-    <strong>{{systemFields.trigger.label}}:</strong> {{system.trigger}}
-  </p>
-  {{/if}}
+  <dl>
+    <dt class="keywords">{{systemFields.keywords.label}}</dt>
+    <dd class="keywords">{{keywordList}}</dd>
+
+    <dt class="type">{{systemFields.type.label}}</dt>
+    <dd class="type">{{lookup (lookup config.abilities.types system.type) "label"}}</dd>
+
+    <dt class="distance">{{systemFields.distance.label}}</dt>
+    <dd class="distance">{{distanceLabel}}</dd>
+
+    <dt class="target">{{systemFields.target.label}}</dt>
+    <dd class="target">{{targetLabel}}</dd>
+
+    {{#if triggeredAction}}
+    <dt class="trigger">{{systemFields.trigger.label}}</dt>
+    <dd class="trigger">{{system.trigger}}</dd>
+    {{/if}}
+  </dl>
 </section>
-{{#if (or tier1 tier2 tier3)}}
+{{#if (or tier1 tier2 tier3 system.effect)}}
 <section class="powerResult">
   <p>
     <strong>{{{localize "DRAW_STEEL.Roll.Power.RollPlusCharacteristics" characteristics=powerRollCharacteristicsList}}}</strong>
   </p>
-  {{#if tier1}}
-  <p>
-    <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier1"}}:</strong> {{{system.powerRoll.tier1.display}}}
-  </p>
-  {{/if}}
-  {{#if tier2}}
-  <p>
-    <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier2"}}:</strong> {{{system.powerRoll.tier2.display}}}
-  </p>
-  {{/if}}
-  {{#if tier3}}
-  <p>
-    <strong>{{localize "DRAW_STEEL.Roll.Power.Results.Tier3"}}:</strong> {{{system.powerRoll.tier3.display}}}
-  </p>
-  {{/if}}
-</section>
-{{/if}}
-{{#if system.effect}}
-<section class="effect">
-  <p>
-    <strong>{{systemFields.effect.label}}</strong> {{system.effect}}
-  </p>
+  <dl class="power-roll-display">
+    {{#if tier1}}
+    <dt class="tier1">{{localize "DRAW_STEEL.Roll.Power.Results.Tier1"}}</dt>
+    <dd class="tier1">{{{system.powerRoll.tier1.display}}}</dd>
+    {{/if}}
+
+    {{#if tier2}}
+    <dt class="tier3">{{localize "DRAW_STEEL.Roll.Power.Results.Tier2"}}</dt>
+    <dd class="tier3">{{{system.powerRoll.tier2.display}}}</dd>
+    {{/if}}
+
+    {{#if tier3}}
+    <dt class="tier3">{{localize "DRAW_STEEL.Roll.Power.Results.Tier3"}}</dt>
+    <dd class="tier3">{{{system.powerRoll.tier3.display}}}</dd>
+    {{/if}}
+
+    {{#if system.effect}}
+    <dt class="effect">{{systemFields.effect.label}}</dt>
+    <dd class="effect">{{system.effect}}</dd>
+    {{/if}}
+  </dl>
 </section>
 {{/if}}

--- a/templates/item/embeds/kit.hbs
+++ b/templates/item/embeds/kit.hbs
@@ -5,72 +5,64 @@
 {{/if}}
 <section class="equipment">
   <h6>{{systemFields.equipment.label}}</h6>
-  <p class="armor">
-    <strong>{{systemFields.equipment.fields.armor.label}}:</strong> {{localize (lookup (lookup config.equipment.armor system.equipment.armor) "label")}}
-  </p>
-  <p class="equipment">
-    <strong>{{systemFields.equipment.fields.weapon.label}}:</strong> {{weaponLabel}}
-  </p>
-  <p class="shield">
-    <strong>{{systemFields.equipment.fields.shield.label}}:</strong> {{localize (ifThen system.equipment.shield "Yes" "No")}}
-  </p>
+  <dl>
+    <dt class="armor">{{systemFields.equipment.fields.armor.label}}</dt>
+    <dd class="armor">{{localize (lookup (lookup config.equipment.armor system.equipment.armor) "label")}}</dd>
+
+    <dt class="equipment">{{systemFields.equipment.fields.weapon.label}}</dt>
+    <dd class="equipment">{{weaponLabel}}</dd>
+
+    <dt class="shield">{{systemFields.equipment.fields.shield.label}}</dt>
+    <dd class="shield">{{localize (ifThen system.equipment.shield "Yes" "No")}}</dd>
+  </dl>
 </section>
 <section class="bonuses">
   <h6>{{systemFields.bonuses.label}}</h6>
-  {{#if system.bonuses.stamina}}
-  <p class="stamina-bonus">
-    <strong>{{systemFields.bonuses.fields.stamina.label}}:</strong> {{localize "DRAW_STEEL.Item.Kit.StaminaEmbed" number=(numberFormat system.bonuses.stamina sign=true)}}
-  </p>
-  {{/if}}
-  {{#if system.bonuses.speed}}
-  <p class="speed-bonus">
-    <strong>{{systemFields.bonuses.fields.speed.label}}:</strong> {{numberFormat system.bonuses.speed sign=true}}
-  </p>
-  {{/if}}
-  {{#if system.bonuses.stability}}
-  <p class="stability-bonus">
-    <strong>{{systemFields.bonuses.fields.stability.label}}:</strong> {{numberFormat system.bonuses.stability sign=true}}
-  </p>
-  {{/if}}
-  {{#with system.bonuses.melee.damage as |damage|}}
-  {{#if (or damage.tier1 damage.tier2 damage.tier3)}}
-  <p class="melee-damage-bonus">
-    <strong>{{@root.systemFields.bonuses.fields.melee.fields.damage.label}}:</strong>
-    <span>
-      {{#if (or damage.tier1 damage.tier2 damage.tier3)}}
-      {{numberFormat damage.tier1 sign=true}} / {{numberFormat damage.tier2 sign=true}} / {{numberFormat damage.tier3 sign=true}}
-      {{/if}}
-    </span>
-  </p>
-  {{/if}}
-  {{/with}}
-  {{#with system.bonuses.ranged.damage as |damage|}}
-  {{#if (or damage.tier1 damage.tier2 damage.tier3)}}
-  <p class="ranged-damage-bonus">
-    <strong>{{@root.systemFields.bonuses.fields.ranged.fields.damage.label}}:</strong>
-    <span>
-      {{#if (or damage.tier1 damage.tier2 damage.tier3)}}
-      {{numberFormat damage.tier1 sign=true}} / {{numberFormat damage.tier2 sign=true}} / {{numberFormat damage.tier3 sign=true}}
-      {{/if}}
-    </span>
-  </p>
-  {{/if}}
-  {{/with}}
-  {{#if system.bonuses.melee.distance}}
-  <p class="melee-distance-bonus">
-    <strong>{{systemFields.bonuses.fields.melee.fields.distance.label}}:</strong> {{numberFormat system.bonuses.melee.distance sign=true}}
-  </p>
-  {{/if}}
-  {{#if system.bonuses.ranged.distance}}
-  <p class="ranged-distance-bonus">
-    <strong>{{systemFields.bonuses.fields.ranged.fields.distance.label}}:</strong> {{numberFormat system.bonuses.ranged.distance sign=true}}
-  </p>
-  {{/if}}
-  {{#if system.bonuses.disengage}}
-  <p class="disengage-bonus">
-    <strong>{{systemFields.bonuses.fields.disengage.label}}:</strong> {{numberFormat system.bonuses.disengage sign=true}}
-  </p>
-  {{/if}}
+  <dl>
+    {{#if system.bonuses.stamina}}
+    <dt class="stamina-bonus">{{systemFields.bonuses.fields.stamina.label}}</dt>
+    <dd class="stamina-bonus">{{localize "DRAW_STEEL.Item.Kit.StaminaEmbed" number=(numberFormat system.bonuses.stamina sign=true)}}</dd>
+    {{/if}}
+
+    {{#if system.bonuses.speed}}
+    <dt class="speed-bonus">{{systemFields.bonuses.fields.speed.label}}</dt>
+    <dd class="speed-bonus">{{numberFormat system.bonuses.speed sign=true}}</dd>
+    {{/if}}
+
+    {{#if system.bonuses.stability}}
+    <dt class="stability-bonus">{{systemFields.bonuses.fields.stability.label}}</dt>
+    <dd class="stability-bonus">{{numberFormat system.bonuses.stability sign=true}}</dd>
+    {{/if}}
+
+    {{#with system.bonuses.melee.damage as |damage|}}
+    {{#if (or damage.tier1 damage.tier2 damage.tier3)}}
+    <dt class="melee-damage-bonus">{{@root.systemFields.bonuses.fields.melee.fields.damage.label}}</dt>
+    <dd class="melee-damage-bonus">{{numberFormat damage.tier1 sign=true}} / {{numberFormat damage.tier2 sign=true}} / {{numberFormat damage.tier3 sign=true}}</dd>
+    {{/if}}
+    {{/with}}
+
+    {{#with system.bonuses.ranged.damage as |damage|}}
+    {{#if (or damage.tier1 damage.tier2 damage.tier3)}}
+    <dt class="ranged-damage-bonus">{{@root.systemFields.bonuses.fields.ranged.fields.damage.label}}</dt>
+    <dd class="ranged-damage-bonus">{{numberFormat damage.tier1 sign=true}} / {{numberFormat damage.tier2 sign=true}} / {{numberFormat damage.tier3 sign=true}}</dd>
+    {{/if}}
+    {{/with}}
+
+    {{#if system.bonuses.melee.distance}}
+    <dt class="melee-distance-bonus">{{systemFields.bonuses.fields.melee.fields.distance.label}}</dt>
+    <dd class="melee-distance-bonus">{{numberFormat system.bonuses.melee.distance sign=true}}</dd>
+    {{/if}}
+
+    {{#if system.bonuses.ranged.distance}}
+    <dt class="ranged-distance-bonus">{{systemFields.bonuses.fields.ranged.fields.distance.label}}</dt>
+    <dd class="ranged-distance-bonus">{{numberFormat system.bonuses.ranged.distance sign=true}}</dd>
+    {{/if}}
+
+    {{#if system.bonuses.disengage}}
+    <dt class="disengage-bonus">{{systemFields.bonuses.fields.disengage.label}}</dt>
+    <dd class="disengage-bonus">{{numberFormat system.bonuses.disengage sign=true}}</dd>
+    {{/if}}
+  </dl>
 </section>
 {{!-- TODO: Display signature item embed or link when kits provide signature abilities --}}
 {{!-- <section class="signature"></section> --}}

--- a/templates/item/embeds/project.hbs
+++ b/templates/item/embeds/project.hbs
@@ -22,6 +22,5 @@
     <dd class="item-link">{{{itemLink}}}</dd>
     {{/if}}
   </dl>
-  Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi eos dolores recusandae sequi! Aliquam odio, eius numquam corporis maxime ut eum aperiam sint ipsam! Voluptates itaque aspernatur eum quia cumque!
   {{{enrichedDescription}}}
 </section>

--- a/templates/item/embeds/project.hbs
+++ b/templates/item/embeds/project.hbs
@@ -1,21 +1,27 @@
 <section class="project-info">
-  <p class="prerequisites">
-    <strong>{{systemFields.prerequisites.label}}:</strong> {{system.prerequisites}}
-  </p>
-  <p class="source">
-    <strong>{{systemFields.projectSource.label}}:</strong> {{system.projectSource}}
-  </p>
-  <p class="characteristics">
-    <strong>{{systemFields.rollCharacteristic.label}}:</strong> {{formattedCharacteristics}}
-  </p>
-  <p class="goal">
-    <strong>{{systemFields.goal.label}}:</strong> {{system.goal}} {{#if system.yield.display}}({{system.yield.display}}){{/if}}
-  </p>
-  {{#if itemLink}}
-  <p class="item-link">
-    <strong>{{localize "DOCUMENT.Item"}}:</strong> {{{itemLink}}}
-  </p>
-  {{/if}}
+  <dl>
+    <dt class="prerequisites">{{systemFields.prerequisites.label}}</dt>
+    <dd class="prerequisites">{{ifThen system.prerequisites system.prerequisites (localize "None")}}</dd>
 
+    <dt class="source">{{systemFields.projectSource.label}}</dt>
+    <dd class="source">{{system.projectSource}}</dd>
+
+    <dt class="characteristics">{{systemFields.rollCharacteristic.label}}</dt>
+    <dd class="characteristics">{{formattedCharacteristics}}</dd>
+
+    <dt class="goal">{{systemFields.goal.label}}</dt>
+    <dd class="goal">{{system.goal}} {{#if system.yield.display}}({{system.yield.display}}){{/if}}</dd>
+
+    {{#if system.points}}
+    <dt class="points">{{systemFields.points.label}}</dt>
+    <dd class="points">{{system.points}}</dd>
+    {{/if}}
+
+    {{#if itemLink}}
+    <dt class="item-link">{{localize "DOCUMENT.Item"}}</dt>
+    <dd class="item-link">{{{itemLink}}}</dd>
+    {{/if}}
+  </dl>
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi eos dolores recusandae sequi! Aliquam odio, eius numquam corporis maxime ut eum aperiam sint ipsam! Voluptates itaque aspernatur eum quia cumque!
   {{{enrichedDescription}}}
 </section>


### PR DESCRIPTION
Closes #356 

- Updated actor headers and item embeds to use the dl elements.
- Added an await to the project embed `getSheetContext` call because it was prevent the item link from showing up on the embed on the actor sheet.
- Also updated the default macro to use the namespaced call to the `Hotbar`. Felt weird to make a separate PR for just that.

![project-embed-updates](https://github.com/user-attachments/assets/78e414c4-8ebe-4d1c-8d9c-f581d7c5dce1)
![ability-embed-updates](https://github.com/user-attachments/assets/59989d85-f76a-417e-9170-b687fb1c139f)
![kit-embed-updates](https://github.com/user-attachments/assets/2dc4d5ed-883e-493d-9dcb-f06573ca289d)
