### PR TITLE
Fixed Free Strike Logic

### DIFF
--- a/draw-steel.d.ts
+++ b/draw-steel.d.ts
@@ -1,5 +1,6 @@
 import "./src/module/_types";
 import "@client/global.mjs";
+import "@common/primitives/global.mjs";
 import Canvas from "@client/canvas/board.mjs";
 
 // Foundry's use of `Object.assign(globalThis) means many globally available objects are not read as such

--- a/lang/en.json
+++ b/lang/en.json
@@ -339,6 +339,7 @@
           }
         },
         "FreeStrike": {
+          "MultiLinked": "You can only target one copy of a linked actor.",
           "NoTargets": "Select one or more targets to make a free strike!",
           "DialogHeader": "{value} {type} Damage",
           "DialogTitle": "Free Strike",

--- a/src/module/applications/sheets/npc.mjs
+++ b/src/module/applications/sheets/npc.mjs
@@ -232,6 +232,11 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    */
   static async #freeStrike(event, target) {
+    try { game.user.targets.map(t => t.actor); } catch (e) {
+      ui.notifications.error("DRAW_STEEL.Actor.NPC.FreeStrike.MultiLinked", { localize: true });
+      throw (e);
+    }
+
     /** @type {Array<DrawSteelActor>} */
     const targets = game.user.targets.map(t => t.actor).filter(a => a?.system?.takeDamage).toObject();
     if (!targets.length) {
@@ -254,6 +259,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
       const formGroup = foundry.applications.fields.createFormGroup({
         label: a.name,
         input: checkboxInput,
+        classes: ["inline"],
       });
       // style fix
       const label = formGroup.querySelector("label");

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -6,6 +6,7 @@ import SourceModel from "../models/source.mjs";
 /** @import DrawSteelItem from "../../documents/item.mjs"; */
 /** @import AbilityModel from "../item/ability.mjs"; */
 /** @import { MaliceModel } from "../settings/_module.mjs"; */
+/** @import DamagePowerRollEffect from "../pseudo-documents/power-roll-effects/damage-effect.mjs"; */
 
 /**
  * NPCs are created and controlled by the director
@@ -90,10 +91,14 @@ export default class NPCModel extends BaseActorModel {
     const signature = this.parent.items.find(i => (i.type === "ability") && (i.system.category === "signature"));
     /** @type {Set<string>} */
     const keywords = signature ? new Set(["magic", "psionic", "weapon"]).intersection(signature.system.keywords) : new Set();
+
+    /** @type {DamagePowerRollEffect} */
+    const firstDamage = signature?.system.power.effects.find(e => e.type === "damage");
+
     const freeStrike = {
       value: this.monster.freeStrike,
       keywords: keywords.add("strike"),
-      type: signature?.system.powerRoll.tier1.damage.type ?? "",
+      type: firstDamage?.damage.tier1.types.first() ?? "",
       range: {
         melee: 1,
         ranged: 5,


### PR DESCRIPTION
I think signature abilities will basically never have either/or damage types so this is probably fine? If we need to we can expand the dialog to allow a choice of damage type

Closes #544 