### PR TITLE
Update embed of power rolls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,10 +20,6 @@
   "ignorePatterns": ["foundry/**/*"],
   "rules": {
     "indent": ["error", 2, {"SwitchCase": 1}],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
     "quotes": [
       "error",
       "double"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/lang/en.json
+++ b/lang/en.json
@@ -1169,6 +1169,10 @@
           "types": {
             "label": "Damage Types"
           }
+        },
+        "DAMAGE": {
+          "formatted": "{value} {damageTypes} damage",
+          "formattedTypeless": "{value} damage"
         }
       },
       "SHEET": {

--- a/src/module/applications/apps/power-roll-dialog.mjs
+++ b/src/module/applications/apps/power-roll-dialog.mjs
@@ -78,10 +78,13 @@ export default class PowerRollDialog extends HandlebarsApplicationMixin(Applicat
     // Find the first instance of multiple damage types and create the options to provide a select
     context.damageOptions = null;
     for (const tier of PowerRoll.TIER_NAMES) {
-      const effect = context.ability.system.powerRoll[tier].find(effect => (effect.type === "damage") && (effect.types.size > 1));
-      if (!effect || context.damageOptions) continue;
 
-      context.damageOptions = Object.entries(ds.CONFIG.damageTypes).filter(([type, data]) => effect.types.has(type)).map(([value, { label }]) => ({ value, label }));
+      const effect = context.ability.system.power.effects.getByType("damage").find(e => e.damage[tier].types.size > 1);
+      if (!effect) continue;
+
+      context.damageOptions = Object.entries(ds.CONFIG.damageTypes)
+        .filter(([type]) => effect.damage[tier].types.has(type))
+        .map(([type, { label }]) => ({ value: type, label }));
       break;
     }
   }

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -50,4 +50,14 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
    * @returns {Promise<void>}   A promise that resolves once the rendering context has been mutated.
    */
   async _tierRenderingContext(context) {}
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Define how an effect renders on sheets and embeds.
+   * @param {number} tier   The specific tier.
+   * @returns {string}
+   * @abstract
+   */
+  toText(tier) {}
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -94,9 +94,8 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
     let damageTypes;
     let i18nString = "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.DAMAGE.formatted";
     if (types.size) {
-      damageTypes = new Intl.ListFormat(game.i18n.lang, {
-        style: "long", type: "disjunction",
-      }).format(Array.from(types).map(type => ds.CONFIG.damageTypes[type].label));
+      const formatter = game.i18n.getListFormatter({ type: "disjunction" })
+      damageTypes = formatter.format(Array.from(types).map(type => ds.CONFIG.damageTypes[type].label));
     } else {
       i18nString += "Typeless";
     }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -84,4 +84,22 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
     }
     context.fields.damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([k, v]) => ({ value: k, label: v.label }));
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  toText(tier) {
+    const { value, types } = this.damage[`tier${tier}`];
+
+    let damageTypes;
+    let i18nString = "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.DAMAGE.formatted";
+    if (types.size) {
+      damageTypes = new Intl.ListFormat(game.i18n.lang, {
+        style: "long", type: "disjunction",
+      }).format(Array.from(types).map(type => ds.CONFIG.damageTypes[type].label));
+    } else {
+      i18nString += "Typeless";
+    }
+    return game.i18n.format(i18nString, { value, damageTypes });
+  }
 }

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -28,28 +28,20 @@
     {{/if}}
   </dl>
 </section>
-{{#if (or tier1 tier2 tier3 system.effect)}}
+{{#if powerRolls}}
 <section class="powerResult">
-  {{#if system.powerRoll.enabled}}
   <p>
     <strong>{{{localize "DRAW_STEEL.Roll.Power.RollPlusBonus" bonus=powerRollBonus}}}</strong>
   </p>
-  {{/if}}
   <dl class="power-roll-display">
-    {{#if tier1}}
     <dt class="tier1">{{localize "DRAW_STEEL.Roll.Power.Results.Tier1"}}</dt>
-    <dd class="tier1">{{{system.powerRoll.tier1.display}}}</dd>
-    {{/if}}
+    <dd class="tier1">{{{powerRollEffects.tier1.text}}}</dd>
 
-    {{#if tier2}}
-    <dt class="tier3">{{localize "DRAW_STEEL.Roll.Power.Results.Tier2"}}</dt>
-    <dd class="tier3">{{{system.powerRoll.tier2.display}}}</dd>
-    {{/if}}
+    <dt class="tier2">{{localize "DRAW_STEEL.Roll.Power.Results.Tier2"}}</dt>
+    <dd class="tier2">{{{powerRollEffects.tier2.text}}}</dd>
 
-    {{#if tier3}}
     <dt class="tier3">{{localize "DRAW_STEEL.Roll.Power.Results.Tier3"}}</dt>
-    <dd class="tier3">{{{system.powerRoll.tier3.display}}}</dd>
-    {{/if}}
+    <dd class="tier3">{{{powerRollEffects.tier3.text}}}</dd>
 
     {{#if system.effect}}
     <dt class="effect">{{systemFields.effect.label}}</dt>


### PR DESCRIPTION
Adds a `toText` method to PowerRollEffects that formats them as a string. For a damage effect, this formats as shown:

![image](https://github.com/user-attachments/assets/673de2e1-77e4-4c16-8877-6884f1239186)

(Unrelated addition, I had annoying difficulties with line endings, so I'm making an attempt at a permanent fix with `.gitattributes`.)