### PR TITLE
Pseudo-document upkeep

### DIFF
--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -2,7 +2,7 @@ import PseudoDocument from "./pseudo-document.mjs";
 
 /** @import { TypedPseudoDocumentCreateDialogOptions } from "./_types" */
 
-const { StringField } = foundry.data.fields;
+const { DocumentTypeField } = foundry.data.fields;
 
 /**
  * A variant of PseudoDocument that allows for polymorphism across different values of `type`.
@@ -11,14 +11,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      type: new StringField({
-        initial: () => this.TYPE,
-        required: true,
-        blank: false,
-        readonly: true,
-        validate: value => value === this.TYPE,
-        validationError: `Type can only be '${this.TYPE}'.`,
-      }),
+      type: new DocumentTypeField(this),
     });
   }
 
@@ -49,7 +42,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
   /* -------------------------------------------------- */
 
   /**
-   * The localized label for this typed pseudodocument's type
+   * The localized label for this typed pseudodocument's type.
    * @type {string}
    */
   get typeLabel() {


### PR DESCRIPTION
Pseudo-documents support having embedded sudokus of their own, so data prep should be relegated to the parent sudo.

Also turns out we can use `DocumentTypeField`. Controversial? Perhaps.

Also fixes the fact that `isSource` always threw an error for AEs adding sudos - this was something that had come about from a change before sudos were added to DS. This new implementation of `isSource` should fix that by relying on `metadata.embedded`.

Also adds drag data method to sudos which will be relevant down the line.