### PR TITLE
Fixed item creation

### DIFF
--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -37,7 +37,7 @@ export default class BaseItemModel extends SubtypeModelMixin(foundry.abstract.Ty
      * The Draw Steel ID, indicating a unique game rules element
      * @remarks `readonly: true` makes this non-iterable
      */
-    schema._dsid = new fields.StringField({ blank: false, readonly: true });
+    schema._dsid = new fields.StringField({ required: true, readonly: true });
 
     return schema;
   }


### PR DESCRIPTION
Adjusted "missing" value for _dsid from undefined to the empty string, fixing some logic in `DataModel#_initialize`

```js
      // Readonly fields
      else if ( field.readonly ) {
        if ( this[name] !== undefined ) continue;
        Object.defineProperty(this, name, {value, writable: false});
      }
```

Closes #592