### PR TITLE
Pseudo-documents: Pseudo-document sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1156,6 +1156,14 @@
       "Psychic": "Psychic",
       "Sonic": "Sonic"
     },
+    "PSEUDO": {
+      "SHEET": {
+        "TABS": {
+          "details": "Details",
+          "identity": "Identity"
+        }
+      }
+    },
     "Roll": {
       "Prompt": "Roll {prompt}",
       "Power": {

--- a/src/module/applications/api/_module.mjs
+++ b/src/module/applications/api/_module.mjs
@@ -1,3 +1,4 @@
 export { default as DSDocumentSheetMixin } from "./document-sheet-mixin.mjs";
 export { default as DSApplication } from "./application.mjs";
 export { default as DSDialog } from "./dialog.mjs";
+export { default as PseudoDocumentSheet } from "./pseudo-document-sheet.mjs";

--- a/src/module/applications/api/pseudo-document-sheet.mjs
+++ b/src/module/applications/api/pseudo-document-sheet.mjs
@@ -1,0 +1,243 @@
+const { HandlebarsApplicationMixin, Application } = foundry.applications.api;
+
+export default class PseudoDocumentSheet extends HandlebarsApplicationMixin(Application) {
+  constructor(options) {
+    super(options);
+    this.#pseudoUuid = options.document.uuid;
+    this.#document = options.document.document;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    id: "{id}",
+    actions: {
+      copyUuid: {
+        handler: PseudoDocumentSheet.#copyUuid,
+        buttons: [0, 2],
+      },
+    },
+    classes: ["draw-steel"],
+    form: {
+      handler: PseudoDocumentSheet.#onSubmitForm,
+      submitOnChange: true,
+    },
+    position: {
+      width: 500,
+      height: "auto",
+    },
+    tag: "form",
+    window: {
+      contentClasses: ["standard-form"],
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    tabs: {
+      template: "templates/generic/tab-navigation.hbs",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static TABS = {
+    primary: {
+      tabs: [
+        { id: "identity", icon: "fa-solid fa-tag" },
+        { id: "details", icon: "fa-solid fa-pen-fancy" },
+      ],
+      initial: "identity",
+      labelPrefix: "DRAW_STEEL.PSEUDO.SHEET.TABS",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Registered sheets.
+   * @type {Map<string, PseudoDocumentSheet>}
+   */
+  static #sheets = new Map();
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Retrieve or register a new instance of a pseudo-document sheet.
+   * @param {ds.data.pseudoDocuments.PseudoDocument} pseudoDocument   The pseudo-document.
+   * @returns {PseudoDocumentSheet|null}    A new or already registered sheet.
+   */
+  static _registerSheet(pseudoDocument) {
+    if (!PseudoDocumentSheet.#sheets.has(pseudoDocument.uuid)) {
+      const Cls = pseudoDocument.constructor.metadata.sheetClass;
+      if (!Cls) return null;
+      PseudoDocumentSheet.#sheets.set(pseudoDocument.uuid, new Cls({ document: pseudoDocument }));
+    }
+    return PseudoDocumentSheet.#sheets.get(pseudoDocument.uuid);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  tabGroups = {};
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Stored uuid of this pseudo document.
+   * @type {string}
+   */
+  #pseudoUuid;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The pseudo-document. This can be null if a parent pseudo-document is removed.
+   * @type {PseudoDocument|null}
+   */
+  get pseudoDocument() {
+    let relative = this.document;
+    const uuidParts = this.#pseudoUuid.replace(relative.uuid, "").slice(1).split(".");
+    for (let i = 0; i < uuidParts.length; i += 2) {
+      const dname = uuidParts[i];
+      const id = uuidParts[i + 1];
+      relative = relative?.getEmbeddedDocument(dname, id);
+      if (!relative) return null;
+    }
+    return relative;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The parent document.
+   * @type {Document}
+   */
+  #document;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The parent document.
+   * @type {Document}
+   */
+  get document() {
+    return this.#document;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get title() {
+    const { documentName, name, id } = this.pseudoDocument;
+    return `${game.i18n.localize(`DOCUMENT.${documentName}`)}: ${name ? name : id}`;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _initializeApplicationOptions({ document, ...options }) {
+    options = super._initializeApplicationOptions(options);
+    options.uniqueId = `${this.constructor.name}-${document.uuid.replaceAll(".", "-")}`;
+    return options;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onFirstRender(context, options) {
+    await super._onFirstRender(context, options);
+    this.document.apps[this.id] = this;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onClose(options) {
+    super._onClose(options);
+    PseudoDocumentSheet.#sheets.delete(this.#pseudoUuid);
+    delete this.document.apps[this.id];
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Utility context preparation method for individual fields.
+   * @param {string} path   The path to the given field, relative to the root of the pseudo document.
+   * @returns {object}      Field context.
+   */
+  _prepareField(path) {
+    const doc = this.pseudoDocument;
+    const field = doc.schema.getField(path);
+    const value = foundry.utils.getProperty(doc, path);
+    const src = foundry.utils.getProperty(doc._source, path);
+    return { field, value, src, name: path };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _renderFrame(options) {
+    const frame = await super._renderFrame(options);
+    const copyLabel = game.i18n.localize("SHEETS.CopyUuid");
+
+    const properties = Object.entries({
+      type: "button",
+      class: "header-control fa-solid fa-passport icon",
+      "data-action": "copyUuid",
+      "data-tooltip": copyLabel,
+      "aria-label": copyLabel,
+    }).map(([k, v]) => `${k}="${v}"`).join(" ");
+    const copyId = `<button ${properties}></button>`;
+    this.window.close.insertAdjacentHTML("beforebegin", copyId);
+    return frame;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _canRender(options) {
+    if (!this.pseudoDocument) {
+      if (this.rendered) this.close();
+      return false;
+    }
+  }
+
+  /* -------------------------------------------------- */
+  /*   Event handlers                                   */
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle form submission.
+   * @this {PseudoDocumentSheet}
+   * @param {PointerEvent} event            The originating click event.
+   * @param {HTMLElement} form              The form element.
+   * @param {FormDataExtended} formData     The form data.
+   */
+  static #onSubmitForm(event, form, formData) {
+    const submitData = foundry.utils.expandObject(formData.object);
+    this.pseudoDocument.update(submitData);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this {PseudoDocumentSheet}
+   * @param {PointerEvent} event      The originating click event.
+   */
+  static #copyUuid(event) {
+    event.preventDefault(); // Don't open context menu
+    event.stopPropagation(); // Don't trigger other events
+    if (event.detail > 1) return; // Ignore repeated clicks
+    const pseudo = this.pseudoDocument;
+    const id = (event.button === 2) ? pseudo.id : pseudo.uuid;
+    const type = (event.button === 2) ? "id" : "uuid";
+    const label = game.i18n.localize(`DOCUMENT.${pseudo.documentName}`);
+    game.clipboard.copyPlainText(id);
+    ui.notifications.info("DOCUMENT.IdCopiedClipboard", { format: { label, type, id } });
+  }
+}

--- a/src/module/applications/api/pseudo-document-sheet.mjs
+++ b/src/module/applications/api/pseudo-document-sheet.mjs
@@ -36,15 +36,6 @@ export default class PseudoDocumentSheet extends HandlebarsApplicationMixin(Appl
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static PARTS = {
-    tabs: {
-      template: "templates/generic/tab-navigation.hbs",
-    },
-  };
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
   static TABS = {
     primary: {
       tabs: [

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -16,14 +16,6 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
 
   /* -------------------------------------------------- */
 
-  /**
-   * Registered sheets.
-   * @type {Map<string, PseudoDocumentSheet>}
-   */
-  static #sheets = new Map();
-
-  /* -------------------------------------------------- */
-
   /** @inheritdoc */
   static defineSchema() {
     return {
@@ -98,25 +90,10 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * Reference to the sheet of this pseudo-document, registered in a static map.
    * A pseudo-document is temporary, unlike regular documents, so the relation here
    * is not one-to-one.
-   * @type {PseudoDocumentSheet|null}
+   * @type {ds.applications.api.PseudoDocumentSheet|null}
    */
   get sheet() {
-    if (!PseudoDocument.#sheets.has(this.uuid)) {
-      const Cls = this.constructor.metadata.sheetClass;
-      if (!Cls) return null;
-      PseudoDocument.#sheets.set(this.uuid, new Cls({ document: this }));
-    }
-    return PseudoDocument.#sheets.get(this.uuid);
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Destroy a sheet.
-   * @param {string} uuid   The uuid of the pseudo-document.
-   */
-  static _removeSheet(uuid) {
-    PseudoDocument.#sheets.delete(uuid);
+    return ds.applications.api.PseudoDocumentSheet._registerSheet(this);
   }
 
   /* -------------------------------------------------- */
@@ -124,8 +101,8 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _initialize(...args) {
-    super._initialize(...args);
+  _initialize(options = {}) {
+    super._initialize(options);
     this.prepareData();
   }
 


### PR DESCRIPTION
Adds the base API for a pseudo-document sheet whose purpose is to configure a single pseudo-document standalone. The sheet registers as an app for the base document, not the pseudo-document, and re-renders on any updates.

If the root document, a parent pseudo-document, or the pseudo-document itself is deleted, the sheet will close with no errors as intended.

A lot of the behavior is mimicking `DocumentSheet`, but saving a reference to the pseudo-document's uuid - this allows for dynamically fetching the current iteration of the pseudo-document, as unlike documents a pseudo-document is not itself updated but reinstantiated.

While the sheet could use `fromUuidSync`, this of course results in an error if the root document is in a compendium.