### PR TITLE
Implement scaffolding of power roll effects in Ability items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,7 @@
 {
+  "DOCUMENT": {
+    "PowerRollEffect": "Power Roll Effect"
+  },
   "DRAW_STEEL": {
     "Sheet": {
       "Labels": {

--- a/src/module/applications/sheets/_module.mjs
+++ b/src/module/applications/sheets/_module.mjs
@@ -4,3 +4,5 @@ export { default as DrawSteelCharacterSheet } from "./character.mjs";
 export { default as DrawSteelCombatantGroupConfig } from "./combatant-group-config.mjs";
 export { default as DrawSteelItemSheet } from "./item-sheet.mjs";
 export { default as DrawSteelNPCSheet } from "./npc.mjs";
+
+export * as pseudoDocuments from "./pseudo-documents/_module.mjs";

--- a/src/module/applications/sheets/pseudo-documents/_module.mjs
+++ b/src/module/applications/sheets/pseudo-documents/_module.mjs
@@ -1,0 +1,1 @@
+export { default as PowerRollEffectSheet } from "./power-roll-effect-sheet.mjs";

--- a/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
@@ -1,0 +1,10 @@
+import PseudoDocumentSheet from "../../api/pseudo-document-sheet.mjs";
+
+export default class PowerRollEffectSheet extends PseudoDocumentSheet {
+  /** @inheritdoc */
+  static PARTS = {
+    tabs: {
+      template: "templates/generic/tab-navigation.hbs",
+    },
+  };
+}

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -67,7 +67,6 @@ export default class AbilityModel extends BaseItemModel {
       effects: new ds.data.fields.CollectionField(ds.data.pseudoDocuments.powerRollEffects.BasePowerRollEffect),
     });
 
-    // TODO: move these into `power`?
     schema.effect = new fields.StringField({ required: true });
     schema.spend = new fields.SchemaField({
       value: new fields.NumberField({ integer: true }),

--- a/src/module/data/pseudo-documents/_module.mjs
+++ b/src/module/data/pseudo-documents/_module.mjs
@@ -1,2 +1,4 @@
+export * as powerRollEffects from "./power-roll-effects/_module.mjs";
+
 export { default as PseudoDocument } from "./pseudo-document.mjs";
 export { default as TypedPseudoDocument } from "./typed-pseudo-document.mjs";

--- a/src/module/data/pseudo-documents/power-roll-effects/_module.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/_module.mjs
@@ -1,0 +1,2 @@
+export { default as BasePowerRollEffect } from "./base-power-roll-effect.mjs";
+export { default as DamagePowerRollEffect } from "./damage-effect.mjs";

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -1,0 +1,20 @@
+import TypedPseudoDocument from "../typed-pseudo-document.mjs";
+
+export default class BasePowerRollEffect extends TypedPseudoDocument {
+  /** @inheritdoc */
+  static get metadata() {
+    return {
+      ...super.metadata,
+      documentName: "PowerRollEffect",
+      sheetClass: ds.applications.sheets.pseudoDocuments.PowerRollEffectSheet,
+      types: ds.data.pseudoDocuments.powerRollEffects,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {});
+  }
+}

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -1,0 +1,15 @@
+import BasePowerRollEffect from "./base-power-roll-effect.mjs";
+
+export default class DamagePowerRollEffect extends BasePowerRollEffect {
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {});
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static get TYPE() {
+    return "damage";
+  }
+}


### PR DESCRIPTION
Showing an example use of the new `CollectionField` and a `PseudoDocument`, this implements `PowerRollEffect`, a typed pseudo-document, residing in a collection at `system.power.effects` in `ability`-items.

No UI yet, but the sheet can render. To test:

```js
const item = /* my ability item */
await ds.data.pseudoDocuments.powerRollEffects.BasePowerRollEffect.create({ type: "damage" }, { parent: item });
item.system.power.effects.contents[0].sheet.render({ force: true });
```