### PR TITLE
Various improvements to mixins

### DIFF
--- a/src/module/applications/api/pseudo-document-sheet.mjs
+++ b/src/module/applications/api/pseudo-document-sheet.mjs
@@ -167,21 +167,6 @@ export default class PseudoDocumentSheet extends HandlebarsApplicationMixin(Appl
 
   /* -------------------------------------------------- */
 
-  /**
-   * Utility context preparation method for individual fields.
-   * @param {string} path   The path to the given field, relative to the root of the pseudo document.
-   * @returns {object}      Field context.
-   */
-  _prepareField(path) {
-    const doc = this.pseudoDocument;
-    const field = doc.schema.getField(path);
-    const value = foundry.utils.getProperty(doc, path);
-    const src = foundry.utils.getProperty(doc._source, path);
-    return { field, value, src, name: path };
-  }
-
-  /* -------------------------------------------------- */
-
   /** @inheritdoc */
   async _renderFrame(options) {
     const frame = await super._renderFrame(options);

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -106,7 +106,6 @@ export default class AbilityModel extends BaseItemModel {
     super.prepareDerivedData();
 
     this.power.roll.enabled = this.power.effects.size > 0;
-    for (const effect of this.power.effects) effect.prepareDerivedData();
     if (this.actor?.type === "character") this._prepareCharacterData();
   }
 

--- a/src/module/documents/base-document-mixin.mjs
+++ b/src/module/documents/base-document-mixin.mjs
@@ -11,12 +11,55 @@ export default base => {
   return class DrawSteelDocument extends base {
     /** @inheritdoc */
     getEmbeddedDocument(embeddedName, id, { invalid = false, strict = false } = {}) {
-      const systemEmbeds = this.system.constructor.metadata.embedded ?? {};
+      const systemEmbeds = this.system?.constructor.metadata.embedded ?? {};
       if (embeddedName in systemEmbeds) {
         const path = systemEmbeds[embeddedName];
         return foundry.utils.getProperty(this, path).get(id, { invalid, strict }) ?? null;
       }
       return super.getEmbeddedDocument(embeddedName, id, { invalid, strict });
+    }
+
+    /* -------------------------------------------------- */
+
+    /**
+     * Obtain the embedded collection of a given pseudo-document type.
+     * @param {string} embeddedName   The document name of the embedded collection.
+     * @returns {ModelCollection}     The embedded collection.
+     */
+    getEmbeddedPseudoDocumentCollection(embeddedName) {
+      const collectionPath = this.system?.constructor.metadata.embedded?.[embeddedName];
+      if (!collectionPath) {
+        throw new Error(
+          `${embeddedName} is not a valid embedded Pseudo-Document within the [${this.type}] ${this.documentName} subtype!`,
+        );
+      }
+      return foundry.utils.getProperty(this, collectionPath);
+    }
+
+    /* -------------------------------------------------- */
+
+    /** @inheritdoc */
+    prepareBaseData() {
+      super.prepareBaseData();
+      const documentNames = Object.keys(this.system?.constructor.metadata?.embedded ?? {});
+      for (const documentName of documentNames) {
+        for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) {
+          pseudoDocument.prepareBaseData();
+        }
+      }
+    }
+
+    /* -------------------------------------------------- */
+
+    /** @inheritdoc */
+    prepareDerivedData() {
+      super.prepareDerivedData();
+      const documentNames = Object.keys(this.system?.constructor.metadata?.embedded ?? {});
+      for (const documentName of documentNames) {
+        for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) {
+          pseudoDocument.prepareDerivedData();
+        }
+      }
     }
   };
 };


### PR DESCRIPTION
Gonna need a lot of retrieving, creating, deleting of pseudo-documents, and a lot of data preparation as well. This automates the process of the latter, and standardizes how to do the former on the various document sheets.

Mark-up of html should contain (on the clicked element or on a parent of it):
- `data-pseudo-document-name` (required; eg "PowerRollEffect" or "Advancement").
- `data-pseudo-id` (required if deleting or retrieving; the id of the pseudo-document).
- `data-pseudo-type` (required if creating and you *don't* want a dialog to pick the type; eg "itemGrant").

Data preparation should be automatic now; each document calling `prepareBaseData` and `prepareDerivedData` for each pseudo-document in their various collections.

Question: Can implement similar standard for non-pseudo embedded documents. I have done this in a different system (same mark-up as above but dropping the `pseudo-`). This however does not work with the default drag-drop handling. I found that was not a great loss (it requires explicitly being eg `data-item-id`).