### PR TITLE
Fix setting power roll characteristic for negative values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 ### Known Issues
 -->
 
+## 0.7.1
+
+### Fixed
+- Fix setting the power roll characteristic if all applicable characteristics are negative.
+
 ## 0.7.0 Foundry v13 Alpha
 
 ### Added

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -95,7 +95,7 @@ export default class AbilityModel extends BaseItemModel {
 
     this.power.characteristic = {
       key: "",
-      value: null,
+      value: -5,
     };
   }
 


### PR DESCRIPTION
Set the initial value to the minimum score of -5 so that any score of -5 to +5 will set the value/key.