### PR TITLE
[#419] Document Sheet Mixin

### DIFF
--- a/src/module/applications/api/_module.mjs
+++ b/src/module/applications/api/_module.mjs
@@ -1,2 +1,3 @@
-export { default as DSDialog } from "./dialog.mjs";
+export { default as DSDocumentSheetMixin } from "./document-sheet-mixin.mjs";
 export { default as DSApplication } from "./application.mjs";
+export { default as DSDialog } from "./dialog.mjs";

--- a/src/module/applications/api/document-sheet-mixin.mjs
+++ b/src/module/applications/api/document-sheet-mixin.mjs
@@ -74,9 +74,9 @@ export default base => {
         document: this.document,
         system: this.document.system,
         systemSource: this.document.system._source,
+        systemFields: this.document.system.schema.fields,
         flags: this.document.flags,
         config: ds.CONFIG,
-        systemFields: this.document.system.schema.fields,
       });
       return context;
     }

--- a/src/module/applications/api/document-sheet-mixin.mjs
+++ b/src/module/applications/api/document-sheet-mixin.mjs
@@ -1,0 +1,84 @@
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+
+export default base => {
+  return class DSDocumentSheet extends HandlebarsApplicationMixin(base) {
+    /** @inheritdoc */
+    static DEFAULT_OPTIONS = {
+      classes: ["draw-steel"],
+      form: {
+        submitOnChange: true,
+        closeOnSubmit: false,
+      },
+      window: {
+        resizable: true,
+      },
+    };
+
+    /* -------------------------------------------------- */
+
+    /**
+     * Available sheet modes.
+     * @enum {number}
+     */
+    static MODES = Object.freeze({
+      PLAY: 1,
+      EDIT: 2,
+    });
+
+    /* -------------------------------------------------- */
+
+    /**
+     * The mode the sheet is currently in.
+     * @type {DSDocumentSheet.MODES}
+     */
+    _mode;
+
+    /* -------------------------------------------------- */
+
+    /**
+     * Is this sheet in Play Mode?
+     * @returns {boolean}
+     */
+    get isPlayMode() {
+      return this._mode === DSDocumentSheet.MODES.PLAY;
+    }
+
+    /* -------------------------------------------------- */
+
+    /**
+     * Is this sheet in Edit Mode?
+     * @returns {boolean}
+     */
+    get isEditMode() {
+      return this._mode === DSDocumentSheet.MODES.EDIT;
+    }
+
+    /* -------------------------------------------------- */
+
+    /** @inheritdoc */
+    _configureRenderOptions(options) {
+      super._configureRenderOptions(options);
+      if (options.mode && this.isEditable) this._mode = options.mode;
+    }
+
+    /* -------------------------------------------------- */
+
+    /** @inheritdoc */
+    async _prepareContext(options) {
+      const context = await super._prepareContext(options);
+      Object.assign(context, {
+        isPlay: this.isPlayMode,
+        owner: this.document.isOwner,
+        limited: this.document.limited,
+        gm: game.user.isGM,
+        document: this.document,
+        system: this.document.system,
+        systemSource: this.document.system._source,
+        flags: this.document.flags,
+        config: ds.CONFIG,
+        systemFields: this.document.system.schema.fields,
+      });
+      return context;
+    }
+  };
+};


### PR DESCRIPTION
Closes #419.

Adds a single mixin intended for use with `ActorSheet` and `ItemSheet` currently. I was conservative in moving things from the existing sheets as I ran out of time and it is possible we may want to use this for other document sheets, such as for effects.

A follow-up PR could likely move the drag-drop handlers into the mixin.