### PR TITLE
Add draw steel class to content embeds

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -269,7 +269,7 @@ export default class AbilityModel extends BaseItemModel {
     }
 
     const embed = document.createElement("div");
-    embed.classList.add("ability");
+    embed.classList.add("draw-steel", "ability");
     embed.insertAdjacentHTML("afterbegin", `<h5>${this.parent.name}</h5>`);
     const context = {
       system: this,

--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -78,7 +78,7 @@ export default class BaseItemModel extends foundry.abstract.TypeDataModel {
     const enriched = await TextEditor.enrichHTML(this.description.value, options);
 
     const embed = document.createElement("div");
-    embed.classList.add(this.parent.type);
+    embed.classList.add("draw-steel", this.parent.type);
     embed.innerHTML = enriched;
 
     return embed;

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -91,7 +91,7 @@ export default class KitModel extends BaseItemModel {
    */
   async toEmbed(config, options = {}) {
     const embed = document.createElement("div");
-    embed.classList.add("kit");
+    embed.classList.add("draw-steel", "kit");
     embed.insertAdjacentHTML("afterbegin", `<h5>${this.parent.name}</h5>`);
     const context = {
       system: this,

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -99,7 +99,7 @@ export default class ProjectModel extends BaseItemModel {
     await this.getSheetContext(context);
 
     const embed = document.createElement("div");
-    embed.classList.add("project");
+    embed.classList.add("draw-steel", "project");
     embed.insertAdjacentHTML("afterbegin", `<h5>${this.parent.name}</h5>`);
     const projectBody = await foundry.applications.handlebars.renderTemplate(systemPath("templates/item/embeds/project.hbs"), context);
     embed.insertAdjacentHTML("beforeend", projectBody);


### PR DESCRIPTION
Notice after the DL got merged, that the CSS wasn't affecting the embeds in the chat log because there was no parent with class "draw-steel". Easiest way seemed to be added the class to our embeds so they are targeted everywhere.