### PR TITLE
Add equipment stacking

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -728,6 +728,9 @@
           "keywords": {
             "label": "Keywords"
           },
+          "quantity": {
+            "label": "Quantity"
+          },
           "project": {
             "label": "Project",
             "prerequisites": {

--- a/src/module/applications/sheets/character.mjs
+++ b/src/module/applications/sheets/character.mjs
@@ -14,6 +14,7 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
       takeRespite: this.#takeRespite,
       spendRecovery: this.#spendRecovery,
       spendStaminaHeroToken: this.#spendStaminaHeroToken,
+      modifyItemQuantity: this.#modifyItemQuantity,
     },
   };
 
@@ -228,6 +229,23 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
    */
   static async #spendStaminaHeroToken() {
     await this.actor.system.spendStaminaHeroToken();
+  }
+
+  /**
+   * Modify the quantity of a piece of equipment.
+   * @this DrawSteelCharacterSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   */
+  static async #modifyItemQuantity(event, target) {
+    const quantityModification = target.dataset.quantityModification;
+    const item = this._getEmbeddedDocument(target);
+    if (!item) return;
+
+    const quantity = item.system.quantity ?? 0;
+    const updatedQuantity = (quantityModification === "increase") ? quantity + 1 : quantity - 1;
+
+    item.update({ "system.quantity": updatedQuantity });
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -54,16 +54,6 @@ export default class EquipmentModel extends BaseItemModel {
   }
 
   /** @inheritdoc */
-  _onUpdate(changed, options, userId) {
-    if (this.quantity === 0) {
-      this.parent.delete();
-      return;
-    }
-
-    super._onUpdate(changed, options, userId);
-  }
-
-  /** @inheritdoc */
   async getSheetContext(context) {
     context.categories = Object.entries(ds.CONFIG.equipment.categories).map(([value, { label }]) => ({ value, label }));
 

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -1,6 +1,6 @@
 import { systemPath } from "../../constants.mjs";
 import FormulaField from "../fields/formula-field.mjs";
-import { setOptions } from "../helpers.mjs";
+import { requiredInteger, setOptions } from "../helpers.mjs";
 import BaseItemModel from "./base.mjs";
 
 /** @import { DrawSteelActor } from "../../documents/_module.mjs"; */
@@ -37,6 +37,8 @@ export default class EquipmentModel extends BaseItemModel {
 
     schema.keywords = new fields.SetField(setOptions());
 
+    schema.quantity = requiredInteger({ initial: 1 });
+
     schema.project = new fields.SchemaField({
       prerequisites: new fields.StringField({ required: true }),
       source: new fields.StringField({ required: true }),
@@ -49,6 +51,16 @@ export default class EquipmentModel extends BaseItemModel {
     });
 
     return schema;
+  }
+
+  /** @inheritdoc */
+  _onUpdate(changed, options, userId) {
+    if (this.quantity === 0) {
+      this.parent.delete();
+      return;
+    }
+
+    super._onUpdate(changed, options, userId);
   }
 
   /** @inheritdoc */

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -261,7 +261,7 @@ export default class ProjectModel extends BaseItemModel {
     if (existingItem) {
       await existingItem.update({ "system.quantity": existingItem.system.quantity + amount });
     } else {
-      const itemData = item.toObject();
+      const itemData = game.items.fromCompendium(item);
       itemData.system.quantity = amount;
       await this.actor.createEmbeddedDocuments("Item", [itemData]);
     }

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -87,7 +87,7 @@ export class ProjectRoll extends DSRoll {
       skills: options.skills,
     };
 
-    const promptValue = await PowerRollDialog.prompt({
+    const promptValue = await PowerRollDialog.create({
       context,
       window: {
         title: "DRAW_STEEL.Roll.Project.Label",

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -269,6 +269,22 @@
       .item-echelon {
         width: 100px;
       }
+
+      .item-quantity {
+        width: 75px;
+
+        &.quantity-controls {
+          display: flex;
+
+          a[data-action="modifyItemQuantity"] {
+            padding: 0px 5px;
+          }
+
+          .quantity {
+            flex-grow: 1;
+          }
+        }
+      }
     }
   }
 

--- a/templates/actor/character/equipment.hbs
+++ b/templates/actor/character/equipment.hbs
@@ -59,6 +59,7 @@
     <div class="item-header">
       <div class="item-column item-name">{{equipmentCategory.label}}</div>
       <div class="item-column item-echelon">{{@root.equipmentFields.echelon.label}}</div>
+      <div class="item-column item-quantity">{{@root.equipmentFields.quantity.label}}</div>
       <div class="item-column item-controls">
         {{#unless (eq @key "other")}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.equipment")) as |addItemTooltip|}}
@@ -80,6 +81,15 @@
             </div>
           </div>
           <div class="item-column item-echelon">{{localize (concat "DRAW_STEEL.Echelon." equipmentContext.item.system.echelon)}}</div>
+          <div class="item-column item-quantity quantity-controls">
+            <a data-action="modifyItemQuantity" data-quantity-modification="decrease">
+              <i class="fa-regular fa-minus"></i>
+            </a>
+            <span class="quantity">{{equipmentContext.item.system.quantity}}</span>
+            <a data-action="modifyItemQuantity" data-quantity-modification="increase">
+              <i class="fa-regular fa-plus"></i>
+            </a>
+          </div>
           <div class="item-column item-controls">
             <a data-action="toggleItemEmbed">
               <i class="fa-solid fa-angle-{{ifThen equipmentContext.expanded "down" "right"}}"></i>

--- a/templates/item/partials/equipment.hbs
+++ b/templates/item/partials/equipment.hbs
@@ -2,6 +2,7 @@
 {{formGroup systemFields.kind value=system.kind options=kinds disabled=isPlay}}
 {{formGroup systemFields.echelon value=system.echelon options=echelons disabled=isPlay}}
 {{formGroup systemFields.keywords value=system.keywords options=keywords disabled=isPlay}}
+{{formGroup systemFields.quantity value=system.quantity disabled=isPlay}}
 <fieldset>
   <legend>{{systemFields.project.label}}</legend>
   {{formGroup systemFields.project.fields.prerequisites value=system.project.prerequisites disabled=isPlay}}


### PR DESCRIPTION
Closes #558 

- Adds `quantity` to the `EquipmentModel`.
- Adds a quantity column to the equipment item lists with -/+ buttons for easy decrease/increase.
- Updated the crafting project method to use the new quantity field instead of creating a new item for each yield. 
   - It attempts to find an existing item by dsid and increases that quantity instead
   - Incidentally fixes an issue with project rolls using the old `prompt` method instead of the new `create` method.

![equipment-stacking](https://github.com/user-attachments/assets/87a3679f-00f0-4c7a-9a2e-bd25474e5f46)
