### PR TITLE
[#420] Input:number for characteristics

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -210,11 +210,13 @@ export default class DrawSteelActorSheet extends api.HandlebarsApplicationMixin(
    * @returns {Record<string, {field: NumberField, value: number}>}
    */
   _getCharacteristics() {
-    const data = this.isPlayMode ? this.actor : this.actor._source;
+    const isPlay = this.isPlayMode;
+    const data = isPlay ? this.actor : this.actor._source;
     return Object.keys(ds.CONFIG.characteristics).reduce((obj, chc) => {
+      const value = foundry.utils.getProperty(data, `system.characteristics.${chc}.value`);
       obj[chc] = {
         field: this.actor.system.schema.getField(["characteristics", chc, "value"]),
-        value: foundry.utils.getProperty(data, `system.characteristics.${chc}.value`),
+        value: isPlay ? (value ?? 0) : (value || null),
       };
       return obj;
     }, {});

--- a/templates/actor/shared/partials/stats/characteristics.hbs
+++ b/templates/actor/shared/partials/stats/characteristics.hbs
@@ -8,7 +8,7 @@
   {{else}}
   <label class="characteristic edit" data-tooltip="{{chr.field.label}}">
     <span class="label">{{chr.field.hint}}</span>
-    <input type="text" name="system.characteristics.{{key}}.value" value="{{numberFormat chr.value sign=true}}" data-dtype="Number" data-source="true">
+    {{formInput chr.field value=chr.value type="number" placeholder="0"}}
   </label>
   {{/if}}
   {{/each}}


### PR DESCRIPTION
Closes #420.

Replaces the inputs with `input:number` with a placeholder of "0".

Data preparation is adjusted such that `null` will display as an empty input in edit mode or "+0" in play mode.