### PR TITLE
Remove unfilled origin button interactivity in play mode

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
         "CombatantGroup": "Draw Steel Combatant Group Config"
       },
       "Add": "+ Add {itemName}",
+      "NoDocument": "No {documentName}",
       "Play": "Play",
       "Edit": "Edit",
       "Resources": "Resources",

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -402,7 +402,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
   async _onFirstRender(context, options) {
     await super._onFirstRender(context, options);
 
-    this._createContextMenu(this._getItemButtonContextOptions, "[data-document-class]", {
+    this._createContextMenu(this._getItemButtonContextOptions, "[data-document-class][data-item-id], [data-document-class][data-effect-id]", {
       hookName: "getItemButtonContextOptions",
       parentClassHooks: false,
       fixed: true,

--- a/templates/actor/character/header.hbs
+++ b/templates/actor/character/header.hbs
@@ -12,9 +12,15 @@
   {{/unless}}
 </span>
 {{else}}
+{{#if isPlay}}
+<span class="unfilled">
+  {{localize "DRAW_STEEL.Sheet.NoDocument" documentName=(localize (concat "TYPES.Item." originType))}}
+</span>
+{{else}}
 <a class="unfilled" data-action="createDoc" data-document-class="Item" data-type="{{originType}}" data-render-sheet="true">
   {{localize "DRAW_STEEL.Sheet.Add" itemName=(localize (concat "TYPES.Item." originType))}}
 </a>
+{{/if}}
 {{/if}}
 {{/inline}}
 


### PR DESCRIPTION
Closes #412 

- In play mode, updated unfilled origin items to be a span displaying "No Class", "No Ancestry", etc. Having them saying "+ Add Class" without having interactivity seemed counterintuitive.
- Updated the context menu css selector to only create if it has `data-document-class` and either `data-item-id` or `data-effect-id`. This also stops it from creating on the other document create buttons (project, equipment, ability, etc) on the sheet.