### PR TITLE
Sheet improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Negative stamina now has unique colors in bar. (#315)
 - Added display for hero tokens and malice below the Players list. (#156)
 - Added a prompt at the end of combat to award victories to each character in the combat. (#388)
+- Added ways to spend hero tokens from the character sheet (#54)
 
 ### Changed
 - Changed system minimum to v13.339, verified system for v13 generally.
@@ -54,6 +55,7 @@
   - `teleport` has been preserved as a calculated value from the base speed, prior to active effects and conditions
 - Switched various fontAwesome icons to pro-exclusives. (#274)
 - Various repository refactors. (#253, #290, #301, #325, #338)
+- Made various sheet actions hard private (#397)
 
 ### Fixed
 - Fixed an error preventing combat start if no player-owned characters are in the combat. (#266)

--- a/src/module/applications/apps/power-roll-dialog.mjs
+++ b/src/module/applications/apps/power-roll-dialog.mjs
@@ -5,6 +5,7 @@ import { PowerRoll } from "../../rolls/power.mjs";
 /** @import { PowerRollDialogPrompt } from "./_types" */
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+const { FormDataExtended } = foundry.applications.ux;
 
 /**
  * AppV2-based sheet Power Roll modifications
@@ -120,7 +121,7 @@ export default class PowerRollDialog extends HandlebarsApplicationMixin(Applicat
    */
   _onChangeForm(formConfig, event) {
     super._onChangeForm(formConfig, event);
-    const formData = foundry.utils.expandObject(new foundry.applications.ux.FormDataExtended(this.element).object);
+    const formData = foundry.utils.expandObject(new FormDataExtended(this.element).object);
 
     this.options.context.modifiers = foundry.utils.mergeObject(this.options.context.modifiers, formData.modifiers, { overwrite: true, recursive: true });
     if (this.options.context.targets) this.options.context.targets = foundry.utils.mergeObject(this.options.context.targets, formData.targets, { overwrite: true, recursive: true });
@@ -143,7 +144,7 @@ export default class PowerRollDialog extends HandlebarsApplicationMixin(Applicat
    * @inheritdoc
    */
   async _onSubmitForm(formConfig, event) {
-    const formData = foundry.utils.expandObject(new foundry.applications.ux.FormDataExtended(this.element).object);
+    const formData = foundry.utils.expandObject(new FormDataExtended(this.element).object);
 
     const targets = this.options.context.targets;
     if (!targets || (targets.length === 0)) this.promptValue = { rolls: [this.options.context.modifiers] };

--- a/src/module/applications/apps/power-roll-dialog.mjs
+++ b/src/module/applications/apps/power-roll-dialog.mjs
@@ -19,7 +19,7 @@ export default class PowerRollDialog extends HandlebarsApplicationMixin(Applicat
       width: 400,
     },
     actions: {
-      setRollMode: this.setRollMode,
+      setRollMode: this.#setRollMode,
     },
     tag: "form",
     form: {
@@ -170,7 +170,7 @@ export default class PowerRollDialog extends HandlebarsApplicationMixin(Applicat
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static setRollMode(event, target) {
+  static #setRollMode(event, target) {
     this.options.context.rollMode = target.dataset.rollMode;
     this.render();
   }

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -24,14 +24,14 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
       resizable: true,
     },
     actions: {
-      toggleMode: this._toggleMode,
-      viewDoc: this._viewDoc,
-      createDoc: this._createDoc,
-      deleteDoc: this._deleteDoc,
-      toggleEffect: this._toggleEffect,
-      roll: this._onRoll,
-      useAbility: this._useAbility,
-      toggleItemEmbed: this._toggleItemEmbed,
+      toggleMode: this.#toggleMode,
+      viewDoc: this.#viewDoc,
+      createDoc: this.#createDoc,
+      deleteDoc: this.#deleteDoc,
+      toggleEffect: this.#toggleEffect,
+      roll: this.#onRoll,
+      useAbility: this.#useAbility,
+      toggleItemEmbed: this.#toggleItemEmbed,
     },
     form: {
       submitOnChange: true,
@@ -568,7 +568,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _toggleMode(event, target) {
+  static async #toggleMode(event, target) {
     if (!this.isEditable) {
       console.error("You can't switch to Edit mode if the sheet is uneditable");
       return;
@@ -585,7 +585,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _viewDoc(event, target) {
+  static async #viewDoc(event, target) {
     const doc = this._getEmbeddedDocument(target);
     if (!doc) {
       console.error("Could not find document");
@@ -602,7 +602,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _deleteDoc(event, target) {
+  static async #deleteDoc(event, target) {
     const doc = this._getEmbeddedDocument(target);
     await doc.deleteDialog();
   }
@@ -615,7 +615,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @private
    */
-  static async _createDoc(event, target) {
+  static async #createDoc(event, target) {
     const docCls = getDocumentClass(target.dataset.documentClass);
     const docData = {
       name: docCls.defaultName({ type: target.dataset.type, parent: this.actor }),
@@ -639,7 +639,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @private
    */
-  static async _toggleEffect(event, target) {
+  static async #toggleEffect(event, target) {
     const effect = this._getEmbeddedDocument(target);
     await effect.update({ disabled: !effect.disabled });
   }
@@ -652,7 +652,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _onRoll(event, target) {
+  static async #onRoll(event, target) {
     event.preventDefault();
     const dataset = target.dataset;
 
@@ -671,7 +671,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _useAbility(event, target) {
+  static async #useAbility(event, target) {
     const item = this._getEmbeddedDocument(target);
     if (item?.type !== "ability") {
       console.error("This is not an ability!", item);
@@ -688,7 +688,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _toggleItemEmbed(event, target) {
+  static async #toggleItemEmbed(event, target) {
     const { itemId } = target.closest(".item").dataset;
 
     if (this.#expanded.has(itemId)) this.#expanded.delete(itemId);

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -159,6 +159,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
   /** @inheritdoc */
   async _preparePartContext(partId, context, options) {
     await super._preparePartContext(partId, context, options);
+    const TextEditor = foundry.applications.ux.TextEditor.implementation;
     switch (partId) {
       case "stats":
         context.characteristics = this._getCharacteristics();
@@ -175,7 +176,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
         break;
       case "biography":
         context.languages = this._getLanguages();
-        context.enrichedBiography = await CONFIG.ux.TextEditor.enrichHTML(
+        context.enrichedBiography = await TextEditor.enrichHTML(
           this.actor.system.biography.value,
           {
             secrets: this.document.isOwner,
@@ -183,7 +184,7 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
             relativeTo: this.actor,
           },
         );
-        context.enrichedGMNotes = await CONFIG.ux.TextEditor.enrichHTML(
+        context.enrichedGMNotes = await TextEditor.enrichHTML(
           this.actor.system.biography.gm,
           {
             secrets: this.document.isOwner,

--- a/src/module/applications/sheets/character.mjs
+++ b/src/module/applications/sheets/character.mjs
@@ -9,11 +9,11 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
   static DEFAULT_OPTIONS = {
     classes: ["character"],
     actions: {
-      gainSurges: this._gainSurges,
-      rollProject: this._rollProject,
-      takeRespite: this._takeRespite,
-      spendRecovery: this._spendRecovery,
-      spendStaminaHeroToken: this._spendStaminaHeroToken,
+      gainSurges: this.#gainSurges,
+      rollProject: this.#rollProject,
+      takeRespite: this.#takeRespite,
+      spendRecovery: this.#spendRecovery,
+      spendStaminaHeroToken: this.#spendStaminaHeroToken,
     },
   };
 
@@ -166,7 +166,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _gainSurges(event, target) {
+  static async #gainSurges(event, target) {
     /** @type {HeroTokenModel} */
     const heroTokens = game.actors.heroTokens;
 
@@ -195,7 +195,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _rollProject(event, target) {
+  static async #rollProject(event, target) {
     const project = this._getEmbeddedDocument(target);
     await project.system.roll();
   }
@@ -206,7 +206,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _takeRespite(event, target) {
+  static async #takeRespite(event, target) {
     await this.actor.system.takeRespite();
   }
 
@@ -216,7 +216,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _spendRecovery(event, target) {
+  static async #spendRecovery(event, target) {
     await this.actor.system.spendRecovery();
   }
 
@@ -226,7 +226,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _spendStaminaHeroToken() {
+  static async #spendStaminaHeroToken() {
     await this.actor.system.spendStaminaHeroToken();
   }
 

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -1,6 +1,6 @@
 import { systemPath } from "../../constants.mjs";
 
-const { api, sheets } = foundry.applications;
+const { api, sheets, ux } = foundry.applications;
 
 /**
  * AppV2-based sheet for all item classes
@@ -172,7 +172,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
 
     switch (partId) {
       case "description":
-        context.enrichedDescription = await CONFIG.ux.TextEditor.enrichHTML(
+        context.enrichedDescription = await ux.TextEditor.implementation.enrichHTML(
           this.item.system.description.value,
           {
             secrets: this.document.isOwner,
@@ -180,7 +180,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
             relativeTo: this.item,
           },
         );
-        context.enrichedGMNotes = await CONFIG.ux.TextEditor.enrichHTML(
+        context.enrichedGMNotes = await ux.TextEditor.implementation.enrichHTML(
           this.item.system.description.gm,
           {
             secrets: this.document.isOwner,
@@ -686,7 +686,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
         dragover: this._onDragOver.bind(this),
         drop: this._onDrop.bind(this),
       };
-      return new foundry.applications.ux.DragDrop(d);
+      return new ux.DragDrop.implementation(d);
     });
   }
 

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -20,14 +20,14 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
       resizable: true,
     },
     actions: {
-      toggleMode: this._toggleMode,
-      showImage: this._showImage,
-      updateSource: this._updateSource,
-      editHTML: this._editHTML,
-      viewDoc: this._viewEffect,
-      createDoc: this._createEffect,
-      deleteDoc: this._deleteEffect,
-      toggleEffect: this._toggleEffect,
+      toggleMode: this.#toggleMode,
+      showImage: this.#showImage,
+      updateSource: this.#updateSource,
+      editHTML: this.#editHTML,
+      viewDoc: this.#viewEffect,
+      createDoc: this.#createEffect,
+      deleteDoc: this.#deleteEffect,
+      toggleEffect: this.#toggleEffect,
     },
     form: {
       submitOnChange: true,
@@ -318,7 +318,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _toggleMode(event, target) {
+  static async #toggleMode(event, target) {
     if (!this.isEditable) {
       console.error("You can't switch to Edit mode if the sheet is uneditable");
       return;
@@ -335,7 +335,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _showImage(event, target) {
+  static async #showImage(event, target) {
     const { img, name, uuid } = this.item;
     new foundry.applications.apps.ImagePopout({ src: img, uuid, window: { title: name } }).render({ force: true });
   }
@@ -347,7 +347,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _updateSource(event, target) {
+  static async #updateSource(event, target) {
     this.item.system.source.updateDialog();
   }
 
@@ -379,7 +379,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _editHTML(event, target) {
+  static async #editHTML(event, target) {
     /** @type {HTMLDivElement} */
     const tab = target.closest("section.tab");
     /** @type {HTMLDivElement} */
@@ -414,7 +414,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _viewEffect(event, target) {
+  static async #viewEffect(event, target) {
     const effect = this._getEffect(target);
     effect.sheet.render(true);
   }
@@ -427,7 +427,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @protected
    */
-  static async _deleteEffect(event, target) {
+  static async #deleteEffect(event, target) {
     const effect = this._getEffect(target);
     await effect.delete();
   }
@@ -440,7 +440,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @private
    */
-  static async _createEffect(event, target) {
+  static async #createEffect(event, target) {
     const aeCls = getDocumentClass("ActiveEffect");
     const effectData = {
       name: aeCls.defaultName({ type: target.dataset.type, parent: this.item }),
@@ -462,7 +462,7 @@ export default class DrawSteelItemSheet extends api.HandlebarsApplicationMixin(
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @private
    */
-  static async _toggleEffect(event, target) {
+  static async #toggleEffect(event, target) {
     const effect = this._getEffect(target);
     await effect.update({ disabled: !effect.disabled });
   }

--- a/src/module/applications/sheets/npc.mjs
+++ b/src/module/applications/sheets/npc.mjs
@@ -8,9 +8,9 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
   static DEFAULT_OPTIONS = {
     classes: ["npc"],
     actions: {
-      updateSource: this._updateSource,
-      editMonsterMetadata: this._editMonsterMetadata,
-      freeStrike: this._freeStrike,
+      updateSource: this.#updateSource,
+      editMonsterMetadata: this.#editMonsterMetadata,
+      freeStrike: this.#freeStrike,
     },
   };
 
@@ -172,7 +172,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _updateSource(event, target) {
+  static async #updateSource(event, target) {
     this.actor.system.source.updateDialog();
   }
 
@@ -182,7 +182,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _editMonsterMetadata(event, target) {
+  static async #editMonsterMetadata(event, target) {
     const htmlContainer = document.createElement("div");
     const schema = this.actor.system.schema;
     const monsterData = this.actor.system.monster;
@@ -230,7 +230,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
-  static async _freeStrike(event, target) {
+  static async #freeStrike(event, target) {
     /** @type {Array<DrawSteelActor>} */
     const targets = game.user.targets.map(t => t.actor).filter(a => a?.system?.takeDamage).toObject();
     if (!targets.length) {

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -188,7 +188,7 @@ export default class DrawSteelCombatTracker extends foundry.applications.sidebar
     await super._onRender(context, options);
 
     if (game.settings.get(systemID, "initiativeMode") !== "default") return;
-    new foundry.applications.ux.DragDrop({
+    new foundry.applications.ux.DragDrop.implementation({
       dragSelector: ".combatant",
       dropSelector: ".combatant-group, .combat-tracker",
       permissions: {

--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -77,7 +77,7 @@ export default class BaseItemModel extends foundry.abstract.TypeDataModel {
   async toEmbed(config, options = {}) {
 
     options.rollData ??= this.parent.getRollData();
-    const enriched = await CONFIG.ux.TextEditor.enrichHTML(this.description.value, options);
+    const enriched = await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.description.value, options);
 
     const embed = document.createElement("div");
     embed.classList.add("draw-steel", this.parent.type);

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -99,7 +99,7 @@ export default class KitModel extends BaseItemModel {
       config: ds.CONFIG,
       showDescription: true, // used to prevent showing the description on the details tab of the kit sheet
     };
-    context.enrichedDescription = await CONFIG.ux.TextEditor.enrichHTML(
+    context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
       this.description.value,
       {
         secrets: this.parent.isOwner,

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -115,7 +115,7 @@ export default class ProjectModel extends BaseItemModel {
     const characteristicList = Array.from(this.rollCharacteristic).map(c => ds.CONFIG.characteristics[c]?.label ?? c);
     context.formattedCharacteristics = characteristicFormatter.format(characteristicList);
 
-    if (this.yield.item) context.itemLink = await CONFIG.ux.TextEditor.enrichHTML(`@UUID[${this.yield.item}]`);
+    if (this.yield.item) context.itemLink = await foundry.applications.ux.TextEditor.implementation.enrichHTML(`@UUID[${this.yield.item}]`);
   }
 
   /**

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -26,6 +26,7 @@
     src="{{actor.img}}"
     alt="{{actor.name}}"
     data-action="{{ifThen isPlay "showPortraitArtwork" "editImage"}}"
+    data-edit="img"
     title="{{actor.name}}"
   >
   <div class="header-center flexcol">

--- a/templates/actor/npc/header.hbs
+++ b/templates/actor/npc/header.hbs
@@ -6,6 +6,7 @@
     src="{{actor.img}}"
     alt="{{actor.name}}"
     data-action="{{ifThen isPlay "showPortraitArtwork" "editImage"}}"
+    data-edit="img"
     title="{{actor.name}}"
   >
   <div class="header-center flexcol">


### PR DESCRIPTION
- Added missing data-edit property (Closes #400)
- Refactored access to `foundry.applications.ux` for more consistent use of `implementation`
- Made various sheet actions hard private (Closes #397)