### PR TITLE
Add properties field to damage and forced PREs

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1046,12 +1046,6 @@
           "distance": {
             "label": "Distance"
           },
-          "vertical": {
-            "label": "Vertical"
-          },
-          "ignoreStability": {
-            "label": "Ignore Stability"
-          },
           "potency": {
             "label": "Potency",
             "value": {
@@ -1072,6 +1066,9 @@
             "text": {
               "label": "Text"
             }
+          },
+          "properties": {
+            "label": "Properties"
           }
         },
         "TYPES": {
@@ -1082,7 +1079,16 @@
         },
         "DAMAGE": {
           "formatted": "{value} {damageTypes} damage",
-          "formattedTypeless": "{value} damage"
+          "formattedTypeless": "{value} damage",
+          "Properties": {
+            "IgnoresImmunity": "Ignores Immunities"
+          }
+        },
+        "FORCED": {
+          "Properties": {
+            "IgnoresStability": "Ignores Stability",
+            "Vertical": "Vertical"
+          }
         }
       },
       "SHEET": {

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1121,12 +1121,17 @@ Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
 
 /**
  * Valid types for the PowerRollEffect pseudo-document
- * @type {Record<string, { label: string; documentClass: pseudoDocuments.powerRollEffects.BasePowerRollEffect }>}
+ * @type {Record<string, { label: string; documentClass: pseudoDocuments.powerRollEffects.BasePowerRollEffect, properties?: Record<string, { label: string; }> }>}
  */
 DRAW_STEEL.PowerRollEffect = {
   damage: {
     label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.TYPES.damage",
     documentClass: pseudoDocuments.powerRollEffects.DamagePowerRollEffect,
+    properties: {
+      ignoresImmunity: {
+        label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.DAMAGE.Properties.IgnoresImmunity",
+      },
+    },
   },
   applied: {
     label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.TYPES.applied",
@@ -1135,6 +1140,14 @@ DRAW_STEEL.PowerRollEffect = {
   forced: {
     label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.TYPES.forced",
     documentClass: pseudoDocuments.powerRollEffects.ForcedMovementPowerRollEffect,
+    properties: {
+      ignoresImmunity: {
+        label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FORCED.Properties.IgnoresStability",
+      },
+      vertical: {
+        label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FORCED.Properties.Vertical",
+      },
+    },
   },
   other: {
     label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.TYPES.other",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1120,8 +1120,20 @@ Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
 });
 
 /**
+ * @typedef PowerRollEffectProperty
+ * @property {string} label
+ */
+
+/**
+ * @typedef PowerRollEffectType
+ * @property {string} label
+ * @property {pseudoDocuments.powerRollEffects.BasePowerRollEffect} documentClass
+ * @property {Record<string, PowerRollEffectProperty} [properties]
+ */
+
+/**
  * Valid types for the PowerRollEffect pseudo-document
- * @type {Record<string, { label: string; documentClass: pseudoDocuments.powerRollEffects.BasePowerRollEffect, properties?: Record<string, { label: string; }> }>}
+ * @type {Record<string, PowerRollEffectType> }>}
  */
 DRAW_STEEL.PowerRollEffect = {
   damage: {

--- a/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
+++ b/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
@@ -7,6 +7,7 @@ declare module "./base-power-roll-effect.mjs" {
 export type DamageSchema = {
   value: string;
   types: Set<string>;
+  properties: Set<string>;
 }
 
 declare module "./damage-effect.mjs" {
@@ -59,11 +60,11 @@ export type ForcedMovementSchema = {
   display: string;
   movement: Set<string>;
   distance: number;
-  vertical: boolean;
   potency: {
     value: string;
     characteristic: string;
   }
+  properties: Set<string>;
 }
 
 declare module "./forced-movement-effect.mjs" {

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -109,10 +109,6 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
             value: this.applied[`tier${n}`].potency.characteristic,
             src: this._source.applied[`tier${n}`].potency.characteristic,
             name: `${path}.potency.characteristic`,
-            options: Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
-              value: "none",
-              label: "None",
-            }]),
             blank: n > 1 ? "Default" : false,
           },
           success: {
@@ -130,6 +126,11 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
         },
       };
     }
+
+    context.fields.characteristic = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
+      value: "none",
+      label: "None",
+    }]);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -1,4 +1,5 @@
 import FormulaField from "../../fields/formula-field.mjs";
+import { setOptions } from "../../helpers.mjs";
 import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 
 const { SetField, StringField } = foundry.data.fields;
@@ -13,7 +14,8 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
     return Object.assign(super.defineSchema(), {
       damage: this.duplicateTierSchema(() => ({
         value: new FormulaField({ initial: "2 + @chr", label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.damage.label" }),
-        types: new SetField(new StringField(), { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.types.label" }),
+        types: new SetField(setOptions(), { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.types.label" }),
+        properties: new SetField(setOptions(), { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.properties.label" }),
       })),
     });
   }
@@ -75,9 +77,16 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
           src: this._source.damage[`tier${n}`].types,
           name: `${path}.types`,
         },
+        properties: {
+          field: this.schema.getField(`${path}.properties`),
+          value: this.damage[`tier${n}`].properties,
+          src: this._source.damage[`tier${n}`].properties,
+          name: `${path}.properties`,
+        },
       };
     }
     context.fields.damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([k, v]) => ({ value: k, label: v.label }));
+    context.fields.properties = Object.entries(ds.CONFIG.PowerRollEffect.damage.properties).map(([value, { label }]) => ({ value, label }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -29,8 +29,6 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
           { initial: ["push"], label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.movement.label" },
         ),
         distance: new FormulaField({ initial: "1", label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.distance.label" }),
-        vertical: new BooleanField({ label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.vertical.label" }),
-        ignoreStability: new BooleanField({ label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.ignoreStability.label" }),
         potency: new SchemaField({
           value: new FormulaField({ initial: potencyFormula[n], label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.value.label" }),
           characteristic: new StringField({
@@ -41,6 +39,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
             hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.characteristic.hint",
           }),
         }, { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.label" }),
+        properties: new SetField(setOptions(), { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.properties.label" }),
       })),
     });
   }
@@ -90,25 +89,12 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
           value: this.forced[`tier${n}`].movement,
           src: this._source.forced[`tier${n}`].movement,
           name: `${path}.movement`,
-          options: Object.entries(ds.CONFIG.abilities.forcedMovement).map(([value, { label }]) => ({ value, label })),
         },
         distance: {
           field: this.schema.getField(`${path}.distance`),
           value: this.forced[`tier${n}`].distance,
           src: this._source.forced[`tier${n}`].distance,
           name: `${path}.distance`,
-        },
-        vertical: {
-          field: this.schema.getField(`${path}.vertical`),
-          value: this.forced[`tier${n}`].vertical,
-          src: this._source.forced[`tier${n}`].vertical,
-          name: `${path}.vertical`,
-        },
-        ignoreStability: {
-          field: this.schema.getField(`${path}.ignoreStability`),
-          value: this.forced[`tier${n}`].ignoreStability,
-          src: this._source.forced[`tier${n}`].ignoreStability,
-          name: `${path}.ignoreStability`,
         },
         potency: {
           field: this.schema.getField(`${path}.potency`),
@@ -123,14 +109,23 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
             value: this.forced[`tier${n}`].potency.characteristic,
             src: this._source.forced[`tier${n}`].potency.characteristic,
             name: `${path}.potency.characteristic`,
-            options: Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
-              value: "none",
-              label: "None",
-            }]),
             blank: n > 1 ? "Default" : false,
           },
         },
+        properties: {
+          field: this.schema.getField(`${path}.properties`),
+          value: this.forced[`tier${n}`].properties,
+          src: this._source.forced[`tier${n}`].properties,
+          name: `${path}.properties`,
+        },
       };
+
+      context.fields.movement = Object.entries(ds.CONFIG.abilities.forcedMovement).map(([value, { label }]) => ({ value, label }));
+      context.fields.characteristic = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
+        value: "none",
+        label: "None",
+      }]);
+      context.fields.properties = Object.entries(ds.CONFIG.PowerRollEffect.forced.properties).map(([value, { label }]) => ({ value, label }));
     }
   }
 
@@ -156,7 +151,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
     const distanceString = game.i18n.format("DRAW_STEEL.Item.Ability.ForcedMovement.Display", {
       movement: formatter.format(tierValue.movement.map(v => {
         const config = ds.CONFIG.abilities.forcedMovement[v];
-        return tierValue.vertical ? config.vertical : config.label;
+        return tierValue.properties.has("vertical") ? config.vertical : config.label;
       })),
       distance: distanceValue,
     });

--- a/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
+++ b/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
@@ -2,6 +2,7 @@
   {{#with tierFields.damage}}
   {{formGroup value.field value=value.src name=value.name placeholder=value.placeholder localize=true}}
   {{formGroup types.field value=types.src name=types.name options=@root.fields.damageTypes localize=true}}
+  {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
   {{/with}}
   {{#with tierFields.applied}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
@@ -13,7 +14,7 @@
     characteristic.field
     value=characteristic.src
     name=characteristic.name
-    options=characteristic.options
+    options=@root.fields.characteristic
     blank=characteristic.blank
     localize=true
     }}
@@ -25,10 +26,9 @@
   {{/with}}
   {{#with tierFields.forced}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
-  {{formGroup movement.field value=movement.src name=movement.name options=movement.options localize=true}}
+  {{formGroup movement.field value=movement.src name=movement.name options=@root.fields.movement localize=true}}
   {{formGroup distance.field value=distance.src name=distance.name localize=true}}
-  {{formGroup vertical.field value=vertical.src name=vertical.name localize=true}}
-  {{formGroup ignoreStability.field value=ignoreStability.src name=ignoreStability.name localize=true}}
+  {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
   {{#with potency}}
   <fieldset>
     <legend>{{localize field.label}}</legend>
@@ -36,7 +36,7 @@
     characteristic.field
     value=characteristic.src
     name=characteristic.name
-    options=characteristic.options
+    options=@root.fields.characteristic
     blank=characteristic.blank
     localize=true
     }}


### PR DESCRIPTION
Added a properties field to the damage (Ignores Immunities) and force (Vertical, Ignores Stability) PREs.

Also updated some inconsistencies in the type for `SetField`s and in where multi-select value/label options were being created.