### PR TITLE
Fixed non-inclusion of packs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         result-encoding: string
         script: |
           const manifest = {
-            includes: ["assets/", "templates/", "CHANGELOG.md", "LICENSE.md"]
+            includes: ["assets/", "templates/", "packs/" "CHANGELOG.md", "LICENSE.md"]
           };
           if ( process.env.ESMODULES ) manifest.esmodules = JSON.parse(process.env.ESMODULES);
           if ( process.env.LANGUAGES ) manifest.languages = JSON.parse(process.env.LANGUAGES);
@@ -128,7 +128,6 @@ jobs:
             ...(manifest.esmodules?.map(s => `${s}.map`) ?? []),
             ...(manifest.styles?.map(s => s.src) ?? []),
             ...(manifest.languages?.map(l => l.path) ?? []),
-            ...(manifest.packs?.map(p => p.path) ?? []),
             ...(manifest.includes ?? [])
           ];
           return includes.join(" ");


### PR DESCRIPTION
Our packs don't have `paths` defined so the too-clever build process I grabbed from dnd5e was leaving them out. Fortunately we can just include the folder post-build.