### PR TITLE
Added type parameter to constructHTMLButton, defaulting to "button"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@
 ## 0.7.1
 
 ### Added
-- Automated flanking bonuses when requirements are met (#451)
+- Automated flanking bonuses when requirements are met. (#451)
 - Added a flag to the wall documents to configure if a wall should block of line of effect.
 
 ### Fixed
-- Fix setting the power roll characteristic if all applicable characteristics are negative.
+- Using the Enter key to submit a character or item sheet will no longer also toggle the sheet mode. (#501)
+- Fixed setting the power roll characteristic if all applicable characteristics are negative.
 
 ## 0.7.0 Foundry v13 Alpha
 

--- a/src/module/utils/construct-html-button.mjs
+++ b/src/module/utils/construct-html-button.mjs
@@ -5,10 +5,12 @@
  * @param {Record<string, string>} [config.dataset={}]
  * @param {string[]} [config.classes=[]]
  * @param {string} [config.icon=""]
+ * @param {"button" | "submit"} [config.type="button"]
  * @returns {HTMLButtonElement}
  */
-export default function constructHTMLButton({ label, dataset = {}, classes = [], icon = "" }) {
+export default function constructHTMLButton({ label, dataset = {}, classes = [], icon = "", type = "button" }) {
   const button = document.createElement("button");
+  button.type = type;
 
   for (const [key, value] of Object.entries(dataset)) {
     button.dataset[key] = value;


### PR DESCRIPTION
Basically, hitting enter and calling the submit event *that* way would cause the form to search for the first button with `type="submit"`, which due to the missing parameter and the move of the button to our header would be the toggle mode button.

Closes #510 