### PR TITLE
Rework socket handler to use query.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1197,6 +1197,12 @@
         "Hint": "Last Performed Migration"
       }
     },
+    "SOCKET": {
+      "WARNING": {
+        "noActiveGM": "No active GM was found to be able to handle the request.",
+        "invalidSpendType": "The spend type [{spendType}] requested by [{name}] is not valid for hero tokens."
+      }
+    },
     "Skill": {
       "Group": {
         "Crafting": "Crafting",

--- a/src/module/data/settings/hero-tokens.mjs
+++ b/src/module/data/settings/hero-tokens.mjs
@@ -63,7 +63,7 @@ export class HeroTokenModel extends foundry.abstract.DataModel {
         flavor: options.flavor ?? game.user.character?.name,
       });
     }
-    else game.system.socketHandler.emit("spendHeroToken", { userId: game.userId, spendType, flavor: options.flavor });
+    else game.system.socketHandler.spendHeroToken({ userId: game.userId, spendType, flavor: options.flavor });
   }
 
   /* -------------------------------------------------- */


### PR DESCRIPTION
The basic setup is that the Socket Handler has the public API method (`spendHeroToken`) and the internal method (`#spendHeroToken`) . The public method handles either making the call for the calling user or sending off to the query system.

Note, this was done really quickly so I did not test.