### PR TITLE
Prevent characteristic scores from becoming `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 ### Known Issues
 -->
 
+### 0.7.2
+
+### Fixed
+- Fixed an issue that allowed characteristics to become null, instead of defaulting back to 0.
+
 ## 0.7.1
 
 ### Added

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -16,7 +16,7 @@ const fields = foundry.data.fields;
 export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.TypeDataModel) {
   /** @inheritdoc */
   static defineSchema() {
-    const characteristic = { min: -5, max: 5, initial: 0, integer: true };
+    const characteristic = { min: -5, max: 5, initial: 0, integer: true, nullable: false };
     const schema = {};
 
     schema.stamina = new fields.SchemaField({


### PR DESCRIPTION
If a characteristic was `0`, changing other values on the sheet would make the characteristic scores `null` because a score of 0 makes the input empty.