### PR TITLE
Pseudo-documents: Document and subtype mixins

### DIFF
--- a/src/module/data/_module.mjs
+++ b/src/module/data/_module.mjs
@@ -10,3 +10,5 @@ export * as fields from "./fields/_module.mjs";
 export * as models from "./models/_module.mjs";
 export * as settings from "./settings/_module.mjs";
 export * as migrations from "./migrations.mjs";
+
+export { default as SubtypeModelMixin } from "./subtype-model-mixin.mjs";

--- a/src/module/data/_types.d.ts
+++ b/src/module/data/_types.d.ts
@@ -13,3 +13,8 @@ export type BarAttribute = {
   value: number,
   max: number
 }
+
+export type SubtypeMetadata = {
+  /* Record of document names of pseudo-documents and the path to the collection. */
+  embedded: Record<string, string>
+}

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -2,6 +2,7 @@ import DrawSteelChatMessage from "../../documents/chat-message.mjs";
 import { PowerRoll } from "../../rolls/power.mjs";
 import { damageTypes, requiredInteger, setOptions } from "../helpers.mjs";
 import SizeModel from "../models/size.mjs";
+import SubtypeModelMixin from "../subtype-model-mixin.mjs";
 
 /** @import { DrawSteelActor, DrawSteelCombatant, DrawSteelCombatantGroup } from "../../documents/_module.mjs"; */
 /** @import AbilityModel from "../item/ability.mjs" */
@@ -12,12 +13,7 @@ const fields = foundry.data.fields;
 /**
  * A base actor model that provides common properties for both characters and npcs
  */
-export default class BaseActorModel extends foundry.abstract.TypeDataModel {
-  /**
-   * Key information about this Actor subtype
-   */
-  static metadata = Object.freeze({});
-
+export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.TypeDataModel) {
   /** @inheritdoc */
   static defineSchema() {
     const characteristic = { min: -5, max: 5, initial: 0, integer: true };

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -12,9 +12,13 @@ const fields = foundry.data.fields;
  */
 export default class CharacterModel extends BaseActorModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    type: "character",
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "character",
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -12,9 +12,13 @@ import SourceModel from "../models/source.mjs";
  */
 export default class NPCModel extends BaseActorModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    type: "npc",
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "npc",
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -2,7 +2,6 @@ import { PowerRollModifiers } from "../../_types.js";
 import DrawSteelItem from "../../documents/item.mjs";
 import SourceModel from "../models/source.mjs";
 
-// TODO: this should extend SubtypeMetadata
 export type ItemMetaData = Readonly<{
   /** The expected `type` value */
   type: string;
@@ -12,7 +11,7 @@ export type ItemMetaData = Readonly<{
   detailsPartial?: string[];
   /** Does this item have advancements? */
   hasAdvancements?: boolean;
-}>
+} & SubtypeMetadata>
 
 declare module "./base.mjs" {
   export default interface BaseItemModel {

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -2,6 +2,7 @@ import { PowerRollModifiers } from "../../_types.js";
 import DrawSteelItem from "../../documents/item.mjs";
 import SourceModel from "../models/source.mjs";
 
+// TODO: this should extend SubtypeMetadata
 export type ItemMetaData = Readonly<{
   /** The expected `type` value */
   type: string;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -15,11 +15,14 @@ const fields = foundry.data.fields;
  */
 export default class AbilityModel extends BaseItemModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "ability",
-    detailsPartial: [systemPath("templates/item/partials/ability.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "ability",
+      detailsPartial: [systemPath("templates/item/partials/ability.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/advancement.mjs
+++ b/src/module/data/item/advancement.mjs
@@ -2,11 +2,14 @@ import BaseItemModel from "./base.mjs";
 
 export default class AdvancementModel extends BaseItemModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "",
-    hasAdvancements: true,
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "",
+      hasAdvancements: true,
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static defineSchema() {

--- a/src/module/data/item/ancestry.mjs
+++ b/src/module/data/item/ancestry.mjs
@@ -5,11 +5,14 @@ import AdvancementModel from "./advancement.mjs";
  */
 export default class AncestryModel extends AdvancementModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "ancestry",
-    invalidActorTypes: ["npc"],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "ancestry",
+      invalidActorTypes: ["npc"],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -1,4 +1,5 @@
 import SourceModel from "../models/source.mjs";
+import SubtypeModelMixin from "../subtype-model-mixin.mjs";
 
 /** @import DrawSteelActor from "../../documents/actor.mjs" */
 
@@ -7,15 +8,17 @@ const fields = foundry.data.fields;
 /**
  * A base item model that provides basic description and source metadata for an item instance
  */
-export default class BaseItemModel extends foundry.abstract.TypeDataModel {
+export default class BaseItemModel extends SubtypeModelMixin(foundry.abstract.TypeDataModel) {
   /**
    * Key information about this item subtype
    * @type {import("./_types").ItemMetaData}
    */
-  static metadata = Object.freeze({
-    type: "base",
-    invalidActorTypes: [],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "base",
+      invalidActorTypes: [],
+    });
+  }
 
   /** @inheritdoc */
   static defineSchema() {

--- a/src/module/data/item/career.mjs
+++ b/src/module/data/item/career.mjs
@@ -6,12 +6,15 @@ import AdvancementModel from "./advancement.mjs";
  */
 export default class CareerModel extends AdvancementModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "career",
-    invalidActorTypes: ["npc"],
-    detailsPartial: [systemPath("templates/item/partials/career.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "career",
+      invalidActorTypes: ["npc"],
+      detailsPartial: [systemPath("templates/item/partials/career.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/class.mjs
+++ b/src/module/data/item/class.mjs
@@ -8,12 +8,15 @@ import AdvancementModel from "./advancement.mjs";
  */
 export default class ClassModel extends AdvancementModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "class",
-    invalidActorTypes: ["npc"],
-    detailsPartial: [systemPath("templates/item/partials/class.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "class",
+      invalidActorTypes: ["npc"],
+      detailsPartial: [systemPath("templates/item/partials/class.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/complication.mjs
+++ b/src/module/data/item/complication.mjs
@@ -6,11 +6,14 @@ import AdvancementModel from "./advancement.mjs";
  */
 export default class ComplicationModel extends AdvancementModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "complication",
-    invalidActorTypes: ["npc"],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "complication",
+      invalidActorTypes: ["npc"],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/culture.mjs
+++ b/src/module/data/item/culture.mjs
@@ -5,11 +5,14 @@ import AdvancementModel from "./advancement.mjs";
  */
 export default class CultureModel extends AdvancementModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "culture",
-    invalidActorTypes: ["npc"],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "culture",
+      invalidActorTypes: ["npc"],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -10,11 +10,14 @@ import BaseItemModel from "./base.mjs";
  */
 export default class EquipmentModel extends BaseItemModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "equipment",
-    detailsPartial: [systemPath("templates/item/partials/equipment.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "equipment",
+      detailsPartial: [systemPath("templates/item/partials/equipment.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/feature.mjs
+++ b/src/module/data/item/feature.mjs
@@ -6,11 +6,14 @@ import BaseItemModel from "./base.mjs";
  */
 export default class FeatureModel extends BaseItemModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "feature",
-    detailsPartial: [systemPath("templates/item/partials/feature.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "feature",
+      detailsPartial: [systemPath("templates/item/partials/feature.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -7,12 +7,15 @@ import BaseItemModel from "./base.mjs";
  */
 export default class KitModel extends BaseItemModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "kit",
-    invalidActorTypes: ["npc"],
-    detailsPartial: [systemPath("templates/item/partials/kit.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "kit",
+      invalidActorTypes: ["npc"],
+      detailsPartial: [systemPath("templates/item/partials/kit.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -14,11 +14,14 @@ const fields = foundry.data.fields;
  */
 export default class ProjectModel extends BaseItemModel {
   /** @inheritdoc */
-  static metadata = Object.freeze({
-    ...super.metadata,
-    type: "project",
-    detailsPartial: [systemPath("templates/item/partials/project.hbs")],
-  });
+  static get metadata() {
+    return foundry.utils.mergeObject(super.metadata, {
+      type: "project",
+      detailsPartial: [systemPath("templates/item/partials/project.hbs")],
+    });
+  }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/src/module/data/subtype-model-mixin.mjs
+++ b/src/module/data/subtype-model-mixin.mjs
@@ -1,0 +1,16 @@
+/** @import { SubtypeMetadata } from "./_types" */
+
+/**
+ * Mixin for common functions used across most or all document subtypes.
+ * @mixin
+ */
+export default base => {
+  return class DrawSteelSystemModel extends base {
+    /** @type {SubtypeMetadata} */
+    static get metadata() {
+      return {
+        embedded: {},
+      };
+    }
+  };
+};

--- a/src/module/documents/_module.mjs
+++ b/src/module/documents/_module.mjs
@@ -10,3 +10,5 @@ export { default as DrawSteelCombatant } from "./combatant.mjs";
 export { default as DrawSteelItem } from "./item.mjs";
 export { default as DrawSteelTokenDocument } from "./token.mjs";
 export { default as DrawSteelUser } from "./user.mjs";
+
+export { default as BaseDocumentMixin } from "./base-document-mixin.mjs";

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -1,7 +1,9 @@
+import BaseDocumentMixin from "./base-document-mixin.mjs";
+
 /**
  * A document subclass adding system-specific behavior and registered in CONFIG.Actor.documentClass
  */
-export default class DrawSteelActor extends foundry.documents.Actor {
+export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.Actor) {
   /**
    * Is this actor a minion?
    * @returns {boolean}

--- a/src/module/documents/base-document-mixin.mjs
+++ b/src/module/documents/base-document-mixin.mjs
@@ -1,0 +1,17 @@
+/**
+ * Mixin for common functions used across most or all document classes in this system.
+ * @mixin
+ */
+export default base => {
+  return class DrawSteelDocument extends base {
+    /** @inheritdoc */
+    getEmbeddedDocument(embeddedName, id, { invalid = false, strict = false } = {}) {
+      const systemEmbeds = this.system.constructor.metadata.embedded ?? {};
+      if (embeddedName in systemEmbeds) {
+        const path = systemEmbeds[embeddedName];
+        return foundry.utils.getProperty(this, path).get(id, { invalid, strict }) ?? null;
+      }
+      return super.getEmbeddedDocument(embeddedName, id, { invalid, strict });
+    }
+  };
+};

--- a/src/module/documents/item.mjs
+++ b/src/module/documents/item.mjs
@@ -1,8 +1,9 @@
+import BaseDocumentMixin from "./base-document-mixin.mjs";
+
 /**
  * A document subclass adding system-specific behavior and registered in CONFIG.Item.documentClass
  */
-export default class DrawSteelItem extends foundry.documents.Item {
-
+export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.Item) {
   /** @inheritdoc */
   getRollData() {
     const rollData = this.actor?.getRollData() ?? {};
@@ -16,6 +17,8 @@ export default class DrawSteelItem extends foundry.documents.Item {
 
     return rollData;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   prepareDerivedData() {


### PR DESCRIPTION
Adds two mixins, one for documents one for subtypes.

The mixin for subtypes lets us define where pseudo-document collections live, mirroring the structure of `Document.metadata.embedded`. This will be a record of document names (such as "PowerRoll") and the path relative to the root document (such as "system.power.rolls").

The mixin for documents lets us define shared functionality for all document classes, currently implementing just `getEmbeddedDocument` - this will allow pseudo-documents to have functional uuids that work with `fromUuid`.

The `metadata` properties have had to be turned into getters - I plan to add the `Record` of pseudo-document subtypes here as well as the application class that they use to render. Having them as static properties would throw an error.