### PR TITLE
Have potency apply to all effect types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1046,6 +1046,14 @@
             "label": "Always",
             "hint": "Effects that apply regardless of potency checks."
           },
+          "failure": {
+            "label": "Failure",
+            "hint": "Effects that apply when the target's characteristic is less than the potency value."
+          },
+          "success": {
+            "label": "Success",
+            "hint": "Effects that apply when the target's characteristic is equal to or greater than the potency value."
+          },
           "movement": {
             "label": "Forced Movement Type"
           },
@@ -1060,18 +1068,11 @@
             "characteristic": {
               "label": "Potency Characteristic",
               "hint": "Tiers 2 and 3 will default to the chosen characteristic of the prior tier."
-            },
-            "failure": {
-              "label": "Failure",
-              "hint": "Effects that apply when the target's characteristic is less than the potency value."
-            },
-            "success": {
-              "label": "Success",
-              "hint": "Effects that apply when the target's characteristic is equal to or greater than the potency value."
-            },
-            "text": {
-              "label": "Text"
             }
+          },
+          "text": {
+            "label": "Text",
+            "hint": "'{{potency}}' will be replaced with the derived potency info (i.e. M<2)."
           },
           "properties": {
             "label": "Properties"
@@ -1086,6 +1087,7 @@
         "DAMAGE": {
           "formatted": "{value} {damageTypes} damage",
           "formattedTypeless": "{value} damage",
+          "formattedPotency": "{potency} {damage}",
           "Properties": {
             "IgnoresImmunity": "Ignores Immunities"
           }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1070,10 +1070,6 @@
               "hint": "Tiers 2 and 3 will default to the chosen characteristic of the prior tier."
             }
           },
-          "text": {
-            "label": "Text",
-            "hint": "'{{potency}}' will be replaced with the derived potency info (i.e. M<2)."
-          },
           "properties": {
             "label": "Properties"
           }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -277,7 +277,7 @@ export default class AbilityModel extends BaseItemModel {
 
     context.powerRollEffects = Object.fromEntries([1, 2, 3].map(tier => [
       `tier${tier}`,
-      { text: powerRollEffectFormatter.format(this.power.effects.contents.map(effect => effect.toText(tier))) },
+      { text: this.power.effects.contents.map(effect => effect.toText(tier)).join("; ") },
     ]));
     context.powerRolls = this.power.effects.size > 0;
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -273,8 +273,6 @@ export default class AbilityModel extends BaseItemModel {
 
     context.characteristics = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label }));
 
-    const powerRollEffectFormatter = game.i18n.getListFormatter({ type: "unit" });
-
     context.powerRollEffects = Object.fromEntries([1, 2, 3].map(tier => [
       `tier${tier}`,
       { text: this.power.effects.contents.map(effect => effect.toText(tier)).join("; ") },

--- a/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
+++ b/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
@@ -4,10 +4,16 @@ declare module "./base-power-roll-effect.mjs" {
   }
 }
 
+type PotencySchema = {
+  value: string;
+  characteristic: string;
+}
+
 export type DamageSchema = {
   value: string;
   types: Set<string>;
   properties: Set<string>;
+  potency: PotencySchema;
 }
 
 declare module "./damage-effect.mjs" {
@@ -22,7 +28,8 @@ declare module "./damage-effect.mjs" {
 }
 
 export type OtherSchema = {
-  value: string;
+  text: string;
+  potency: PotencySchema;
 }
 
 declare module "./other-effect.mjs" {
@@ -38,12 +45,9 @@ declare module "./other-effect.mjs" {
 export type AppliedEffectSchema = {
   display: string;
   always: Set<string>;
-  potency: {
-    value: string;
-    characteristic: string;
-    success: Set<string>;
-    failure: Set<string>;
-  }
+  success: Set<string>;
+  failure: Set<string>;
+  potency: PotencySchema;
 }
 
 declare module "./applied-effect.mjs" {
@@ -60,10 +64,7 @@ export type ForcedMovementSchema = {
   display: string;
   movement: Set<string>;
   distance: number;
-  potency: {
-    value: string;
-    characteristic: string;
-  }
+  potency: PotencySchema;
   properties: Set<string>;
 }
 

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -73,7 +73,7 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
 
     for (const n of [1, 2, 3]) {
       const path = `applied.tier${n}`;
-      context.fields[`tier${n}`].applied = foundry.utils.mergeObject(context.fields[`tier${n}`].applied, {
+      Object.assign(context.fields[`tier${n}`].applied, {
         effectOptions: this.item.effects.filter(e => !e.transfer).map(e => ({ value: e.id, label: e.name })),
         display: {
           field: this.schema.getField(`${path}.display`),

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -17,7 +17,7 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
 
     return Object.assign(super.defineSchema(), {
       // TODO: Remove manual label assignment when localization bug is fixed
-      applied: this.duplicateTierSchema((n) => ({
+      applied: this.duplicateTierSchema(() => ({
         display: new StringField({
           required: true,
           label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.display.label",
@@ -27,24 +27,14 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
           setOptions({ validate: foundry.data.validators.isValidId }),
           { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.always.label", hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.always.hint" },
         ),
-        potency: new SchemaField({
-          value: new FormulaField({ initial: potencyFormula[n], label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.value.label" }),
-          characteristic: new StringField({
-            required: true,
-            initial: n > 1 ? "" : "none",
-            blank: n > 1,
-            label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.characteristic.label",
-            hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.characteristic.hint",
-          }),
-          failure: new SetField(setOptions(
-            { validate: foundry.data.validators.isValidId }),
-          { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.failure.label", hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.failure.hint" },
-          ),
-          success: new SetField(
-            setOptions({ validate: foundry.data.validators.isValidId }),
-            { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.success.label", hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.success.hint" },
-          ),
-        }, { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.label" }),
+        failure: new SetField(
+          setOptions({ validate: foundry.data.validators.isValidId }),
+          { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.failure.label", hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.failure.hint" },
+        ),
+        success: new SetField(
+          setOptions({ validate: foundry.data.validators.isValidId }),
+          { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.success.label", hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.success.hint" },
+        ),
       })),
     });
   }
@@ -79,9 +69,11 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
 
   /** @inheritdoc */
   async _tierRenderingContext(context) {
+    await super._tierRenderingContext(context);
+
     for (const n of [1, 2, 3]) {
       const path = `applied.tier${n}`;
-      context.fields[`tier${n}`].applied = {
+      context.fields[`tier${n}`].applied = foundry.utils.mergeObject(context.fields[`tier${n}`].applied, {
         effectOptions: this.item.effects.filter(e => !e.transfer).map(e => ({ value: e.id, label: e.name })),
         display: {
           field: this.schema.getField(`${path}.display`),
@@ -96,41 +88,20 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
           src: this._source.applied[`tier${n}`].always,
           name: `${path}.always`,
         },
-        potency: {
-          field: this.schema.getField(`${path}.potency`),
-          value: {
-            field: this.schema.getField(`${path}.potency.value`),
-            value: this.applied[`tier${n}`].potency.value,
-            src: this._source.applied[`tier${n}`].potency.value,
-            name: `${path}.potency.value`,
-          },
-          characteristic: {
-            field: this.schema.getField(`${path}.potency.characteristic`),
-            value: this.applied[`tier${n}`].potency.characteristic,
-            src: this._source.applied[`tier${n}`].potency.characteristic,
-            name: `${path}.potency.characteristic`,
-            blank: n > 1 ? "Default" : false,
-          },
-          success: {
-            field: this.schema.getField(`${path}.potency.success`),
-            value: this.applied[`tier${n}`].potency.success,
-            src: this._source.applied[`tier${n}`].potency.success,
-            name: `${path}.potency.success`,
-          },
-          failure: {
-            field: this.schema.getField(`${path}.potency.failure`),
-            value: this.applied[`tier${n}`].potency.failure,
-            src: this._source.applied[`tier${n}`].potency.failure,
-            name: `${path}.potency.failure`,
-          },
+        success: {
+          field: this.schema.getField(`${path}.success`),
+          value: this.applied[`tier${n}`].success,
+          src: this._source.applied[`tier${n}`].success,
+          name: `${path}.success`,
         },
-      };
+        failure: {
+          field: this.schema.getField(`${path}.failure`),
+          value: this.applied[`tier${n}`].failure,
+          src: this._source.applied[`tier${n}`].failure,
+          name: `${path}.failure`,
+        },
+      });
     }
-
-    context.fields.characteristic = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
-      value: "none",
-      label: "None",
-    }]);
   }
 
   /* -------------------------------------------------- */
@@ -140,15 +111,7 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
    * @inheritdoc
    */
   toText(tier) {
-    const tierValue = this.applied[`tier${tier}`];
-    let potencyValue = tierValue.potency.value;
-    if (this.actor) {
-      potencyValue = new DSRoll(potencyValue, this.item.getRollData()).evaluateSync({ strict: false }).total;
-    }
-    const potencyString = game.i18n.format("DRAW_STEEL.Item.Ability.Potency.Embed", {
-      characteristic: ds.CONFIG.characteristics[tierValue.potency.characteristic]?.rollKey ?? "",
-      value: potencyValue,
-    });
+    const potencyString = this.toPotencyText(tier);
     return this.applied[`tier${tier}`].display.replaceAll("{{potency}}", potencyString);
   }
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -103,16 +103,15 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
   /* -------------------------------------------------- */
 
   /**
-   * Helper method to derive default potency characteristic used for both derived data
-   * and for placeholders when rendering.
+   * Helper method to derive default potency characteristic for tiers 2 and 3.
    * @param {1|2|3} n     The tier.
    * @returns {string}    The default characteristic.
    */
-  #defaultPotencyCharacteristic(n) {
-    const tierValue = this[`${this.constructor.TYPE}`][`tier${n}`];
+  #defaultPotencyCharacteristic(tier) {
+    const tierValue = this[`${this.constructor.TYPE}`][`tier${tier}`];
     let potencyCharacteristic = tierValue.potency.characteristic;
-    if (n > 1) {
-      const prevTier = this[`${this.constructor.TYPE}`][`tier${n - 1}`];
+    if (tier > 1) {
+      const prevTier = this[`${this.constructor.TYPE}`][`tier${tier - 1}`];
       if (prevTier.potency.characteristic) potencyCharacteristic ||= prevTier.potency.characteristic;
     }
 

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -1,8 +1,9 @@
+import { DSRoll } from "../../../rolls/base.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import { setOptions } from "../../helpers.mjs";
 import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 
-const { SetField, StringField } = foundry.data.fields;
+const { SetField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * For abilities that do damage
@@ -61,9 +62,11 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
 
   /** @inheritdoc */
   async _tierRenderingContext(context) {
+    await super._tierRenderingContext(context);
+
     for (const n of [1, 2, 3]) {
       const path = `damage.tier${n}`;
-      context.fields[`tier${n}`].damage = {
+      context.fields[`tier${n}`].damage = foundry.utils.mergeObject(context.fields[`tier${n}`].damage, {
         value: {
           field: this.schema.getField(`${path}.value`),
           value: this.damage[`tier${n}`].value,
@@ -83,7 +86,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
           src: this._source.damage[`tier${n}`].properties,
           name: `${path}.properties`,
         },
-      };
+      });
     }
     context.fields.damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([k, v]) => ({ value: k, label: v.label }));
     context.fields.properties = Object.entries(ds.CONFIG.PowerRollEffect.damage.properties).map(([value, { label }]) => ({ value, label }));
@@ -96,7 +99,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
    * @inheritdoc
    */
   toText(tier) {
-    const { value, types } = this.damage[`tier${tier}`];
+    const { value, types, potency } = this.damage[`tier${tier}`];
 
     let damageTypes;
     let i18nString = "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.DAMAGE.formatted";
@@ -106,6 +109,14 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
     } else {
       i18nString += "Typeless";
     }
-    return game.i18n.format(i18nString, { value, damageTypes });
+    const formattedDamageString = game.i18n.format(i18nString, { value, damageTypes });
+    if (potency.characteristic === "none") return formattedDamageString;
+
+    const potencyString = this.toPotencyText(tier);
+
+    return game.i18n.format("DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.DAMAGE.formattedPotency", {
+      damage: formattedDamageString,
+      potency: potencyString,
+    });
   }
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -66,7 +66,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
 
     for (const n of [1, 2, 3]) {
       const path = `damage.tier${n}`;
-      context.fields[`tier${n}`].damage = foundry.utils.mergeObject(context.fields[`tier${n}`].damage, {
+      Object.assign(context.fields[`tier${n}`].damage, {
         value: {
           field: this.schema.getField(`${path}.value`),
           value: this.damage[`tier${n}`].value,

--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -68,7 +68,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
 
     for (const n of [1, 2, 3]) {
       const path = `forced.tier${n}`;
-      context.fields[`tier${n}`].forced = foundry.utils.mergeObject(context.fields[`tier${n}`].forced, {
+      Object.assign(context.fields[`tier${n}`].forced, {
         display: {
           field: this.schema.getField(`${path}.display`),
           value: this.forced[`tier${n}`].display,

--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -17,7 +17,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
 
     return Object.assign(super.defineSchema(), {
       // TODO: Remove manual label assignment when localization bug is fixed
-      forced: this.duplicateTierSchema((n) => ({
+      forced: this.duplicateTierSchema(() => ({
         display: new StringField({
           required: true,
           label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.display.label",
@@ -29,16 +29,6 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
           { initial: ["push"], label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.movement.label" },
         ),
         distance: new FormulaField({ initial: "1", label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.distance.label" }),
-        potency: new SchemaField({
-          value: new FormulaField({ initial: potencyFormula[n], label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.value.label" }),
-          characteristic: new StringField({
-            required: true,
-            initial: n > 1 ? "" : "none",
-            blank: n > 1,
-            label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.characteristic.label",
-            hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.characteristic.hint",
-          }),
-        }, { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.potency.label" }),
         properties: new SetField(setOptions(), { label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.properties.label" }),
       })),
     });
@@ -74,9 +64,11 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
 
   /** @inheritdoc */
   async _tierRenderingContext(context) {
+    await super._tierRenderingContext(context);
+
     for (const n of [1, 2, 3]) {
       const path = `forced.tier${n}`;
-      context.fields[`tier${n}`].forced = {
+      context.fields[`tier${n}`].forced = foundry.utils.mergeObject(context.fields[`tier${n}`].forced, {
         display: {
           field: this.schema.getField(`${path}.display`),
           value: this.forced[`tier${n}`].display,
@@ -96,35 +88,15 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
           src: this._source.forced[`tier${n}`].distance,
           name: `${path}.distance`,
         },
-        potency: {
-          field: this.schema.getField(`${path}.potency`),
-          value: {
-            field: this.schema.getField(`${path}.potency.value`),
-            value: this.forced[`tier${n}`].potency.value,
-            src: this._source.forced[`tier${n}`].potency.value,
-            name: `${path}.potency.value`,
-          },
-          characteristic: {
-            field: this.schema.getField(`${path}.potency.characteristic`),
-            value: this.forced[`tier${n}`].potency.characteristic,
-            src: this._source.forced[`tier${n}`].potency.characteristic,
-            name: `${path}.potency.characteristic`,
-            blank: n > 1 ? "Default" : false,
-          },
-        },
         properties: {
           field: this.schema.getField(`${path}.properties`),
           value: this.forced[`tier${n}`].properties,
           src: this._source.forced[`tier${n}`].properties,
           name: `${path}.properties`,
         },
-      };
+      });
 
       context.fields.movement = Object.entries(ds.CONFIG.abilities.forcedMovement).map(([value, { label }]) => ({ value, label }));
-      context.fields.characteristic = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
-        value: "none",
-        label: "None",
-      }]);
       context.fields.properties = Object.entries(ds.CONFIG.PowerRollEffect.forced.properties).map(([value, { label }]) => ({ value, label }));
     }
   }
@@ -137,16 +109,11 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
    */
   toText(tier) {
     const tierValue = this.forced[`tier${tier}`];
-    let potencyValue = tierValue.potency.value;
     let distanceValue = tierValue.distance;
     if (this.actor) {
-      potencyValue = new DSRoll(potencyValue, this.item.getRollData()).evaluateSync({ strict: false }).total;
       distanceValue = new DSRoll(distanceValue, this.item.getRollData()).evaluateSync({ strict: false }).total;
     }
-    const potencyString = game.i18n.format("DRAW_STEEL.Item.Ability.Potency.Embed", {
-      characteristic: ds.CONFIG.characteristics[tierValue.potency.characteristic]?.rollKey ?? "",
-      value: potencyValue,
-    });
+    const potencyString = this.toPotencyText(tier);
     const formatter = game.i18n.getListFormatter({ type: "disjunction" });
     const distanceString = game.i18n.format("DRAW_STEEL.Item.Ability.ForcedMovement.Display", {
       movement: formatter.format(tierValue.movement.map(v => {

--- a/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
@@ -10,8 +10,12 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
       // TODO: Remove manual label assignment when localization bug is fixed
-      text: this.duplicateTierSchema(() => ({
-        value: new StringField({ required: true, label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.text.label" }),
+      other: this.duplicateTierSchema(() => ({
+        text: new StringField({
+          required: true,
+          label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.text.label",
+          hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.text.hint",
+        }),
       })),
     });
   }
@@ -27,16 +31,18 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
 
   /** @inheritdoc */
   async _tierRenderingContext(context) {
+    await super._tierRenderingContext(context);
+
     for (const n of [1, 2, 3]) {
-      const path = `text.tier${n}`;
-      context.fields[`tier${n}`].text = {
-        value: {
-          field: this.schema.getField(`${path}.value`),
-          value: this.text[`tier${n}`].value,
-          src: this._source.text[`tier${n}`].value,
-          name: `${path}.value`,
+      const path = `other.tier${n}`;
+      context.fields[`tier${n}`].other = foundry.utils.mergeObject(context.fields[`tier${n}`].other, {
+        text: {
+          field: this.schema.getField(`${path}.text`),
+          value: this.other[`tier${n}`].text,
+          src: this._source.other[`tier${n}`].text,
+          name: `${path}.text`,
         },
-      };
+      });
     }
   }
   /* -------------------------------------------------- */
@@ -46,6 +52,7 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
    * @inheritdoc
    */
   toText(tier) {
-    return this.text[`tier${tier}`].value;
+    const potencyString = this.toPotencyText(tier);
+    return this.other[`tier${tier}`].text.replaceAll("{{potency}}", potencyString);
   }
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
@@ -35,7 +35,7 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
 
     for (const n of [1, 2, 3]) {
       const path = `other.tier${n}`;
-      context.fields[`tier${n}`].other = foundry.utils.mergeObject(context.fields[`tier${n}`].other, {
+      Object.assign(context.fields[`tier${n}`].other, {
         display: {
           field: this.schema.getField(`${path}.display`),
           value: this.other[`tier${n}`].display,

--- a/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
@@ -11,10 +11,10 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
     return Object.assign(super.defineSchema(), {
       // TODO: Remove manual label assignment when localization bug is fixed
       other: this.duplicateTierSchema(() => ({
-        text: new StringField({
+        display: new StringField({
           required: true,
-          label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.text.label",
-          hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.text.hint",
+          label: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.display.label",
+          hint: "DRAW_STEEL.PSEUDO.POWER_ROLL_EFFECT.FIELDS.display.hint",
         }),
       })),
     });
@@ -36,11 +36,11 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
     for (const n of [1, 2, 3]) {
       const path = `other.tier${n}`;
       context.fields[`tier${n}`].other = foundry.utils.mergeObject(context.fields[`tier${n}`].other, {
-        text: {
-          field: this.schema.getField(`${path}.text`),
-          value: this.other[`tier${n}`].text,
-          src: this._source.other[`tier${n}`].text,
-          name: `${path}.text`,
+        display: {
+          field: this.schema.getField(`${path}.display`),
+          value: this.other[`tier${n}`].display,
+          src: this._source.other[`tier${n}`].display,
+          name: `${path}.display`,
         },
       });
     }
@@ -53,6 +53,6 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
    */
   toText(tier) {
     const potencyString = this.toPotencyText(tier);
-    return this.other[`tier${tier}`].text.replaceAll("{{potency}}", potencyString);
+    return this.other[`tier${tier}`].display.replaceAll("{{potency}}", potencyString);
   }
 }

--- a/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
+++ b/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
@@ -3,6 +3,20 @@
   {{formGroup value.field value=value.src name=value.name placeholder=value.placeholder localize=true}}
   {{formGroup types.field value=types.src name=types.name options=@root.fields.damageTypes localize=true}}
   {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
+  {{#with potency}}
+  <fieldset>
+    <legend>{{localize field.label}}</legend>
+    {{formGroup
+    characteristic.field
+    value=characteristic.src
+    name=characteristic.name
+    options=@root.fields.characteristic
+    blank=characteristic.blank
+    localize=true
+    }}
+    {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
+  </fieldset>
+  {{/with}}
   {{/with}}
   {{#with tierFields.applied}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
@@ -19,8 +33,10 @@
     localize=true
     }}
     {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
-    {{formGroup failure.field value=failure.src name=failure.name options=../effectOptions localize=true}}
-    {{formGroup success.field value=success.src name=success.name options=../effectOptions localize=true}}
+    {{#with ../../tierFields.applied}}
+    {{formGroup failure.field value=failure.src name=failure.name options=../../effectOptions localize=true}}
+    {{formGroup success.field value=success.src name=success.name options=../../effectOptions localize=true}}
+    {{/with}}
   </fieldset>
   {{/with}}
   {{/with}}
@@ -44,7 +60,21 @@
   </fieldset>
   {{/with}}
   {{/with}}
-  {{#with tierFields.text}}
-  {{formGroup value.field value=value.src name=value.name placeholder=value.placeholder localize=true}}
+  {{#with tierFields.other}}
+  {{formGroup text.field value=text.src name=text.name placeholder=text.placeholder localize=true}}
+  {{#with potency}}
+  <fieldset>
+    <legend>{{localize field.label}}</legend>
+    {{formGroup
+    characteristic.field
+    value=characteristic.src
+    name=characteristic.name
+    options=@root.fields.characteristic
+    blank=characteristic.blank
+    localize=true
+    }}
+    {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
+  </fieldset>
+  {{/with}}
   {{/with}}
 </section>

--- a/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
+++ b/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
@@ -1,80 +1,45 @@
+{{#* inline "potencyFields"}}
+<fieldset>
+  <legend>{{localize field.label}}</legend>
+  {{formGroup
+  characteristic.field
+  value=characteristic.src
+  name=characteristic.name
+  options=@root.fields.characteristic
+  blank=characteristic.blank
+  localize=true
+  }}
+  {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
+  {{{extraFields}}}
+</fieldset>
+{{/inline}}
+
 <section class="tab {{tab.cssClass}}" data-tab="{{tab.id}}" data-group="{{tab.group}}">
   {{#with tierFields.damage}}
   {{formGroup value.field value=value.src name=value.name placeholder=value.placeholder localize=true}}
   {{formGroup types.field value=types.src name=types.name options=@root.fields.damageTypes localize=true}}
   {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
-  {{#with potency}}
-  <fieldset>
-    <legend>{{localize field.label}}</legend>
-    {{formGroup
-    characteristic.field
-    value=characteristic.src
-    name=characteristic.name
-    options=@root.fields.characteristic
-    blank=characteristic.blank
-    localize=true
-    }}
-    {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
-  </fieldset>
-  {{/with}}
+  {{> potencyFields potency}}
   {{/with}}
   {{#with tierFields.applied}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
   {{formGroup always.field value=always.src name=always.name options=effectOptions localize=true}}
-  {{#with potency}}
-  <fieldset>
-    <legend>{{localize field.label}}</legend>
-    {{formGroup
-    characteristic.field
-    value=characteristic.src
-    name=characteristic.name
-    options=@root.fields.characteristic
-    blank=characteristic.blank
-    localize=true
-    }}
-    {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
-    {{#with ../../tierFields.applied}}
-    {{formGroup failure.field value=failure.src name=failure.name options=../../effectOptions localize=true}}
-    {{formGroup success.field value=success.src name=success.name options=../../effectOptions localize=true}}
-    {{/with}}
-  </fieldset>
-  {{/with}}
+  {{> potencyFields potency
+  extraFields=(concat
+  (formGroup failure.field value=failure.src name=failure.name options=effectOptions localize=true)
+  (formGroup success.field value=success.src name=success.name options=effectOptions localize=true)
+  )
+  }}
   {{/with}}
   {{#with tierFields.forced}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
   {{formGroup movement.field value=movement.src name=movement.name options=@root.fields.movement localize=true}}
   {{formGroup distance.field value=distance.src name=distance.name localize=true}}
   {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
-  {{#with potency}}
-  <fieldset>
-    <legend>{{localize field.label}}</legend>
-    {{formGroup
-    characteristic.field
-    value=characteristic.src
-    name=characteristic.name
-    options=@root.fields.characteristic
-    blank=characteristic.blank
-    localize=true
-    }}
-    {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
-  </fieldset>
-  {{/with}}
+  {{> potencyFields potency}}
   {{/with}}
   {{#with tierFields.other}}
-  {{formGroup text.field value=text.src name=text.name placeholder=text.placeholder localize=true}}
-  {{#with potency}}
-  <fieldset>
-    <legend>{{localize field.label}}</legend>
-    {{formGroup
-    characteristic.field
-    value=characteristic.src
-    name=characteristic.name
-    options=@root.fields.characteristic
-    blank=characteristic.blank
-    localize=true
-    }}
-    {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
-  </fieldset>
-  {{/with}}
+  {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
+  {{> potencyFields potency}}
   {{/with}}
 </section>

--- a/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
+++ b/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
@@ -10,7 +10,8 @@
   localize=true
   }}
   {{formGroup value.field value=value.src name=value.name placeholder=value.field.initial localize=true}}
-  {{{extraFields}}}
+
+  {{> @partial-block}}
 </fieldset>
 {{/inline}}
 
@@ -19,27 +20,25 @@
   {{formGroup value.field value=value.src name=value.name placeholder=value.placeholder localize=true}}
   {{formGroup types.field value=types.src name=types.name options=@root.fields.damageTypes localize=true}}
   {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
-  {{> potencyFields potency}}
+  {{#> potencyFields potency}}{{/potencyFields}}
   {{/with}}
   {{#with tierFields.applied}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
   {{formGroup always.field value=always.src name=always.name options=effectOptions localize=true}}
-  {{> potencyFields potency
-  extraFields=(concat
-  (formGroup failure.field value=failure.src name=failure.name options=effectOptions localize=true)
-  (formGroup success.field value=success.src name=success.name options=effectOptions localize=true)
-  )
-  }}
+  {{#> potencyFields potency success=success failure=failure effectOptions=effectOptions}}
+  {{formGroup failure.field value=failure.src name=failure.name options=effectOptions localize=true}}
+  {{formGroup success.field value=success.src name=success.name options=effectOptions localize=true}}
+  {{/potencyFields}}
   {{/with}}
   {{#with tierFields.forced}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
   {{formGroup movement.field value=movement.src name=movement.name options=@root.fields.movement localize=true}}
   {{formGroup distance.field value=distance.src name=distance.name localize=true}}
   {{formGroup properties.field value=properties.src name=properties.name options=@root.fields.properties localize=true}}
-  {{> potencyFields potency}}
+  {{#> potencyFields potency}}{{/potencyFields}}
   {{/with}}
   {{#with tierFields.other}}
   {{formGroup display.field value=display.src name=display.name placeholder=display.placeholder localize=true}}
-  {{> potencyFields potency}}
+  {{#> potencyFields potency}}{{/potencyFields}}
   {{/with}}
 </section>


### PR DESCRIPTION
Closes #486

- Move the potency schema inside the `BasePowerRollEffect.duplicateTierSchema` so that potency auto applies to all effects.
   - For this I had to move the applied effects success/failure to the top level of the applied effects schema.
- To make the above easier I used `this.constructor.TYPE` a lot. This meant in the other effect schema I renamed `text` to `other` and `value` to `text`. This has the benefit of being consistent with the top level being the type. 
   - Should `text` be display instead? The applied and forced use display instead of text.
   - Should damage get a display field too? Right now, I'm inferring that potency should be first, but with a display field, it'd be configurable.
- With all of the effects now having a potency, should there just be one potency section in the HTML instead of inside each `{{#with}}`?
 