### PR TITLE
Implemented _getSegmentStyle for DrawSteelTokenRuler

### DIFF
--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -118,14 +118,28 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
   _getSegmentStyle(waypoint) {
     const segment = super._getSegmentStyle(waypoint);
 
-    const value = foundry.utils.getProperty(this, "token.document.actor.system.movement.value") ?? Infinity;
-
-    // green for up to 1x, yellow for up to 2x, red for 3x
+    // color order
     const colors = [0x33BC4E, 0xF1D836, 0xE72124];
 
-    const index = Math.min(2, Math.floor(waypoint.measurement.cost / value));
+    if (waypoint.actionConfig.teleport) {
+      // Teleports on creatures without a teleport speed are ignored for distance calculations
+      // It's possible we should be also subtracting them for mixed paths
+      if (!this.token.document.movementTypes.has("teleport")) return segment;
 
-    segment.color = colors[index];
+      const value = foundry.utils.getProperty(this, "token.document.actor.system.movement.teleport") ?? 0;
+
+      // Teleport yes/no are evaluated per segment
+      const index = waypoint.cost > value ? 2 : 0;
+      segment.color = colors[index];
+    }
+    else {
+      const value = foundry.utils.getProperty(this, "token.document.actor.system.movement.value") ?? Infinity;
+
+      // Total cost, up to 1x is green, up to 2x is yellow, up to 3x is green
+      const index = Math.min(2, Math.floor(waypoint.measurement.cost / value));
+
+      segment.color = colors[index];
+    }
 
     return segment;
   }

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -1,4 +1,5 @@
 /** @import { TokenMovementActionConfig, TokenRulerWaypoint } from "@client/_types.mjs" */
+/** @import { DeepReadonly } from "@common/_types.mjs" */
 /** @import DrawSteelTokenDocument from "../../../documents/token.mjs"; */
 
 /**
@@ -108,5 +109,24 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
     context.strikes = strikes;
 
     return context;
+  }
+
+  /**
+   * @param {DeepReadonly<TokenRulerWaypoint>} waypoint
+   * @inheritdoc
+   */
+  _getSegmentStyle(waypoint) {
+    const segment = super._getSegmentStyle(waypoint);
+
+    const value = foundry.utils.getProperty(this, "token.document.actor.system.movement.value") ?? Infinity;
+
+    // green for up to 1x, yellow for up to 2x, red for 3x
+    const colors = [0x33BC4E, 0xF1D836, 0xE72124];
+
+    const index = Math.min(2, Math.floor(waypoint.measurement.cost / value));
+
+    segment.color = colors[index];
+
+    return segment;
   }
 }


### PR DESCRIPTION
Simple green/yellow/red, using the same colors as the default token disposition. Added some special handling for teleports

![image](https://github.com/user-attachments/assets/a889bb59-9364-4a87-b36f-f1caf9dcfe44)
