### PR TITLE
Fixed doubled characteristic dice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed setting the power roll characteristic if all applicable characteristics are negative.
 - Fixed missing story text from ability embeds. (#506)
 - Fixed kit speed bonuses not applying. (#511)
+- Fixed doubled roll display for characteristic rolls from Dice So Nice. (#522)
 
 ## 0.7.0 Foundry v13 Alpha
 

--- a/src/module/helpers/dsn.mjs
+++ b/src/module/helpers/dsn.mjs
@@ -11,8 +11,8 @@
  * @param {boolean} context.blind If the roll is blind for the current user
  */
 export function diceSoNiceRollStart(messageId, context) {
-  const message = game.messages.get(messageId);
-  if (message?.type !== "abilityUse") return;
+  // `rollOrder === 999` as a special-case way we check for "Don't display these rolls"
+  // Added by the PowerRoll.prompt factory method
   if (game.settings.get("dice-so-nice", "enabledSimultaneousRollForMessage")) {
     const terms = context.roll.terms.filter((t, i, arr) => {
       if (t.options.rollOrder === 999) return false;


### PR DESCRIPTION
Removed the abilityUse check, meaning that this should hold up for any use of the PowerRoll.prompt method

Closes #496 