### PR TITLE
[#467] List power roll effects.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -462,6 +462,9 @@
           },
           "power": {
             "label": "Power Roll",
+            "effects": {
+              "label": "Power Roll Effects"
+            },
             "roll": {
               "flat": {
                 "label": "Flat"

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -79,6 +79,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     },
     impact: {
       template: systemPath("templates/item/impact.hbs"),
+      scrollable: [""],
     },
     effects: {
       template: systemPath("templates/item/effects.hbs"),

--- a/src/styles/system/applications/sheets/item-sheet.css
+++ b/src/styles/system/applications/sheets/item-sheet.css
@@ -109,9 +109,6 @@
       flex-direction: column;
       gap: 1rem;
     }
-    .power-roll-list {
-      display: flex;
-      gap: 0.5rem;
-    }
+    .power-roll-list {}
   }
 }

--- a/src/styles/system/applications/sheets/item-sheet.css
+++ b/src/styles/system/applications/sheets/item-sheet.css
@@ -107,8 +107,11 @@
     .power-roll-data {
       display: flex;
       flex-direction: column;
-      gap: 1rem;
     }
-    .power-roll-list {}
+    .power-roll-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.5rem;
+    }
   }
 }

--- a/templates/item/impact.hbs
+++ b/templates/item/impact.hbs
@@ -8,7 +8,7 @@
 
   </fieldset>
 
-  <fieldset class="power-roll-list">
+  <fieldset>
     <legend>{{systemFields.power.fields.effects.label}}</legend>
     {{#unless isPlay}}
     <button type="button" data-action="createPowerRollEffect">
@@ -17,14 +17,13 @@
     </button>
     {{/unless}}
     {{!-- Using document.system to ensure initialized values in edit mode --}}
-    {{#each document.system.power.effects as |effect|}}
-    <div class="form-group power-roll" data-id="{{effect.id}}">
-      <label>{{localize effect.typeLabel}}</label>
-      <div class="form-fields">
-        <button type="button" class="icon fa-solid fa-fw fa-cog" data-action="editPowerRollEffect"></button>
-      </div>
+    <div class="power-roll-list">
+      {{#each document.system.power.effects as |effect|}}
+      <button type="button" class="power-roll" data-action="editPowerRollEffect" data-id="{{effect.id}}">
+        {{localize effect.typeLabel}}
+      </button>
+      {{/each}}
     </div>
-    {{/each}}
   </fieldset>
   <fieldset>
     <legend>{{systemFields.spend.label}}</legend>

--- a/templates/item/impact.hbs
+++ b/templates/item/impact.hbs
@@ -2,28 +2,34 @@
   <fieldset class="power-roll-data">
     <legend>{{localize "DRAW_STEEL.Item.Ability.FIELDS.power.label"}}</legend>
     {{#with systemFields.power.fields.roll.fields as |powerRoll|}}
-    {{formGroup powerRoll.characteristics value=@root.system.power.roll.characteristics options=@root.characteristics}}
-    {{formGroup powerRoll.formula value=@root.system.power.roll.formula placeholder=powerRoll.formula.initial}}
+    {{formGroup powerRoll.characteristics value=@root.system.power.roll.characteristics options=@root.characteristics disabled=@root.isPlay}}
+    {{formGroup powerRoll.formula value=@root.system.power.roll.formula placeholder=powerRoll.formula.initial disabled=@root.isPlay}}
     {{/with}}
-    <div class="power-roll-list">
-      {{!-- Using document.system to ensure initialized values in edit mode --}}
-      {{#each document.system.power.effects as |effect|}}
-      <button type="button" class="power-roll flexrow" data-action="editPowerRollEffect" data-id="{{effect.id}}">
-        {{localize effect.typeLabel}}
-      </button>
-      {{/each}}
-      {{#if editable}}
-      <button type="button" data-action="createPowerRollEffect">
-        <i class="fa-solid fa-plus"></i>
-        {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.PowerRollEffect")}}
-      </button>
-      {{/if}}
+
+  </fieldset>
+
+  <fieldset class="power-roll-list">
+    <legend>{{systemFields.power.fields.effects.label}}</legend>
+    {{#unless isPlay}}
+    <button type="button" data-action="createPowerRollEffect">
+      <i class="fa-solid fa-plus"></i>
+      {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.PowerRollEffect")}}
+    </button>
+    {{/unless}}
+    {{!-- Using document.system to ensure initialized values in edit mode --}}
+    {{#each document.system.power.effects as |effect|}}
+    <div class="form-group power-roll" data-id="{{effect.id}}">
+      <label>{{localize effect.typeLabel}}</label>
+      <div class="form-fields">
+        <button type="button" class="icon fa-solid fa-fw fa-cog" data-action="editPowerRollEffect"></button>
+      </div>
     </div>
+    {{/each}}
   </fieldset>
   <fieldset>
     <legend>{{systemFields.spend.label}}</legend>
-    {{formGroup systemFields.spend.fields.value value=system.spend.value}}
-    {{formGroup systemFields.spend.fields.text value=system.spend.text}}
+    {{formGroup systemFields.spend.fields.value value=system.spend.value disabled=@root.isPlay}}
+    {{formGroup systemFields.spend.fields.text value=system.spend.text disabled=@root.isPlay}}
   </fieldset>
   {{#if isPlay}}
   {{{enrichedEffect}}}


### PR DESCRIPTION
Closes #467.

![image](https://github.com/user-attachments/assets/3040d1d1-5bef-4536-8baa-1c02a445f93e)

![image](https://github.com/user-attachments/assets/06cfee4b-ce54-4d87-a769-de1157ee8f8f)

Turned the list of powers into, well, a list. Also added `disabled` attribute to the formGroups and fixed the tab not saving scroll position.