### PR TITLE
Update power roll messages to show formula per target

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1190,6 +1190,8 @@
           "Bane": "Bane",
           "Banes": "Banes",
           "Bonuses": "Bonuses/Penalties",
+          "Bonus": "Bonus",
+          "Penalty": "Penalty",
           "Label": "{number} {mod}"
         },
         "BaseRoll": "Base Power Roll",

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -265,6 +265,16 @@ export class PowerRoll extends DSRoll {
     return (this.dice[0].total >= this.options.criticalThreshold);
   }
 
+  /**
+   * Return a version of the formula that doesn't have the flavor text.
+   * @returns {string}
+   */
+  get flavorlessFormula() {
+    const flavorlessRoll = new this.constructor(this.formula);
+    for (const term of flavorlessRoll.terms) term.options.flavor = "";
+    return flavorlessRoll.formula;
+  }
+
   async _prepareContext({ flavor, isPrivate }) {
     const context = await super._prepareContext({ flavor, isPrivate });
 
@@ -299,6 +309,7 @@ export class PowerRoll extends DSRoll {
 
     context.baseRoll = this.options.baseRoll ?? false;
     context.critical = (this.isCritical || this.isNat20) ? "critical" : "";
+    context.flavorlessFormula = this.flavorlessFormula;
 
     return context;
   }

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -22,11 +22,13 @@ export class PowerRoll extends DSRoll {
     if (!options.appliedModifier) {
 
       // Add edges/banes to formula
-      if (Math.abs(this.netBoon === 1)) {
+      if (Math.abs(this.netBoon) === 1) {
         const operation = new foundry.dice.terms.OperatorTerm({ operator: (this.netBoon > 0 ? "+" : "-") });
         const number = new foundry.dice.terms.NumericTerm({
           number: 2,
-          flavor: game.i18n.localize(this.netBoon > 0 ? "DRAW_STEEL.Roll.Power.Modifier.Edge" : "DRAW_STEEL.Roll.Power.Modifier.Bane"),
+          options: {
+            flavor: game.i18n.localize(this.netBoon > 0 ? "DRAW_STEEL.Roll.Power.Modifier.Edge" : "DRAW_STEEL.Roll.Power.Modifier.Bane"),
+          },
         });
         this.terms.push(operation, number);
       }
@@ -36,7 +38,9 @@ export class PowerRoll extends DSRoll {
         const operation = new foundry.dice.terms.OperatorTerm({ operator: (this.options.bonuses > 0 ? "+" : "-") });
         const number = new foundry.dice.terms.NumericTerm({
           number: Math.abs(this.options.bonuses),
-          flavor: game.i18n.localize("DRAW_STEEL.Roll.Power.Modifier.Bonuses"),
+          options: {
+            flavor: game.i18n.localize(this.options.bonuses > 0 ? "DRAW_STEEL.Roll.Power.Modifier.Bonus" : "DRAW_STEEL.Roll.Power.Modifier.Penalty"),
+          },
         });
         this.terms.push(operation, number);
       }

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -270,6 +270,7 @@ export class PowerRoll extends DSRoll {
    * @returns {string}
    */
   get flavorlessFormula() {
+    // Didn't use this.clone as the formula is already fully derived and doesn't need the roll data or options
     const flavorlessRoll = new this.constructor(this.formula);
     for (const term of flavorlessRoll.terms) term.options.flavor = "";
     return flavorlessRoll.formula;

--- a/src/styles/system/applications/sidebar/tabs/chat.css
+++ b/src/styles/system/applications/sidebar/tabs/chat.css
@@ -1,4 +1,5 @@
-.chat-sidebar {
+.chat-sidebar,
+#chat-notifications {
   .chat-message {
     .powerResult {
       .potency {
@@ -22,6 +23,22 @@
         text-align: center;
         font-size: var(--font-size-16);
         font-weight: bold;
+      }
+
+      .inline-result {
+        display: flex;
+        margin-bottom: 5px;
+
+        .dice-formula {
+          flex: 1 0 calc(100% - 50px);
+          border-radius: 3px 0px 0px 3px;
+          margin-bottom: 0px;
+        }
+
+        .dice-total {
+          flex: 0 0 50px;
+          border-radius: 0px 3px 3px 0px;
+        }
       }
 
       .dice-result {

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -1,30 +1,27 @@
+{{#unless baseRoll}}
 <div class="dice-roll" data-action="expandRoll">
+  {{#if target}}
   <div class="header" data-uuid="{{target.uuid}}">
-    {{#if baseRoll}}
-    {{localize "DRAW_STEEL.Roll.Power.BaseRoll"}}
-    {{else if target}}
     {{target.name}}
-    {{/if}}
   </div>
+  {{/if}}
 
-  {{#unless baseRoll}}
   <div class="tier {{tier.class}}">
     {{tier.label}}
     {{#if modifier.number}}
     <em>({{localize "DRAW_STEEL.Roll.Power.Modifier.Label" number=modifier.number mod=modifier.mod}})</em>
     {{/if}}
   </div>
-  {{/unless}}
   {{#if flavor}}
   <div class="dice-flavor">{{flavor}}</div>
   {{/if}}
   <div class="dice-result">
-    {{#if baseRoll}}
-    <div class="dice-formula">{{formula}}</div>
+    <div class="inline-result">
+      <div class="dice-formula">{{formula}}</div>
+      <div class="dice-total {{critical}}">{{total}}</div>
+    </div>
     {{{tooltip}}}
-    {{/if}}
-    {{#unless baseRoll}}
-    <h4 class="dice-total {{critical}}">{{total}}</h4>
-    {{/unless}}
   </div>
+
 </div>
+{{/unless}}

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -15,9 +15,9 @@
   {{#if flavor}}
   <div class="dice-flavor">{{flavor}}</div>
   {{/if}}
-  <div class="dice-result">
+  <div class="dice-result" data-tooltip="{{formula}}">
     <div class="inline-result">
-      <div class="dice-formula">{{formula}}</div>
+      <div class="dice-formula">{{flavorlessFormula}}</div>
       <div class="dice-total {{critical}}">{{total}}</div>
     </div>
     {{{tooltip}}}


### PR DESCRIPTION
Related to #416

- Per that issue, banes/edges should show in the formula, which requires showing the formula per target. I set it up so that the formula and roll total are on the same line to conserve space when there are many targets.
- I didn't change the `2 Edges` to `Double Edge` as noted in the issue.
- In the process, I noticed banes weren't being applied due to a misplaced closing parenthesis.
- Flavor was also being incorrectly set so I fixed that as well


![power-roll-formula](https://github.com/user-attachments/assets/614e6a33-1e61-4cd5-901d-c85ce6f2a01a)

