### PR TITLE
Pseudo-documents: Pseudo-document data model

### DIFF
--- a/src/module/data/_module.mjs
+++ b/src/module/data/_module.mjs
@@ -10,5 +10,6 @@ export * as fields from "./fields/_module.mjs";
 export * as models from "./models/_module.mjs";
 export * as settings from "./settings/_module.mjs";
 export * as migrations from "./migrations.mjs";
+export * as pseudoDocuments from "./pseudo-documents/_module.mjs";
 
 export { default as SubtypeModelMixin } from "./subtype-model-mixin.mjs";

--- a/src/module/data/_types.d.ts
+++ b/src/module/data/_types.d.ts
@@ -18,3 +18,14 @@ export type SubtypeMetadata = {
   /* Record of document names of pseudo-documents and the path to the collection. */
   embedded: Record<string, string>
 }
+
+export type PseudoDocumentMetadata = {
+  /* The document name of this pseudo-document. */
+  documentName: string,
+  /* Record of document names of pseudo-documents and the path to the collection. */
+  embedded: Record<string, string>,
+  /* A record of this pseudo-document's base class and subtypes. */
+  types?: Record<string, typeof PseudoDocument>,
+  /* The class used to render this pseudo-document. */
+  sheetClass?: PseudoDocumentSheet,
+}

--- a/src/module/data/pseudo-documents/_module.mjs
+++ b/src/module/data/pseudo-documents/_module.mjs
@@ -1,0 +1,2 @@
+export { default as PseudoDocument } from "./pseudo-document.mjs";
+export { default as TypedPseudoDocument } from "./typed-pseudo-document.mjs";

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -1,4 +1,4 @@
-const { DocumentIdField, StringField } = foundry.data.fields;
+const { DocumentIdField } = foundry.data.fields;
 
 /** @import { PseudoDocumentMetadata } from "../../_types" */
 
@@ -96,6 +96,8 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
 
   /**
    * Reference to the sheet of this pseudo-document, registered in a static map.
+   * A pseudo-document is temporary, unlike regular documents, so the relation here
+   * is not one-to-one.
    * @type {PseudoDocumentSheet|null}
    */
   get sheet() {

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -1,0 +1,272 @@
+const { DocumentIdField, StringField } = foundry.data.fields;
+
+/** @import { PseudoDocumentMetadata } from "../../_types" */
+
+export default class PseudoDocument extends foundry.abstract.DataModel {
+  /**
+   * Pseudo-document metadata.
+   * @type {PseudoDocumentMetadata}
+   */
+  static get metadata() {
+    return {
+      documentName: null,
+      embedded: {},
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Registered sheets.
+   * @type {Map<string, PseudoDocumentSheet>}
+   */
+  static #sheets = new Map();
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The id of this pseudo-document.
+   * @type {string}
+   */
+  get id() {
+    return this._id;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The document name of this pseudo document.
+   * @type {string}
+   */
+  get documentName() {
+    return this.constructor.metadata.documentName;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The uuid of this document.
+   * @type {string}
+   */
+  get uuid() {
+    let parent = this.parent;
+    while (!(parent instanceof PseudoDocument) && !(parent instanceof foundry.abstract.Document)) parent = parent.parent;
+    return [parent.uuid, this.documentName, this.id].join(".");
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The parent document of this pseudo-document.
+   * @type {Document}
+   */
+  get document() {
+    let parent = this;
+    while (!(parent instanceof foundry.abstract.Document)) parent = parent.parent;
+    return parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The property path to this pseudo document relative to its parent document.
+   * @type {string}
+   */
+  get fieldPath() {
+    const fp = this.schema.fieldPath;
+    let path = fp.slice(0, fp.lastIndexOf("element") - 1);
+
+    if (this.parent instanceof PseudoDocument) {
+      path = [this.parent.fieldPath, this.parent.id, path].join(".");
+    }
+
+    return path;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Reference to the sheet of this pseudo-document, registered in a static map.
+   * @type {PseudoDocumentSheet|null}
+   */
+  get sheet() {
+    if (!PseudoDocument.#sheets.has(this.uuid)) {
+      const Cls = this.constructor.metadata.sheetClass;
+      if (!Cls) return null;
+      PseudoDocument.#sheets.set(this.uuid, new Cls({ document: this }));
+    }
+    return PseudoDocument.#sheets.get(this.uuid);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Destroy a sheet.
+   * @param {string} uuid   The uuid of the pseudo-document.
+   */
+  static _removeSheet(uuid) {
+    PseudoDocument.#sheets.delete(uuid);
+  }
+
+  /* -------------------------------------------------- */
+  /*   Data preparation                                 */
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _initialize(...args) {
+    super._initialize(...args);
+    this.prepareData();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare data.
+   */
+  prepareData() {
+    this.prepareBaseData();
+    this.prepareDerivedData();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepase base data.
+   */
+  prepareBaseData() {}
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare derived data.
+   */
+  prepareDerivedData() {}
+
+  /* -------------------------------------------------- */
+  /*   Instance Methods                                 */
+  /* -------------------------------------------------- */
+
+  /**
+   * Retrieve an embedded pseudo-document.
+   * @param {string} embeddedName         The document name of the embedded pseudo-document.
+   * @param {string} id                   The id of the embedded pseudo-document.
+   * @param {object} [options]            Retrieval options.
+   * @param {boolean} [options.invalid]   Retrieve an invalid pseudo-document?
+   * @param {boolean} [options.strinct]   Throw an error if the embedded pseudo-document does not exist?
+   * @returns {PseudoDocument|null}
+   */
+  getEmbeddedDocument(embeddedName, id, { invalid = false, strict = false } = {}) {
+    const embeds = this.constructor.metadata.embedded ?? {};
+    if (embeddedName in embeds) {
+      const path = embeds[embeddedName];
+      return foundry.utils.getProperty(this, path).get(id, { invalid, strict }) ?? null;
+    }
+    return null;
+  }
+
+  /* -------------------------------------------------- */
+  /*   CRUD Handlers                                    */
+  /* -------------------------------------------------- */
+
+  /**
+   * Does this pseudo-document exist in the document's source?
+   * @type {boolean}
+   */
+  get isSource() {
+    const source = foundry.utils.getProperty(this.document._source, this.fieldPath);
+    if (foundry.utils.getType(source) !== "Object") {
+      throw new Error("Source is not an object!");
+    }
+    return this.id in source;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create a new instance of this pseudo-document.
+   * @param {object} [data]                                 The data used for the creation.
+   * @param {object} operation                              The context of the operation.
+   * @param {foundry.abstract.Document} operation.parent    The parent of this document.
+   * @returns {Promise<foundry.abstract.Document>}          A promise that resolves to the updated document.
+   */
+  static async create(data = {}, { parent, ...operation } = {}) {
+    if (!parent) {
+      throw new Error("A parent document must be specified for the creation of a pseudo-document!");
+    }
+    const id = operation.keepId && foundry.data.validators.isValidId(data._id) ? data._id : foundry.utils.randomID();
+
+    const fieldPath = parent.system.constructor.metadata.embedded?.[this.metadata.documentName];
+    if (!fieldPath) {
+      throw new Error(`A ${parent.documentName} of type '${parent.type}' does not support ${this.metadata.documentName}!`);
+    }
+
+    const update = { [`${fieldPath}.${id}`]: { ...data, _id: id } };
+    this._configureUpdates("create", parent, update, operation);
+    return parent.update(update, operation);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Delete this pseudo-document.
+   * @param {object} [operation]                      The context of the operation.
+   * @returns {Promise<foundry.abstract.Document>}    A promise that resolves to the updated document.
+   */
+  async delete(operation = {}) {
+    if (!this.isSource) throw new Error("You cannot delete a non-source pseudo-document!");
+    Object.assign(operation, { pseudo: { operation: "delete", type: this.constructor.documentName, uuid: this.uuid } });
+    const update = { [`${this.fieldPath}.-=${this.id}`]: null };
+    this.constructor._configureUpdates("delete", this.document, update, operation);
+    return this.document.update(update, operation);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Duplicate this pseudo-document.
+   * @returns {Promise<foundry.abstract.Document>}    A promise that resolves to the updated document.
+   */
+  async duplicate() {
+    if (!this.isSource) throw new Error("You cannot duplicate a non-source pseudo-document!");
+    const activityData = foundry.utils.mergeObject(this.toObject(), {
+      name: game.i18n.format("DOCUMENT.CopyOf", { name: this.name }),
+    });
+    return this.constructor.create(activityData, { parent: this.document });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Update this pseudo-document.
+   * @param {object} [change]                         The change to perform.
+   * @param {object} [operation]                      The context of the operation.
+   * @returns {Promise<foundry.abstract.Document>}    A promise that resolves to the updated document.
+   */
+  async update(change = {}, operation = {}) {
+    if (!this.isSource) throw new Error("You cannot update a non-source pseudo-document!");
+    const path = [this.fieldPath, this.id].join(".");
+    const update = { [path]: change };
+    this.constructor._configureUpdates("update", this.document, update, operation);
+    return this.document.update(update, operation);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Allow for subclasses to configure the CRUD workflow.
+   * @param {"create"|"update"|"delete"} action     The operation.
+   * @param {foundry.abstract.Document} document    The parent document.
+   * @param {object} update                         The data used for the update.
+   * @param {object} operation                      The context of the operation.
+   */
+  static _configureUpdates(action, document, update, operation) {}
+}

--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -1,0 +1,65 @@
+import PseudoDocument from "./pseudo-document.mjs";
+
+const { StringField } = foundry.data.fields;
+
+export default class TypedPseudoDocument extends PseudoDocument {
+  /** @inheritdoc */
+  static get metadata() {
+    return {
+      ...super.metadata,
+      types: null,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      type: new StringField({
+        initial: () => this.TYPE,
+        required: true,
+        blank: false,
+        readonly: true,
+        validate: value => value === this.TYPE,
+        validationError: `Type can only be '${this.TYPE}'.`,
+      }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The type of this pseudo-document subclass.
+   * @type {string}
+   * @abstract
+   */
+  static get TYPE() {
+    return "";
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The subtypes of this pseudo-document.
+   * @type {Record<string, typeof PseudoDocument>}
+   */
+  static get TYPES() {
+    return Object.values(this.metadata.types).reduce((acc, Cls) => {
+      if (Cls.TYPE) acc[Cls.TYPE] = Cls;
+      return acc;
+    }, {});
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static async create(data = {}, { parent, ...operation } = {}) {
+    data = foundry.utils.deepClone(data);
+    if (!data.type) data.type = Object.keys(this.TYPES)[0];
+    if (!(data.type in this.TYPES)) {
+      throw new Error(`The '${data.type}' type is not a valid type for a '${this.metadata.documentName}' pseudo-document!`);
+    }
+    return super.create(data, { parent, ...operation });
+  }
+}


### PR DESCRIPTION
Adds the base pseudo-document datamodels from which all other pseudo-documents will inherit.

Pseudo-documents will support having pseudo-document collections themselves, and can either
- be an untyped PseudoDocument, which is a subtype that inherits from `PseudoDocument`.
- have multiple subtypes (think akin to dnd5e activities) which would benefit from having one "base" model the subtypes inherit from - these should inherit from `TypedPseudoDocument`.
