### PR TITLE
Add spending recovery to actor sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -14,7 +14,8 @@
       "Resources": "Resources",
       "Other": "Other",
       "TakeRespite": "Take Respite",
-      "LevelUp": "Level Up Available"
+      "LevelUp": "Level Up Available",
+      "SpendRecovery": "Spend a recovery to gain recovery value.<br><strong>Shift+Click:</strong> Spend 2 hero tokens to gain recovery without spending a recovery."
     },
     "Source": {
       "FIELDS": {
@@ -209,7 +210,13 @@
             }
           }
         },
-        "HeroicResourceGain": "Start of turn resource gain"
+        "HeroicResourceGain": "Start of turn resource gain",
+        "SpendRecovery": {
+          "Notifications": {
+            "NoRecovery": "{actor} does not have any recoveries to spend",
+            "Success": "{actor} has regained stamina equal to their recovery value."
+          }
+        }
       },
       "NPC": {
         "FIELDS": {
@@ -1220,7 +1227,8 @@
         },
         "RegainStamina": {
           "label": "Regain Stamina",
-          "messageContent": "Spends two hero tokens to regain stamina equal to their recovery value."
+          "messageContent": "Spends two hero tokens to regain stamina equal to their recovery value.",
+          "dialogContent": "Spend two of {value} hero tokens to regain stamina equal to recovery value."
         }
       },
       "Malice": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,7 +15,8 @@
       "Other": "Other",
       "TakeRespite": "Take Respite",
       "LevelUp": "Level Up Available",
-      "SpendRecovery": "Spend a recovery to gain recovery value.<br><strong>Shift+Click:</strong> Spend 2 hero tokens to gain recovery without spending a recovery."
+      "SpendRecovery": "Spend a recovery to regain stamina.",
+      "HeroTokenRegainStamina": "Regain Stamina with Hero Tokens"
     },
     "Source": {
       "FIELDS": {
@@ -213,8 +214,8 @@
         "HeroicResourceGain": "Start of turn resource gain",
         "SpendRecovery": {
           "Notifications": {
-            "NoRecovery": "{actor} does not have any recoveries to spend",
-            "Success": "{actor} has regained stamina equal to their recovery value."
+            "NoRecoveries": "{actor} does not have any recoveries to spend.",
+            "Success": "{actor} has spent a recovery to regain stamina."
           }
         }
       },

--- a/src/module/applications/sheets/character.mjs
+++ b/src/module/applications/sheets/character.mjs
@@ -13,6 +13,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
       rollProject: this._rollProject,
       takeRespite: this._takeRespite,
       spendRecovery: this._spendRecovery,
+      spendStaminaHeroToken: this._spendStaminaHeroToken,
     },
   };
 
@@ -211,37 +212,22 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
 
   /**
    * Spend a recovery, adding to the character's stamina and reducing the number of recoveries
-   * Shift + Click: Spend two hero tokens for a free recovery
    * @this DrawSteelCharacterSheet
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
   static async _spendRecovery(event, target) {
-    // If shift clicked prompt for spending hero tokens.
-    if (event.shiftKey) {
-      /** @type {HeroTokenModel} */
-      const heroTokens = game.actors.heroTokens;
-
-      const spend = await foundry.applications.api.DialogV2.confirm({
-        window: {
-          title: "DRAW_STEEL.Setting.HeroTokens.RegainStamina.label",
-        },
-        content: `<p>${game.i18n.format("DRAW_STEEL.Setting.HeroTokens.RegainStamina.dialogContent", {
-          value: heroTokens.value,
-        })}</p>`,
-        rejectClose: false,
-      });
-
-      if (spend) {
-        const valid = await heroTokens.spendToken("regainStamina", { flavor: this.actor.name });
-        if (valid !== false) {
-          await this.actor.system.spendRecovery({ free: true });
-        }
-      }
-      return;
-    }
-
     await this.actor.system.spendRecovery();
+  }
+
+  /**
+   * Spend a recovery, adding to the character's stamina and reducing the number of recoveries
+   * @this DrawSteelCharacterSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   */
+  static async _spendStaminaHeroToken() {
+    await this.actor.system.spendStaminaHeroToken();
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -306,7 +306,7 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
       return this.parent;
     }
 
-    return this.parent.update({ "system.stamina.value": this.stamina.value + stamina });
+    return this.parent.modifyTokenAttribute("stamina", stamina, true);
   }
 
   /**

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -296,6 +296,20 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
   }
 
   /**
+   * Regain stamina equal to the provided value
+   * @param {number} stamina
+   * @returns {DrawSteelActor}
+   */
+  async regainStamina(stamina) {
+    if (!Number.isNumeric(stamina)) {
+      console.error("stamina is required to be a number.");
+      return this.parent;
+    }
+
+    return this.parent.update({ "system.stamina.value": this.stamina.value + stamina });
+  }
+
+  /**
    * Deal damage to the actor, accounting for immunities and resistances
    * @param {number} damage    The amount of damage to take
    * @param {object} [options] Options to modify the damage application

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -296,20 +296,6 @@ export default class BaseActorModel extends foundry.abstract.TypeDataModel {
   }
 
   /**
-   * Regain stamina equal to the provided value
-   * @param {number} stamina
-   * @returns {DrawSteelActor}
-   */
-  async regainStamina(stamina) {
-    if (!Number.isNumeric(stamina)) {
-      console.error("stamina is required to be a number.");
-      return this.parent;
-    }
-
-    return this.parent.modifyTokenAttribute("stamina", stamina, true);
-  }
-
-  /**
    * Deal damage to the actor, accounting for immunities and resistances
    * @param {number} damage    The amount of damage to take
    * @param {object} [options] Options to modify the damage application

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -201,20 +201,6 @@ export default class CharacterModel extends BaseActorModel {
   }
 
   /**
-   * Regain stamina equal to the provided value
-   * @param {number} stamina
-   * @returns {DrawSteelActor}
-   */
-  async regainStamina(stamina) {
-    if (!Number.isNumeric(stamina)) {
-      console.error("stamina is required to be a number.");
-      return this.parent;
-    }
-
-    return this.parent.update({ "system.stamina.value": this.stamina.value + stamina });
-  }
-
-  /**
    * Spend a recovery, adding to the character's stamina and reducing the number of recoveries
    * @returns {Promise<DrawSteelActor}
    */

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -200,6 +200,29 @@ export default class CharacterModel extends BaseActorModel {
     });
   }
 
+  /**
+   * Spend a recovery, adding to the character's stamina and reducing the number of recoveries
+   * @param {object} [options]
+   * @param {boolean} [options.free] Should this character gain the recovery value without spending a recovery
+   * @returns {Promise<DrawSteelActor}
+   */
+  async spendRecovery({ free = false } = {}) {
+    if (!free && (this.hero.recoveries.value === 0)) {
+      ui.notifications.error("DRAW_STEEL.Actor.Character.SpendRecovery.Notifications.NoRecovery", { format: { actor: this.parent.name } });
+      return this.parent;
+    }
+
+    ui.notifications.success("DRAW_STEEL.Actor.Character.SpendRecovery.Notifications.Success", { format: { actor: this.parent.name } });
+
+    const recoveryToSpend = free ? 0 : 1;
+    return this.parent.update({
+      system: {
+        stamina: { value: this.stamina.value + this.hero.recoveries.recoveryValue },
+        hero: { recoveries: { value: this.hero.recoveries.value - recoveryToSpend } },
+      },
+    });
+  }
+
   /** @inheritdoc */
   get reach() {
     return 1 + this.abilityBonuses.melee.distance;

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -213,7 +213,7 @@ export default class CharacterModel extends BaseActorModel {
     ui.notifications.success("DRAW_STEEL.Actor.Character.SpendRecovery.Notifications.Success", { format: { actor: this.parent.name } });
     await this.parent.update({ "system.hero.recoveries.value": this.hero.recoveries.value - 1 });
 
-    return await this.regainStamina(this.hero.recoveries.recoveryValue);
+    return this.parent.modifyTokenAttribute("stamina", this.hero.recoveries.recoveryValue, true);
   }
 
   /**
@@ -237,7 +237,7 @@ export default class CharacterModel extends BaseActorModel {
     if (spend) {
       const valid = await heroTokens.spendToken("regainStamina", { flavor: this.parent.name });
       if (valid !== false) {
-        await this.regainStamina(this.hero.recoveries.recoveryValue);
+        await this.parent.modifyTokenAttribute("stamina", this.hero.recoveries.recoveryValue, true);
       }
     }
     return this.parent;

--- a/templates/actor/character/stats.hbs
+++ b/templates/actor/character/stats.hbs
@@ -4,7 +4,7 @@
     <legend>{{localize "DRAW_STEEL.Sheet.Resources"}}</legend>
     <div class="resource stamina">
       <label class="resource-label">
-        {{systemFields.stamina.label}}
+        <a data-action="spendStaminaHeroToken" data-tooltip="DRAW_STEEL.Sheet.HeroTokenRegainStamina" data-tooltip-direction="UP">{{systemFields.stamina.label}}</a>
       </label>
       <div class="resource-content flexrow">
         {{#if isPlay}}

--- a/templates/actor/character/stats.hbs
+++ b/templates/actor/character/stats.hbs
@@ -43,7 +43,7 @@
     </div>
     <div class="resource recoveries">
       <label class="resource-label">
-        {{systemFields.hero.fields.recoveries.label}}
+        <a data-action="spendRecovery" data-tooltip="DRAW_STEEL.Sheet.SpendRecovery" data-tooltip-direction="UP">{{systemFields.hero.fields.recoveries.label}}</a>
       </label>
       <div class="resource-content flexrow">
         {{#if isPlay}}


### PR DESCRIPTION
Closes #137

- Added `CharacterModel#spendRecovery` that reduces the recovery value by and adds stamina.
- Added `CharacterModel#spendStaminaHeroToken` that prompts the user to spend the tokens and adds stamina.
- Clicking "Recoveries" on the character sheet will spend a recovery
- Clicking "Stamina" on the character sheet will prompt for spending hero tokens