### PR TITLE
Automate edges from flanking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ## 0.7.1
 
+### Added
+- Automated flanking bonuses when requirements are met (#451)
+- Added a flag to the wall documents to configure if a wall should block of line of effect.
+
 ### Fixed
 - Fix setting the power roll characteristic if all applicable characteristics are negative.
 

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -88,6 +88,11 @@ Hooks.once("init", function () {
     makeDefault: true,
     label: "DRAW_STEEL.Sheet.Labels.ActiveEffect",
   });
+  DocumentSheetConfig.unregisterSheet(WallDocument, "core", foundry.applications.sheets.WallConfig);
+  DocumentSheetConfig.registerSheet(WallDocument, DS_CONST.systemID, applications.sheets.DrawSteelWallConfig, {
+    makeDefault: true,
+    label: "DRAW_STEEL.Sheet.Labels.WallDocument",
+  });
   DocumentSheetConfig.registerSheet(CombatantGroup, DS_CONST.systemID, applications.sheets.DrawSteelCombatantGroupConfig, {
     makeDefault: true,
     label: "DRAW_STEEL.Sheet.Labels.CombatantGroup",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,7 +9,8 @@
         "NPC": "Draw Steel NPC Sheet",
         "Item": "Draw Steel Item Sheet",
         "ActiveEffect": "Draw Steel Active Effect Config",
-        "CombatantGroup": "Draw Steel Combatant Group Config"
+        "CombatantGroup": "Draw Steel Combatant Group Config",
+        "WallDocument": "Draw Steel Wall Config"
       },
       "Add": "+ Add {itemName}",
       "NoDocument": "No {documentName}",
@@ -1346,6 +1347,15 @@
           "NoItem": "Could not find item. You may need to delete and recreate this macro.",
           "NotOwnedItem": "{item} is not an owned item. Only owned items may be rolled.",
           "NoRoll": "{item} does not have a roll function."
+        }
+      }
+    },
+    "Wall": {
+      "Config": {
+        "Legend": "Draw Steel Configuration",
+        "BlocksLineOfEffect": {
+          "label": "Blocks Line of Effect",
+          "hint": "Should this wall block line of effect between tokens?"
         }
       }
     }

--- a/src/module/applications/sheets/_module.mjs
+++ b/src/module/applications/sheets/_module.mjs
@@ -4,5 +4,6 @@ export { default as DrawSteelCharacterSheet } from "./character.mjs";
 export { default as DrawSteelCombatantGroupConfig } from "./combatant-group-config.mjs";
 export { default as DrawSteelItemSheet } from "./item-sheet.mjs";
 export { default as DrawSteelNPCSheet } from "./npc.mjs";
+export { default as DrawSteelWallConfig } from "./wall-config.mjs";
 
 export * as pseudoDocuments from "./pseudo-documents/_module.mjs";

--- a/src/module/applications/sheets/wall-config.mjs
+++ b/src/module/applications/sheets/wall-config.mjs
@@ -1,0 +1,30 @@
+import { systemID } from "../../constants.mjs";
+
+/**
+ * The Application responsible for configuring a single Wall document.
+ */
+export default class DrawSteelWallConfig extends foundry.applications.sheets.WallConfig {
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+
+    const fieldset = document.createElement("fieldset");
+    const legend = document.createElement("legend");
+    legend.textContent = game.i18n.localize("DRAW_STEEL.Wall.Config.Legend");
+
+    const checkbox = foundry.applications.fields.createCheckboxInput({
+      name: `flags.${systemID}.blocksLineOfEffect`,
+      value: this.document.blocksLineOfEffect,
+    });
+    const formGroup = foundry.applications.fields.createFormGroup({
+      label: "DRAW_STEEL.Wall.Config.BlocksLineOfEffect.label",
+      hint: "DRAW_STEEL.Wall.Config.BlocksLineOfEffect.hint",
+      input: checkbox,
+      localize: true,
+    });
+    fieldset.append(legend, formGroup);
+
+    this.element.querySelector("div.standard-form").append(fieldset);
+  }
+}

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -22,7 +22,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
   /* -------------------------------------------------- */
 
   /**
-   * Does the actor have restrictions preventing flanking ability
+   * Can the token's actor flank? Effects that restrict the ability to take triggered actions block flanking.
    * @type {boolean}
    */
   get canFlank() {
@@ -30,13 +30,17 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     return !this.actor.system.restrictions.type.has("triggered");
   }
 
+  /* -------------------------------------------------- */
+
   /**
-   * Can the actor be flanked?
+   * Can the token's actor be flanked?
    * @type {boolean}
    */
   get canBeFlanked() {
     return this.actor.system.flankable ?? true;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * An array of inset vertices for each of the token's grid spaces.
@@ -60,6 +64,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     return vertices;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Determine if any of the token's occupied squares are adjacent to any of the target's occupied squares.
    * @param {DrawSteelToken} target
@@ -79,6 +85,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     return false;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Return all allies adjacent to the target with line of effect
    * @param {*} target
@@ -95,6 +103,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
 
     return alliedTokens;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Does this token have line of effect to the target token
@@ -113,6 +123,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     return false;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Are this token and the ally on opposite sides or corners of the target.
    * @param {DrawSteelToken} target
@@ -129,6 +141,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
 
     return onOppositeSides || onOppositeCorners;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Is the token flanking the target with an ally.

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -52,7 +52,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
   get insetVertices() {
     const vertices = [];
 
-    for (const offset of this.document.getOccupiedGridSpaceOffsets(this.center)) {
+    for (const offset of this.document.getOccupiedGridSpaceOffsets()) {
       const topLeftPoint = { x: (offset.j - 1) * canvas.grid.size, y: (offset.i - 1) * canvas.grid.size };
 
       const topLeft = { x: topLeftPoint.x + 1, y: topLeftPoint.y + 1 };
@@ -74,8 +74,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
    * @returns {boolean}
    */
   isAdjacentTo(target) {
-    const tokenOffsets = this.document.getOccupiedGridSpaceOffsets(this.center);
-    const targetOffsets = target.document.getOccupiedGridSpaceOffsets(target.center);
+    const tokenOffsets = this.document.getOccupiedGridSpaceOffsets();
+    const targetOffsets = target.document.getOccupiedGridSpaceOffsets();
 
     for (const tokenOffset of tokenOffsets) {
       for (const targetOffset of targetOffsets) {

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -56,8 +56,8 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
       const topLeftPoint = { x: (offset.j - 1) * canvas.grid.size, y: (offset.i - 1) * canvas.grid.size };
 
       const topLeft = { x: topLeftPoint.x + 1, y: topLeftPoint.y + 1 };
-      const topRight = { x: topLeftPoint.x + canvas.grid.size - 1, y: topLeftPoint.y };
-      const bottomLeft = { x: topLeftPoint.x, y: topLeftPoint.y + canvas.grid.size - 1 };
+      const topRight = { x: topLeftPoint.x + canvas.grid.size - 1, y: topLeftPoint.y + 1 };
+      const bottomLeft = { x: topLeftPoint.x + 1, y: topLeftPoint.y + canvas.grid.size - 1 };
       const bottomRight = { x: topLeftPoint.x + canvas.grid.size - 1, y: topLeftPoint.y + canvas.grid.size - 1 };
 
       vertices.push(topLeft, topRight, bottomLeft, bottomRight);

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -114,9 +114,11 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
    * @returns {boolean}
    */
   hasLineOfEffect(target) {
-    // TODO: Add flag to walls for "blocks line of effect" that defaults to true.
-    for (const tokenVertex of this.insetVertices) {
-      for (const targetVertex of target.insetVertices) {
+    const tokenInsetVertices = this.insetVertices;
+    const targetInsetVertices = target.insetVertices;
+
+    for (const tokenVertex of tokenInsetVertices) {
+      for (const targetVertex of targetInsetVertices) {
         const collsions = CONFIG.Canvas.polygonBackends.move.testCollision(tokenVertex, targetVertex, { type: "move", mode: "all" });
         const hasCollisions = collsions.some(c => c.edges.some(e => e.object?.document?.blocksLineOfEffect ?? true));
         if (!hasCollisions) return true;

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -91,7 +91,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
 
   /**
    * Return all allies adjacent to the target with line of effect
-   * @param {*} target
+   * @param {DrawSteelToken} target
    * @returns {DrawSteelToken[]}
    */
   getAdjacentAllies(target) {

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -1,4 +1,5 @@
 /** @import DrawSteelTokenDocument from "../../documents/token.mjs" */
+/** @import { Point } from "@common/_types.mjs" */
 
 /**
  * A Placeable Object subclass adding system-specific behavior and registered in CONFIG.Token.objectClass
@@ -14,6 +15,149 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     if (token.id === this.id) return false;
     if (!this.document.visible || this.document.isSecret) return false;
     return true;
+  }
+
+  /* -------------------------------------------------- */
+  /*   Flanking                                    */
+  /* -------------------------------------------------- */
+
+  /**
+   * Does the actor have restrictions preventing flanking ability
+   * @type {boolean}
+   */
+  get canFlank() {
+    // Checking if active effects have restricted triggered abilities
+    if (this.actor.system.restrictions.type.has("triggered")) return false;
+
+    // Checking if statuses have restricted triggered abilities
+    for (const effect of CONFIG.statusEffects) {
+      if (!this.actor.statuses.has(effect.id) || !effect.restrictions) continue;
+
+      if (effect.restrictions.type?.has("triggered")) return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Can the actor be flanked?
+   * @type {boolean}
+   */
+  get canBeFlanked() {
+    return this.actor.system.flankable ?? true;
+  }
+
+  /**
+   * An array of inset vertices for each of the token's grid spaces.
+   * Each vertex is inset by 1px to account for cases where the vertex is on a wall
+   * @returns {Point[]}
+   */
+  get insetVertices() {
+    const vertices = [];
+
+    for (const offset of this.document.getOccupiedGridSpaceOffsets(this.center)) {
+      const topLeftPoint = { x: (offset.j - 1) * canvas.grid.size, y: (offset.i - 1) * canvas.grid.size };
+
+      const topLeft = { x: topLeftPoint + 1, y: topLeftPoint + 1 };
+      const topRight = { x: topLeftPoint.x + canvas.grid.size - 1, y: topLeftPoint.y };
+      const bottomLeft = { x: topLeftPoint.x, y: topLeftPoint.y + canvas.grid.size - 1 };
+      const bottomRight = { x: topLeftPoint.x + canvas.grid.size - 1, y: topLeftPoint.y + canvas.grid.size - 1 };
+
+      vertices.push(topLeft, topRight, bottomLeft, bottomRight);
+    }
+
+    return vertices;
+  }
+
+  /**
+   * Determine if any of the token's occupied squares are adjacent to any of the target's occupied squares.
+   * @param {DrawSteelToken} target
+   * @returns {boolean}
+   */
+  isAdjacentTo(target) {
+    const tokenOffsets = this.document.getOccupiedGridSpaceOffsets(this.center);
+    const targetOffsets = target.document.getOccupiedGridSpaceOffsets(target.center);
+
+    for (const tokenOffset of tokenOffsets) {
+      for (const targetOffset of targetOffsets) {
+        const adjacent = canvas.grid.testAdjacency(tokenOffset, targetOffset);
+        if (adjacent) return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Return all allies adjacent to the target with line of effect
+   * @param {*} target
+   * @returns {DrawSteelToken[]}
+   */
+  getAdjacentAllies(target) {
+    const alliedTokens = [];
+    for (const token of canvas.tokens.placeables) {
+      if ((token === this) || (this.document.disposition !== token.document.disposition)) continue;
+      if (!token.isAdjacentTo(target) || !token.hasLineOfEffect(target)) continue;
+
+      alliedTokens.push(token);
+    }
+
+    return alliedTokens;
+  }
+
+  /**
+   * Does this token have line of effect to the target token
+   * @param {DrawSteelToken} token    The token that is moving.
+   * @returns {boolean}
+   */
+  hasLineOfEffect(target) {
+    // TODO: Add flag to walls for "blocks line of effect" that defaults to true.
+    for (const tokenVertex of this.insetVertices) {
+      for (const targetVertex of target.insetVertices) {
+        const hasCollisions = CONFIG.Canvas.polygonBackends.move.testCollision(tokenVertex, targetVertex, { type: "move", mode: "any" });
+        if (!hasCollisions) return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Are this token and the ally on opposite sides or corners of the target.
+   * @param {DrawSteelToken} target
+   * @param {DrawSteelToken} ally
+   * @returns {boolean}
+   */
+  onOppositeSideOrCorner(target, ally) {
+    const { leftEdge, rightEdge, topEdge, bottomEdge } = target.bounds;
+
+    const [intersectsLeft, intersectsRight, intersectsTop, intersectsBottom] = [leftEdge, rightEdge, topEdge, bottomEdge].map(edge => foundry.utils.lineSegmentIntersects(this.center, ally.center, edge.A, edge.B));
+
+    const onOppositeSides = (intersectsLeft && intersectsRight) || (intersectsTop && intersectsBottom);
+    const onOppositeCorners = intersectsLeft && intersectsRight && intersectsTop && intersectsBottom;
+
+    return onOppositeSides || onOppositeCorners;
+  }
+
+  /**
+   * Is the token flanking the target with an ally.
+   * @param {DrawSteelToken} target
+   * @returns {boolean}
+   */
+  isFlanking(target) {
+    if (!this.canFlank || !target.canBeFlanked) return false;
+    if (!this.isAdjacentTo(target) || !this.hasLineOfEffect(target)) return false;
+
+    const adjacentAllies = this.getAdjacentAllies(target);
+    if (adjacentAllies.length === 0) return false;
+
+    for (const ally of adjacentAllies) {
+      // Some features allow you to provide flanking while just adjacent to the target
+      if (ally.actor.system.adjacentFlanking) return true;
+      if (this.onOppositeSideOrCorner(target, ally)) return true;
+    }
+
+    return false;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -27,16 +27,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
    */
   get canFlank() {
     // Checking if active effects have restricted triggered abilities
-    if (this.actor.system.restrictions.type.has("triggered")) return false;
-
-    // Checking if statuses have restricted triggered abilities
-    for (const effect of CONFIG.statusEffects) {
-      if (!this.actor.statuses.has(effect.id) || !effect.restrictions) continue;
-
-      if (effect.restrictions.type?.has("triggered")) return false;
-    }
-
-    return true;
+    return !this.actor.system.restrictions.type.has("triggered");
   }
 
   /**
@@ -152,6 +143,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     if (adjacentAllies.length === 0) return false;
 
     for (const ally of adjacentAllies) {
+      if (!ally.canFlank) continue;
       // Some features allow you to provide flanking while just adjacent to the target
       if (ally.actor.system.adjacentFlanking) return true;
       if (this.onOppositeSideOrCorner(target, ally)) return true;

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -53,7 +53,7 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     const vertices = [];
 
     for (const offset of this.document.getOccupiedGridSpaceOffsets()) {
-      const topLeftPoint = { x: (offset.j - 1) * canvas.grid.size, y: (offset.i - 1) * canvas.grid.size };
+      const topLeftPoint = { x: offset.j * canvas.grid.size, y: offset.i * canvas.grid.size };
 
       const topLeft = { x: topLeftPoint.x + 1, y: topLeftPoint.y + 1 };
       const topRight = { x: topLeftPoint.x + canvas.grid.size - 1, y: topLeftPoint.y + 1 };

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -109,6 +109,14 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
     this.potency.average += highestCharacteristic - 1 + this.potency.bonuses;
     this.potency.strong += highestCharacteristic + this.potency.bonuses;
 
+    // Add restrictions based on status effects
+    for (const effect of CONFIG.statusEffects) {
+      if (!this.parent.statuses.has(effect.id) || !effect.restrictions) continue;
+
+      effect.restrictions.type?.forEach(t => this.restrictions.type.add(t));
+      effect.restrictions.dsid?.forEach(d => this.restrictions.dsid.add(d));
+    }
+
     // Set movement speeds when affected by grabbed, restrained, or slowed
     const isSlowed = this.parent.statuses.has("slowed");
     const isGrabbedOrRestrained = this.parent.statuses.has("grabbed") || this.parent.statuses.has("restrained");

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -562,14 +562,6 @@ export default class AbilityModel extends BaseItemModel {
     if (restrictions.type.has(this.type)) return true;
     if (restrictions.dsid.has(this._dsid)) return true;
 
-    // Checking if statuses have restricted this ability based on type or _dsid
-    for (const effect of CONFIG.statusEffects) {
-      if (!this.actor.statuses.has(effect.id) || !effect.restrictions) continue;
-
-      if (effect.restrictions.type?.has(this.type)) return true;
-      if (effect.restrictions.dsid?.has(this._dsid)) return true;
-    }
-
     return false;
   }
 }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -542,6 +542,7 @@ export default class AbilityModel extends BaseItemModel {
 
     // Restrained condition check - targeting restrained gets an edge
     if (targetActor.statuses.has("restrained")) modifiers.edges += 1;
+
     // Flanking checks
     if (this.keywords.has("melee") && this.keywords.has("strike") && token && token.isFlanking(target)) modifiers.edges += 1;
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -438,7 +438,7 @@ export default class AbilityModel extends BaseItemModel {
         targets: [...game.user.targets].reduce((accumulator, target) => {
           accumulator.push({
             uuid: target.actor.uuid,
-            modifiers: this.getTargetModifiers(target.actor),
+            modifiers: this.getTargetModifiers(target),
           });
           return accumulator;
         }, []),
@@ -528,18 +528,22 @@ export default class AbilityModel extends BaseItemModel {
       edges: 0,
       bonuses: 0,
     };
+    const targetActor = target.actor;
+    const token = canvas.tokens.controlled[0]?.actor === this.actor ? canvas.tokens.controlled[0] : null;
 
     //TODO: ALL CONDITION CHECKS
 
     // Frightened condition checks
-    if (DrawSteelActiveEffect.isStatusSource(this.actor, target, "frightened")) modifiers.banes += 1; // Attacking the target frightening the actor
-    if (DrawSteelActiveEffect.isStatusSource(target, this.actor, "frightened")) modifiers.edges += 1; // Attacking the target the actor has frightened
+    if (DrawSteelActiveEffect.isStatusSource(this.actor, targetActor, "frightened")) modifiers.banes += 1; // Attacking the target frightening the actor
+    if (DrawSteelActiveEffect.isStatusSource(targetActor, this.actor, "frightened")) modifiers.edges += 1; // Attacking the target the actor has frightened
 
     // Grabbed condition check - targeting a non-source adds a bane
-    if (DrawSteelActiveEffect.isStatusSource(this.actor, target, "grabbed") === false) modifiers.banes += 1;
+    if (DrawSteelActiveEffect.isStatusSource(this.actor, targetActor, "grabbed") === false) modifiers.banes += 1;
 
     // Restrained condition check - targeting restrained gets an edge
-    if (target.statuses.has("restrained")) modifiers.edges += 1;
+    if (targetActor.statuses.has("restrained")) modifiers.edges += 1;
+    // Flanking checks
+    if (this.keywords.has("melee") && this.keywords.has("strike") && token && token.isFlanking(target)) modifiers.edges += 1;
 
     return modifiers;
   }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -519,7 +519,7 @@ export default class AbilityModel extends BaseItemModel {
 
   /**
    * Get the modifiers based on conditions that apply to ability Power Rolls specific to a target
-   * @param {DrawSteelActor} target A target of the Ability Roll
+   * @param {DrawSteelToken} target A target of the Ability Roll
    * @returns {PowerRollModifiers}
    */
   getTargetModifiers(target) {

--- a/src/module/documents/_module.mjs
+++ b/src/module/documents/_module.mjs
@@ -10,5 +10,6 @@ export { default as DrawSteelCombatant } from "./combatant.mjs";
 export { default as DrawSteelItem } from "./item.mjs";
 export { default as DrawSteelTokenDocument } from "./token.mjs";
 export { default as DrawSteelUser } from "./user.mjs";
+export { default as DrawSteelWallDocument } from "./wall.mjs";
 
 export { default as BaseDocumentMixin } from "./base-document-mixin.mjs";

--- a/src/module/documents/wall.mjs
+++ b/src/module/documents/wall.mjs
@@ -3,6 +3,6 @@
  */
 export default class DrawSteelWallDocument extends foundry.documents.WallDocument {
   get blocksLineOfEffect() {
-    return foundry.utils.getProperty(this.flags, "draw-steel.blocksLineOfEffect") ?? true;
+    return this.getFlag("draw-steel", "blocksLineOfEffect") ?? true;
   }
 }

--- a/src/module/documents/wall.mjs
+++ b/src/module/documents/wall.mjs
@@ -1,0 +1,8 @@
+/**
+ * A document subclass adding system-specific behavior and registered in CONFIG.Wall.documentClass
+ */
+export default class DrawSteelWallDocument extends foundry.documents.WallDocument {
+  get blocksLineOfEffect() {
+    return foundry.utils.getProperty(this.flags, "draw-steel.blocksLineOfEffect") ?? true;
+  }
+}


### PR DESCRIPTION
Closes #451 

- Automates flanking checks. To flank, you need to be adjacent, have line of effect, be able to take triggered actions, and be on opposite sides/corners.
- Adds `DrawSteelToken#isFlanking` with several helper methods.
   - Most notably is `hasLineOfEffect` that checks each corner of each occupied space of the token with  each corner of each occupied space of the target. This can also be used for automating the taunted condition later.
 - Added an input to the Wall Config for if a wall should block LoE. In `hasLineOfEffect`, verify that each wall collision blocks LoE. This defaults to true

<details closed>
<summary>Wall Config image</summary>
<img src="https://github.com/user-attachments/assets/58f5dc6f-d24a-4c79-87a0-a8e62af92d2b">
</details>