### PR TITLE
[#419] Add Dialog class and base Application class

### DIFF
--- a/src/module/applications/_module.mjs
+++ b/src/module/applications/_module.mjs
@@ -1,3 +1,4 @@
+export * as api from "./api/_module.mjs";
 export * as apps from "./apps/_module.mjs";
 export * as hooks from "./hooks/_module.mjs";
 export * as sheets from "./sheets/_module.mjs";

--- a/src/module/applications/api/_module.mjs
+++ b/src/module/applications/api/_module.mjs
@@ -1,0 +1,2 @@
+export { default as DSDialog } from "./dialog.mjs";
+export { default as DSApplication } from "./application.mjs";

--- a/src/module/applications/api/application.mjs
+++ b/src/module/applications/api/application.mjs
@@ -1,0 +1,86 @@
+const { HandlebarsApplicationMixin, Application } = foundry.applications.api;
+
+/**
+ * A stock application meant for async behavior using templates.
+ */
+export default class DSApplication extends HandlebarsApplicationMixin(Application) {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["draw-steel"],
+    form: {
+      handler: DSApplication.#submitHandler,
+      closeOnSubmit: true,
+    },
+    position: {
+      width: 450,
+      height: "auto",
+    },
+    tag: "form",
+    window: {
+      contentClasses: ["standard-form"],
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Stored form data.
+   * @type {object|null}
+   */
+  #config = null;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Stored form data.
+   * @type {object|null}
+   */
+  get config() {
+    return this.#config;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Factory method for asynchronous behavior.
+   * @param {object} options            Application rendering options.
+   * @returns {Promise<object|null>}    A promise that resolves to the form data, or `null`
+   *                                    if the application was closed without submitting.
+   */
+  static async create(options) {
+    const { promise, resolve } = Promise.withResolvers();
+    const application = new this(options);
+    application.addEventListener("close", () => resolve(application.config), { once: true });
+    application.render({ force: true });
+    return promise;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle form submission. The basic usage of this function is to set `#config`
+   * when the form is valid and submitted, thus returning `config: null` when
+   * cancelled, or non-`null` when successfully submitted. The `#config` property
+   * should not be used to store data across re-renders of this application.
+   * @this {DSApplication}
+   * @param {SubmitEvent} event           The submit event.
+   * @param {HTMLFormElement} form        The form element.
+   * @param {FormDataExtended} formData   The form data.
+   */
+  static #submitHandler(event, form, formData) {
+    this.#config = this._processFormData(event, form, formData);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform processing of the submitted data. To prevent submission, throw an error.
+   * @param {SubmitEvent} event           The submit event.
+   * @param {HTMLFormElement} form        The form element.
+   * @param {FormDataExtended} formData   The form data.
+   * @returns {object}                    The data to return from this application.
+   */
+  _processFormData(event, form, formData) {
+    return foundry.utils.expandObject(formData.object);
+  }
+}

--- a/src/module/applications/api/dialog.mjs
+++ b/src/module/applications/api/dialog.mjs
@@ -1,0 +1,10 @@
+export default class DSDialog extends foundry.applications.api.Dialog {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["draw-steel"],
+    position: {
+      width: 400,
+      height: "auto",
+    },
+  };
+}


### PR DESCRIPTION
Re: #419.

This adds a simple subclass `DSDialog` and a basic configuration class `DSApplication`.