### PR TITLE
Improved resilient sheet registering.

### DIFF
--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -93,7 +93,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * @type {ds.applications.api.PseudoDocumentSheet|null}
    */
   get sheet() {
-    return ds.applications.api.PseudoDocumentSheet._registerSheet(this);
+    return ds.applications.api.PseudoDocumentSheet.getSheet(this);
   }
 
   /* -------------------------------------------------- */


### PR DESCRIPTION
Played around with an improved way to register sheets. This way they're both resilient to documents being deleted and still won't try to be the "same" pseudo sheet if an item is re-created with the same id/uuid.

Previously closing a pseudo sheet would cause the next render to create an entirely new instance. This gets rid of some of the cruft.