### PR TITLE
Psseudo-document sheet fix and tier rendering context.

### DIFF
--- a/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
@@ -52,36 +52,8 @@ export default class PowerRollEffectSheet extends PseudoDocumentSheet {
     // TODO: add placeholder equal to the "default" text this effect would display
     context.fields.text = this._prepareField("text");
 
-    switch (context.pseudo.type) {
-      case "damage":
-        await this.#prepareDamageFields(context);
-        break;
-    }
+    await context.pseudo._tierRenderingContext?.(context);
 
     return context;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Prepare fields specific to the `damage` effect.
-   * @param {object} context    Rendering context. **will be mutated**
-   * @returns {Promise<void>}   A promise that resolves once the context has been mutated.
-   */
-  async #prepareDamageFields(context) {
-    context.fields.text.placeholder = "{{damage}}";
-    for (const n of [1, 2, 3]) {
-      context.fields[`tier${n}`].damage = {
-        value: Object.assign(this._prepareField(`damage.tier${n}.value`), {
-          placeholder: (n === 1)
-            ? "1"
-            : (n === 2)
-              ? 2 * context.fields.tier1.damage.value.value
-              : 3 * context.fields.tier1.damage.value.value,
-        }),
-        types: this._prepareField(`damage.tier${n}.types`),
-      };
-    }
-    context.fields.damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([k, v]) => ({ value: k, label: v.label }));
   }
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -41,4 +41,13 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
       tier3: new SchemaField(fieldsFn()),
     });
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Implement rendering context for tiers 1-3.
+   * @param {object} context    Rendering context. **will be mutated**
+   * @returns {Promise<void>}   A promise that resolves once the rendering context has been mutated.
+   */
+  async _tierRenderingContext(context) {}
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -37,7 +37,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
       this.damage[`tier${n}`].value ??= this.#defaultDamageValue(n);
     }
 
-    this.text ||= "{{damage}}";
+    // this.text ||= "{{damage}}";
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -33,10 +33,55 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
   prepareDerivedData() {
     super.prepareDerivedData();
 
-    this.damage.tier1.value ??= 1;
-    this.damage.tier2.value ??= 2 * this.damage.tier1.value;
-    this.damage.tier3.value ??= 3 * this.damage.tier1.value;
+    for (const n of [1, 2, 3]) {
+      this.damage[`tier${n}`].value ??= this.#defaultDamageValue(n);
+    }
 
     this.text ||= "{{damage}}";
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Helper method to derive default damage value used for both derived data
+   * and for placeholders when rendering.
+   * @param {1|2|3} n     The tier.
+   * @returns {number}    The default value.
+   */
+  #defaultDamageValue(n) {
+    switch (n) {
+      case 1:
+        return 1;
+      case 2:
+        return 2 * this.damage.tier1.value;
+      case 3:
+        return 3 * this.damage.tier1.value;
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _tierRenderingContext(context) {
+    context.fields.text.placeholder = "{{damage}}";
+    for (const n of [1, 2, 3]) {
+      const path = `damage.tier${n}`;
+      context.fields[`tier${n}`].damage = {
+        value: {
+          field: this.schema.getField(`${path}.value`),
+          value: this.damage[`tier${n}`].value,
+          src: this._source.damage[`tier${n}`].value,
+          name: `${path}.value`,
+          placeholder: this.#defaultDamageValue(n),
+        },
+        types: {
+          field: this.schema.getField(`${path}.types`),
+          value: this.damage[`tier${n}`].types,
+          src: this._source.damage[`tier${n}`].types,
+          name: `${path}.types`,
+        },
+      };
+    }
+    context.fields.damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([k, v]) => ({ value: k, label: v.label }));
   }
 }


### PR DESCRIPTION
Adds a `watch` parameter to the sheet method - this means the `PseudoDocument#sheet` getter can be accessed without registering a unique sheet; registering a *unique* sheet happens only if it is actually ever rendered. While that does mean a sheet gets instantiated twice in most cases, it prevents the issue in #442.

Also moved rendering context into the PowerRollEffect subtype.