### PR TITLE
Minion Squad Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 ### Fixed
 - Fixed an issue that allowed characteristics to become null, instead of defaulting back to 0.
 - Fixed free strikes not applying. (#544)
+- Minions which have unlinked tokens in a squad but are not themselves in a squad will not display as if they are in a squad. (#561)
 
 ## 0.7.1
 

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -191,7 +191,11 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
    * @returns {Set<DrawSteelCombatantGroup>}
    */
   get combatGroups() {
-    return new Set(game.combat?.getCombatantsByActor(this.parent).map(c => c.group).filter(group => !!group) ?? []);
+    const combatants = game.combat?.getCombatantsByActor(this.parent) ?? [];
+    // The root actor will match to *all* unlinked tokens, so need to check against that
+    const actorMatches = combatants.filter(c => c.actor === this.parent);
+    const groups = actorMatches.map(c => c.group).filter(g => !!g);
+    return new Set(groups);
   }
 
   /**

--- a/templates/actor/npc/stats.hbs
+++ b/templates/actor/npc/stats.hbs
@@ -19,7 +19,13 @@
           </div>
           <div class="resource-current">
             {{#if isSingleSquadMinion}}
-            {{formGroup combatGroup.system.schema.fields.staminaValue value=combatGroup.system.staminaValue name="squadStaminaValue" classes="paired"}}
+            {{formGroup
+            combatGroup.system.schema.fields.staminaValue
+            value=combatGroup.system.staminaValue
+            name="squadStaminaValue"
+            classes="paired"
+            label=(localize "TYPES.CombatantGroup.squad")
+            }}
             {{else}}
             {{formGroup
             systemFields.stamina.fields.value


### PR DESCRIPTION
Minions which have unlinked tokens in a squad but are not themselves in a squad will not display as if they are in a squad.

Closes #561 