### PR TITLE
Added Spend to embedded display

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -249,7 +249,9 @@ export default class AbilityModel extends BaseItemModel {
     const config = ds.CONFIG.abilities;
     const formattedLabels = this.formattedLabels;
 
-    context.resourceName = this.actor?.system.coreResource?.name ?? game.i18n.localize("DRAW_STEEL.Actor.Character.FIELDS.hero.primary.value.label");
+    const resourceName = this.actor?.system.coreResource?.name ?? game.i18n.localize("DRAW_STEEL.Actor.Character.FIELDS.hero.primary.value.label");
+
+    context.resourceName = resourceName;
 
     context.keywordList = formattedLabels.keywords;
     context.actionTypes = Object.entries(config.types).map(([value, { label }]) => ({ value, label }));
@@ -293,6 +295,11 @@ export default class AbilityModel extends BaseItemModel {
 
     context.enrichedBeforeEffect = await enrichHTML(this.effect.before, { relativeTo: this.parent });
     context.enrichedAfterEffect = await enrichHTML(this.effect.after, { relativeTo: this.parent });
+
+    context.spendLabel = game.i18n.format("DRAW_STEEL.Item.Ability.ConfigureUse.SpendLabel", {
+      value: this.spend.value ?? "",
+      name: resourceName,
+    });
   }
 
   /* -------------------------------------------------- */

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -231,6 +231,16 @@
       .metadata dl {
         grid-template-columns: auto 1fr auto 1fr;
       }
+
+      .draw-steel.ability {
+        dd.effect {
+          :first-child {
+            /* Ensures the text lines up with the dt element */
+            margin-top: 0;
+            padding-top: 0;
+          }
+        }
+      }
     }
   }
 

--- a/templates/item/embeds/ability.hbs
+++ b/templates/item/embeds/ability.hbs
@@ -62,3 +62,11 @@
   </dl>
 </section>
 {{/if}}
+{{#if system.spend.text}}
+<section class="spend">
+  <dl>
+    <dt>{{spendLabel}}</dt>
+    <dd>{{{system.spend.text}}}</dd>
+  </dl>
+</section>
+{{/if}}


### PR DESCRIPTION
Crude display of our Spend field. While doing this I'm realizing we probably need a more comprehensive fix as part of #475 that is kinda making me wonder if we're going to want _another_ set of Sudokus, with the explicit idea that modules that add classes will be responsible for adding a new resource-mangement sudoku to implement their weird take on spends

![image](https://github.com/user-attachments/assets/2948ac1e-1fd0-4475-b7c6-1b5a232af8f3)

![image](https://github.com/user-attachments/assets/757e8d6e-1336-42ca-aa34-58d8f05bbf40)

Closes #398