### PR TITLE
Update biography editors

### DIFF
--- a/templates/actor/shared/partials/biography/biography.hbs
+++ b/templates/actor/shared/partials/biography/biography.hbs
@@ -1,16 +1,14 @@
-{{#if editable}}
-{{formGroup
-systemFields.biography.fields.value
-enriched=enrichedBiography
-value=systemSource.biography.value
-documentUUID=document.uuid
-collaborate=true
-toggled=isPlay
-height=200
-}}
-{{else}}
 <fieldset>
   <legend>{{systemFields.biography.fields.value.label}}</legend>
+  {{#if (and editable (not isPlay))}}
+  {{formInput
+  systemFields.biography.fields.value
+  value=systemSource.biography.value
+  documentUUID=document.uuid
+  collaborate=true
+  height=200
+  }}
+  {{else}}
   {{{enrichedBiography}}}
+  {{/if}}
 </fieldset>
-{{/if}}

--- a/templates/actor/shared/partials/biography/gm-notes.hbs
+++ b/templates/actor/shared/partials/biography/gm-notes.hbs
@@ -1,17 +1,13 @@
-{{#if gm}}
-{{#if editable}}
-{{formGroup
-systemFields.biography.fields.gm
-enriched=enrichedGMNotes
-value=systemSource.biography.gm
-documentUUID=document.uuid
-toggled=isPlay
-height=300
-}}
-{{else}}
 <fieldset>
   <legend>{{systemFields.biography.fields.gm.label}}</legend>
+  {{#if (and gm editable (not isPlay))}}
+  {{formInput
+  systemFields.biography.fields.gm
+  value=systemSource.biography.gm
+  documentUUID=document.uuid
+  height=200
+  }}
+  {{else}}
   {{{enrichedGMNotes}}}
+  {{/if}}
 </fieldset>
-{{/if}}
-{{/if}}


### PR DESCRIPTION
Closes #414 

- Instead of just marking them as disabled in play mode, I've changed it so that the editor only shows when in edit mode. Otherwise it just shows the enriched version. With a disabled editor, the description still takes up the editors height and could leave a lot of empty space. With this approach, it only takes up the necessary amount of space.
- There was also a fieldset used when it wasn't editable, but not when it was editable, so I just moved it all to a fieldset.

![edit-bio](https://github.com/user-attachments/assets/e3435322-42f5-4a55-bac5-c0d4cb49fd2e)
![play-bio](https://github.com/user-attachments/assets/670f472e-82fb-4163-808d-421590f8f3e6)
