### PR TITLE
Split effect into before & after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
   - Power roll, spend, and effects have been moved to the new Impact tab
   - Power roll effects are now organized by type first (e.g. Damage)
     - Each type has data for each tier
-  - The Effect line is now a full rich text editor
+  - The Effect line has been split into two rich text editors for before & after the power roll.
 - Changed system minimum to v13.340, verified system for v13 generally.
 - Updated application overrides and hooks to v13 UI overhaul compatibility. (#226, #229, #230, #231, #232, #233, #255, #298)
 - [BREAKING] Actor `system.movement` has been refactored from values for each type to `system.movement.value` and `system.movement.types`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
   - Power roll, spend, and effects have been moved to the new Impact tab
   - Power roll effects are now organized by type first (e.g. Damage)
     - Each type has data for each tier
-  - The Effect line has been split into two rich text editors for before & after the power roll.
+  - The Effect line has been split into two rich text editors for before & after the power roll. (#478)
 - Changed system minimum to v13.340, verified system for v13 generally.
 - Updated application overrides and hooks to v13 UI overhaul compatibility. (#226, #229, #230, #231, #232, #233, #255, #298)
 - [BREAKING] Actor `system.movement` has been refactored from values for each type to `system.movement.value` and `system.movement.types`

--- a/lang/en.json
+++ b/lang/en.json
@@ -478,7 +478,13 @@
             }
           },
           "effect": {
-            "label": "Effect"
+            "label": "Effect Description",
+            "before": {
+              "label": "Effect (Before Power Roll)"
+            },
+            "after": {
+              "label": "Effect (After Power Roll)"
+            }
           },
           "spend": {
             "label": "Spend",

--- a/lang/en.json
+++ b/lang/en.json
@@ -478,7 +478,7 @@
             }
           },
           "effect": {
-            "label": "Effect Description",
+            "label": "Effect",
             "before": {
               "label": "Effect (Before Power Roll)"
             },

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -19,7 +19,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     classes: ["item"],
     position: {
       // Allows "Their Lack of Focus is Their Undoing" to fit in two lines
-      width: 540,
+      // Also ensures the prosemirror editor bar doesn't overflow to a second line when selecting a paragraph element
+      width: 560,
     },
     actions: {
       toggleMode: this.#toggleMode,

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -146,7 +146,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
         await this.item.system.getSheetContext(context);
         break;
       case "impact":
-        context.enrichedEffect = await enrichHTML(this.item.system.effect, { relativeTo: this.item });
+        context.enrichedBeforeEffect = await enrichHTML(this.item.system.effect.before, { relativeTo: this.item });
+        context.enrichedAfterEffect = await enrichHTML(this.item.system.effect.after, { relativeTo: this.item });
         break;
       case "effects":
         context.effects = this.prepareActiveEffectCategories();

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -68,7 +68,10 @@ declare module "./ability.mjs" {
       value: number;
       text: string;
     };
-    effect: string;
+    effect: {
+      before: string;
+      after: string;
+    };
   }
 
   export interface AbilityUseOptions {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -1,8 +1,9 @@
 import { systemPath } from "../../constants.mjs";
 import { DrawSteelActiveEffect, DrawSteelActor, DrawSteelChatMessage } from "../../documents/_module.mjs";
-import { DamageRoll, DSRoll, PowerRoll } from "../../rolls/_module.mjs";
+import { DamageRoll, PowerRoll } from "../../rolls/_module.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import { setOptions } from "../helpers.mjs";
+import enrichHTML from "../../utils/enrichHTML.mjs";
 import DamagePowerRollEffect from "../pseudo-documents/power-roll-effects/damage-effect.mjs";
 import BaseItemModel from "./base.mjs";
 
@@ -73,7 +74,10 @@ export default class AbilityModel extends BaseItemModel {
       effects: new ds.data.fields.CollectionField(ds.data.pseudoDocuments.powerRollEffects.BasePowerRollEffect),
     });
 
-    schema.effect = new fields.HTMLField();
+    schema.effect = new fields.SchemaField({
+      before: new fields.HTMLField(),
+      after: new fields.HTMLField(),
+    });
     schema.spend = new fields.SchemaField({
       value: new fields.NumberField({ integer: true }),
       text: new fields.StringField({ required: true }),
@@ -288,6 +292,9 @@ export default class AbilityModel extends BaseItemModel {
 
       context.powerRollBonus = this.power.roll.formula.replace("@chr", characteristicsFormatter.format(Array.from(characteristicList)));
     }
+
+    context.enrichedBeforeEffect = await enrichHTML(this.effect.before, { relativeTo: this.parent });
+    context.enrichedAfterEffect = await enrichHTML(this.effect.after, { relativeTo: this.parent });
   }
 
   /* -------------------------------------------------- */

--- a/src/styles/system/applications/sheets/item-sheet.css
+++ b/src/styles/system/applications/sheets/item-sheet.css
@@ -21,7 +21,7 @@
     }
   }
 
-  section[data-tab="description"] {
+  [data-application-part="description"] {
     &.editorActive {
       .prosemirror.editor {
         &:not(.active) {
@@ -40,7 +40,7 @@
 
     .description-label {
       display: block;
-      line-height: var(--form-field-height);
+      line-height: 2rem;
       font-family: var(--font-h4);
       font-size: var(--font-h4-size);
 
@@ -54,9 +54,12 @@
       height: 300px;
     }
 
-    .description {
+    .prosemirror.editor > .description {
       padding: 0.25rem;
+      position: inherit;
+      flex: 1;
     }
+
   }
 
   section[data-tab="details"] {

--- a/system.json
+++ b/system.json
@@ -24,7 +24,7 @@
     },
     "Item": {
       "ability": {
-        "htmlFields": ["effect"]
+        "htmlFields": ["effect.before", "effect.after"]
       },
       "ancestry": {
         "htmlFields": ["description.value", "description.gm"],

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -28,6 +28,14 @@
     {{/if}}
   </dl>
 </section>
+{{#if system.effect.before}}
+<section class="effect before">
+  <dl>
+    <dt class="effect">{{systemFields.effect.label}}</dt>
+    <dd class="effect">{{{enrichedBeforeEffect}}}</dd>
+  </dl>
+</section>
+{{/if}}
 {{#if powerRolls}}
 <section class="powerResult">
   <p>
@@ -46,11 +54,11 @@
   </dl>
 </section>
 {{/if}}
-<section class="">
+{{#if system.effect.after}}
+<section class="effect after">
   <dl>
-    {{#if system.effect}}
     <dt class="effect">{{systemFields.effect.label}}</dt>
-    <dd class="effect">{{{system.effect}}}</dd>
-    {{/if}}
+    <dd class="effect">{{{enrichedAfterEffect}}}</dd>
   </dl>
 </section>
+{{/if}}

--- a/templates/item/impact.hbs
+++ b/templates/item/impact.hbs
@@ -1,5 +1,12 @@
 {{! Impact Tab }}
 <section class="tab standard-form {{tab.cssClass}}" data-group="primary" data-tab="impact" data-subtype="{{document.type}}">
+  <div class="effect">
+    {{#if isPlay}}
+    {{{enrichedBeforeEffect}}}
+    {{else}}
+    {{formGroup systemFields.effect.fields.before value=system.effect.before height="200"}}
+    {{/if}}
+  </div>
   <fieldset class="power-roll-data">
     <legend>{{localize "DRAW_STEEL.Item.Ability.FIELDS.power.label"}}</legend>
     {{#with systemFields.power.fields.roll.fields as |powerRoll|}}
@@ -34,9 +41,9 @@
 
   <div class="effect">
     {{#if isPlay}}
-    {{{enrichedEffect}}}
+    {{{enrichedAfterEffect}}}
     {{else}}
-    {{formGroup systemFields.effect value=system.effect height="200"}}
+    {{formGroup systemFields.effect.fields.after value=system.effect.after height="200"}}
     {{/if}}
   </div>
 </section>

--- a/templates/item/impact.hbs
+++ b/templates/item/impact.hbs
@@ -1,12 +1,16 @@
 {{! Impact Tab }}
 <section class="tab standard-form {{tab.cssClass}}" data-group="primary" data-tab="impact" data-subtype="{{document.type}}">
-  <div class="effect">
+  <div class="effect form-group stacked">
+    <label>{{systemFields.effect.fields.before.label}}</label>
     {{#if isPlay}}
     {{{enrichedBeforeEffect}}}
     {{else}}
-    {{formGroup systemFields.effect.fields.before value=system.effect.before height="200"}}
+    <div class="form-fields">
+      {{formInput systemFields.effect.fields.before value=system.effect.before height="200"}}
+    </div>
     {{/if}}
   </div>
+
   <fieldset class="power-roll-data">
     <legend>{{localize "DRAW_STEEL.Item.Ability.FIELDS.power.label"}}</legend>
     {{#with systemFields.power.fields.roll.fields as |powerRoll|}}
@@ -39,11 +43,14 @@
     {{formGroup systemFields.spend.fields.text value=system.spend.text disabled=@root.isPlay}}
   </fieldset>
 
-  <div class="effect">
+  <div class="effect form-group stacked">
+    <label>{{systemFields.effect.fields.after.label}}</label>
     {{#if isPlay}}
     {{{enrichedAfterEffect}}}
     {{else}}
-    {{formGroup systemFields.effect.fields.after value=system.effect.after height="200"}}
+    <div class="form-fields">
+      {{formInput systemFields.effect.fields.after value=system.effect.after height="200"}}
+    </div>
     {{/if}}
   </div>
 </section>


### PR DESCRIPTION
- Also found some display bugs in the description tab, I suspect from CSS changes by core between early v13 builds and stable
- Widened the sheet a bit so the prosemirror headers don't overflow by default when selecting a p element

Closes #478 