### PR TITLE
Add an option to spend career points to Project context menu

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1066,6 +1066,11 @@
         "Craft": {
           "ItemName": "Craft {name}",
           "CompletedNotification": "{actor} successfully crafted {amount} {item}(s)."
+        },
+        "SpendCareerPoints": {
+          "Title": "Spend Career Points",
+          "Label": "How many points do you want to spend?",
+          "Success": "{actor} has spent {points} project points from their career."
         }
       }
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1070,7 +1070,7 @@
         "SpendCareerPoints": {
           "Title": "Spend Career Points",
           "Label": "How many points do you want to spend?",
-          "Success": "{actor} has spent {points} project points from their career."
+          "Success": "{actor} has spent {points} project points from their career on {project}."
         }
       }
     },

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -455,6 +455,29 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
           await this.render();
         },
       },
+      // Project specific options
+      {
+        name: "DRAW_STEEL.Item.Project.SpendCareerPoints.Title",
+        icon: "<i class=\"fa-solid fa-hammer\"></i>",
+        condition: (target) => {
+          const item = this._getEmbeddedDocument(target);
+          if (item.type !== "project") return false;
+
+          const careerPoints = this.actor.system.career.system.projectPoints ?? 0;
+          const pointsToCompletion = item.system.goal - item.system.points;
+
+          return careerPoints && pointsToCompletion;
+        },
+        callback: async (target) => {
+          const item = this._getEmbeddedDocument(target);
+          if (!item) {
+            console.error("Could not find item");
+            return;
+          }
+          await item.system.spendCareerPoints();
+          await this.render();
+        },
+      },
       // All applicable options
       {
         name: "View",

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -463,7 +463,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
           const item = this._getEmbeddedDocument(target);
           if (item.type !== "project") return false;
 
-          const careerPoints = this.actor.system.career.system.projectPoints ?? 0;
+          const careerPoints = foundry.utils.getProperty(this.actor, "system.career.system.projectPoints") ?? 0;
           const pointsToCompletion = Math.max(0, item.system.goal - item.system.points);
 
           return careerPoints && pointsToCompletion;

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -464,7 +464,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
           if (item.type !== "project") return false;
 
           const careerPoints = this.actor.system.career.system.projectPoints ?? 0;
-          const pointsToCompletion = item.system.goal - item.system.points;
+          const pointsToCompletion = Math.max(0, item.system.goal - item.system.points);
 
           return careerPoints && pointsToCompletion;
         },


### PR DESCRIPTION
Closes #457 

- Adds an option to project context menu to spend career project points. Only shows if you have career points to spend and the project goal hasn't been met. This prompts an input with a range picker to choose how many points to spend.
- Moved the project complete stuff from the `roll` method into the `_onUpdate`, so that item creation automation runs no matter how the points are updated (rolling, spending career points, project sheet, etc).
