### PR TITLE
Various 13.340 fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -16,7 +16,8 @@
       "TakeRespite": "Take Respite",
       "LevelUp": "Level Up Available",
       "SpendRecovery": "Spend a recovery to regain stamina.",
-      "HeroTokenRegainStamina": "Regain Stamina with Hero Tokens"
+      "HeroTokenRegainStamina": "Regain Stamina with Hero Tokens",
+      "GainSurges": "Spend a hero token to gain two surges."
     },
     "Source": {
       "FIELDS": {

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -14,9 +14,9 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
    * @internal
    */
   static applyDSMovementConfig() {
-    const teleport = { ...CONFIG.Token.movement.actions.blink, label: "TOKEN.MOVEMENT.ACTIONS.teleport.label" };
-
     // Adjusting `Blink (Teleport)` to just be Teleport and maintain its use elsewhere
+    const teleport = { ...CONFIG.Token.movement.actions.blink, label: "TOKEN.MOVEMENT.ACTIONS.teleport.label" };
+    // Optional chaining on canSelect until https://github.com/foundryvtt/foundryvtt/issues/12603 is resolved
     foundry.utils.mergeObject(CONFIG.Token.movement.actions, {
       "-=blink": null,
       teleport,
@@ -29,7 +29,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       },
       /** @type {TokenMovementActionConfig} */
       climb: {
-        canSelect: (token) => !token.hasStatusEffect("prone"),
+        canSelect: (token) => !token?.hasStatusEffect("prone"),
         getCostFunction: (token, _options) => {
           if (token.movementTypes.has("climb")) return cost => cost;
           else return cost => cost * 2;
@@ -37,21 +37,21 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       },
       /** @type {TokenMovementActionConfig} */
       crawl: {
-        canSelect: (token) => token.hasStatusEffect("prone"),
+        canSelect: (token) => token?.hasStatusEffect("prone"),
       },
       /** @type {TokenMovementActionConfig} */
       fly: {
-        canSelect: (token) => !token.hasStatusEffect("prone"),
+        canSelect: (token) => !token?.hasStatusEffect("prone"),
       },
       /** @type {TokenMovementActionConfig} */
       jump: {
-        canSelect: (token) => !token.hasStatusEffect("prone"),
+        canSelect: (token) => !token?.hasStatusEffect("prone"),
         // default for jump is cost * 2
         getCostFunction: () => cost => cost,
       },
       /** @type {TokenMovementActionConfig} */
       swim: {
-        canSelect: (token) => !token.hasStatusEffect("prone"),
+        canSelect: (token) => !token?.hasStatusEffect("prone"),
         getCostFunction: (token, _options) => {
           if (token.movementTypes.has("swim")) return cost => cost;
           else return cost => cost * 2;
@@ -59,7 +59,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       },
       /** @type {TokenMovementActionConfig} */
       walk: {
-        canSelect: (token) => !token.hasStatusEffect("prone"),
+        canSelect: (token) => !token?.hasStatusEffect("prone"),
       },
     }, { performDeletions: true });
   }

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -70,7 +70,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
   /**
    * @typedef WaypointLabelState
    * @property {TokenRulerWaypoint[]} segmentWaypoints
-   * @property  {Set<DrawSteelTokenDocument>} endPointEnemies
+   * @property {Set<DrawSteelTokenDocument>} endPointEnemies
    * @property {object} strikes
    * @property {number} strikes.delta
    * @property {number} strikes.total

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -1,4 +1,5 @@
-/** @import { TokenCompleteMovementWaypoint, TokenMovementActionConfig, TokenRulerWaypoint } from "@client/_types.mjs" */
+/** @import { TokenMovementActionConfig, TokenRulerWaypoint } from "@client/_types.mjs" */
+/** @import DrawSteelTokenDocument from "../../../documents/token.mjs"; */
 
 /**
  * Draw Steel implementation of the core token ruler
@@ -29,7 +30,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       },
       /** @type {TokenMovementActionConfig} */
       climb: {
-        canSelect: (token) => !token?.hasStatusEffect("prone"),
+        canSelect: (token) => !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
         getCostFunction: (token, _options) => {
           if (token.movementTypes.has("climb")) return cost => cost;
           else return cost => cost * 2;
@@ -37,21 +38,21 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       },
       /** @type {TokenMovementActionConfig} */
       crawl: {
-        canSelect: (token) => token?.hasStatusEffect("prone"),
+        canSelect: (token) => (token instanceof TokenDocument) && token.hasStatusEffect("prone"),
       },
       /** @type {TokenMovementActionConfig} */
       fly: {
-        canSelect: (token) => !token?.hasStatusEffect("prone"),
+        canSelect: (token) => !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
       },
       /** @type {TokenMovementActionConfig} */
       jump: {
-        canSelect: (token) => !token?.hasStatusEffect("prone"),
+        canSelect: (token) => !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
         // default for jump is cost * 2
         getCostFunction: () => cost => cost,
       },
       /** @type {TokenMovementActionConfig} */
       swim: {
-        canSelect: (token) => !token?.hasStatusEffect("prone"),
+        canSelect: (token) => !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
         getCostFunction: (token, _options) => {
           if (token.movementTypes.has("swim")) return cost => cost;
           else return cost => cost * 2;
@@ -59,7 +60,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       },
       /** @type {TokenMovementActionConfig} */
       walk: {
-        canSelect: (token) => !token?.hasStatusEffect("prone"),
+        canSelect: (token) => !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
       },
     }, { performDeletions: true });
   }
@@ -67,28 +68,44 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
   /* -------------------------------------------------- */
 
   /**
-   * @param {TokenRulerWaypoint} waypoint
-   * @param {object} state
-   * @inheritdoc */
+   * @typedef WaypointLabelState
+   * @property {TokenRulerWaypoint[]} segmentWaypoints
+   * @property  {Set<DrawSteelTokenDocument>} endPointEnemies
+   * @property {object} strikes
+   * @property {number} strikes.delta
+   * @property {number} strikes.total
+   */
+
+  /**
+   * @param {DeepReadonly<TokenRulerWaypoint>} waypoint
+   * @param {WaypointLabelState} state
+   * @inheritdoc
+   */
   _getWaypointLabelContext(waypoint, state) {
     const context = super._getWaypointLabelContext(waypoint, state);
 
-    if (!this.token.inCombat || !waypoint.previous) return context;
+    if (!this.token.inCombat) return context;
 
-    const points = this.token.document.getCompleteMovementPath([waypoint.previous, waypoint]);
+    state.segmentWaypoints ??= [];
+    state.segmentWaypoints.push(waypoint);
 
-    const startedNear = waypoint.previous?.endPointEnemies ?? new Set();
+    if (!context) return;
+
+    const points = this.token.document.getCompleteMovementPath(state.segmentWaypoints);
+
+    const startedNear = state.endPointEnemies ?? new Set();
     const endPointEnemies = new Set(this.token.document.getHostileTokensFromPoints([points.at(-1)]));
     const passedBy = new Set(this.token.document.getHostileTokensFromPoints(points)).union(startedNear);
     const delta = waypoint.actionConfig.teleport ? 0 : passedBy.difference(endPointEnemies).size;
     const strikes = {
       delta,
-      total: delta + (waypoint.previous?.strikes?.total ?? 0),
+      total: delta + (state.strikes?.total ?? 0),
     };
 
-    Object.assign(waypoint, { endPointEnemies, strikes });
-
-    if (context) Object.assign(context, { strikes });
+    state.endPointEnemies = endPointEnemies;
+    state.strikes = strikes;
+    state.segmentWaypoints = [waypoint];
+    context.strikes = strikes;
 
     return context;
   }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -236,7 +236,7 @@ export default class AbilityModel extends BaseItemModel {
 
         if (distance) {
           // All three tier.damage.value fields should be identical, so their apply change should be identical
-          const formulaField = this.schema.getField(["powerRoll", "tier1", "damage", "value"]);
+          const formulaField = this.schema.getField(["powerRoll", "tier1", "damage", "damage", "value"]);
           for (const tier of PowerRoll.TIER_NAMES) {
             const firstDamageEffect = this.powerRoll[tier].find(effect => effect.type === "damage");
             if (!firstDamageEffect || !bonuses[distance]?.damage?.[tier]) continue;

--- a/templates/actor/character/stats.hbs
+++ b/templates/actor/character/stats.hbs
@@ -86,7 +86,9 @@
       {{/if}}
       <div class="form-group">
         <label>
-          <a data-action="gainSurges">{{systemFields.hero.fields.surges.label}}</a>
+          <a data-action="gainSurges" data-tooltip="DRAW_STEEL.Sheet.GainSurges">
+            {{systemFields.hero.fields.surges.label}}
+          </a>
         </label>
         <div class="form-fields">
           {{formInput systemFields.hero.fields.surges value=system.hero.surges dataset=datasets.notSource}}


### PR DESCRIPTION
- Took another look at how data fields are handled; while the localization loops may be messy, it's better than the alternatives to repetition
  - Fixed new bug in actor data prep related to field path changes (Closes #387)
- Made token ruler adjustments to canSelect logic for prototype token
- Reworked token ruler context prep again (Closes #406)
- Added a tooltip for gaining surges via spending hero tokens on the character sheet