### PR TITLE
Updated actor sheet Ability and Equipment header display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Changed
 
 - Unused ability sections are no longer displayed in play mode.
+- "Add Ability" button only displays in edit mode.
 
 ## 0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,17 @@
 ### Known Issues
 -->
 
-### 0.7.2
+## 0.7.3
+
+### Added
+
+- Equipment now has a "quantity" property. Completing a project will now add to an equipment's quantity if it already exists on the actor, based on matching `dsid` values. (#558)
+
+### Changed
+
+- Unused ability sections are no longer displayed in play mode.
+
+## 0.7.2
 
 ### Added
 - Added support for the automatic end of effects. (#551)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@
 
 ### Changed
 
-- Unused ability sections are no longer displayed in play mode.
-- "Add Ability" button only displays in edit mode.
+- Adjusted display of the actor sheets in play mode
+  - Unused ability and equipment sections are no longer displayed in play mode.
+  - Add Item buttons only display in edit mode.
 
 ## 0.7.2
 

--- a/src/module/applications/sheets/_types.d.ts
+++ b/src/module/applications/sheets/_types.d.ts
@@ -45,10 +45,13 @@ interface ActorSheetAbilityContext extends ActorSheetItemContext {
 
 export interface ActorSheetAbilitiesContext {
   label: string;
-  abilities: ActorSheetAbilityContext[]
+  abilities: ActorSheetAbilityContext[];
+  showAdd: boolean;
+  showHeader: boolean;
 }
 
 export interface ActorSheetEquipmentContext {
   label: string;
-  equipment: ActorSheetItemContext[]
+  equipment: ActorSheetItemContext[];
+  showAdd: boolean;
 }

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -327,6 +327,8 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
       context[type] = {
         label: config.label,
         abilities: [],
+        showHeader: true,
+        showAdd: this.isEditMode,
       };
     }
 
@@ -334,6 +336,9 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
     context["other"] = {
       label: game.i18n.localize("DRAW_STEEL.Sheet.Other"),
       abilities: [],
+      showAdd: false,
+      // Show "other" if and only if there are abilities of that type
+      showHeader: false,
     };
 
     // Prepare the context for each individual ability
@@ -348,6 +353,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
         const villainActionCount = context[type].abilities.length;
         abilityContext.order = villainActionCount + 1;
       }
+      context[type].showHeader = true;
 
       context[type].abilities.push(abilityContext);
     }

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -311,9 +311,11 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
 
   /**
    * Prepare the context for ability categories and individual abilities
-   * @returns {Record<keyof typeof ds["CONFIG"]["abilities"]["types"] | "other", ActorSheetAbilitiesContext>}
    */
   async _prepareAbilitiesContext() {
+    /**
+     * @type {Record<string, ActorSheetAbilitiesContext>}
+     */
     const context = {};
     const abilities = this.actor.itemTypes.ability.toSorted((a, b) => a.sort - b.sort);
 
@@ -348,6 +350,13 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
       }
 
       context[type].abilities.push(abilityContext);
+    }
+
+    // Filter out unused headers for play mode
+    if (this.isPlayMode) {
+      for (const [key, value] of Object.entries(context)) {
+        if (!value.abilities.length) delete context[key];
+      }
     }
 
     return context;

--- a/src/module/applications/sheets/character.mjs
+++ b/src/module/applications/sheets/character.mjs
@@ -123,6 +123,8 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
       context[category] = {
         label: config.label,
         equipment: [],
+        showAdd: this.isEditMode,
+        showHeader: this.isEditMode,
       };
     }
 
@@ -130,12 +132,15 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
     context["other"] = {
       label: game.i18n.localize("DRAW_STEEL.Sheet.Other"),
       equipment: [],
+      showAdd: false,
+      // Show "other" if and only if there is equipment of that category
+      showHeader: false,
     };
 
     // Prepare the context for each individual equipment item
     for (const item of equipment) {
       const category = context[item.system.category] ? item.system.category : "other";
-
+      context[category].showHeader = true;
       context[category].equipment.push(await this._prepareItemContext(item));
     }
 

--- a/src/module/applications/sheets/character.mjs
+++ b/src/module/applications/sheets/character.mjs
@@ -3,7 +3,7 @@ import { EquipmentModel, KitModel, ProjectModel } from "../../data/item/_module.
 import DrawSteelActorSheet from "./actor-sheet.mjs";
 
 /** @import { HeroTokenModel } from "../../data/settings/hero-tokens.mjs"; */
-/** @import { ActorSheetItemContext, ActorSheetEquipmentContext } from "../_types.js" */
+/** @import { ActorSheetItemContext, ActorSheetEquipmentContext } from "./_types.js" */
 
 export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
   static DEFAULT_OPTIONS = {
@@ -112,9 +112,9 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
 
   /**
    * Prepare the context for equipment categories and individual equipment items
-   * @returns {Record<keyof typeof ds["CONFIG"]["equipment"]["categories"] | "other", ActorSheetEquipmentContext>}
    */
   async _prepareEquipmentContext() {
+    /** @type {Record<string, ActorSheetEquipmentContext>} */
     const context = {};
     const equipment = this.actor.itemTypes.equipment.toSorted((a, b) => a.sort - b.sort);
 
@@ -137,6 +137,13 @@ export default class DrawSteelCharacterSheet extends DrawSteelActorSheet {
       const category = context[item.system.category] ? item.system.category : "other";
 
       context[category].equipment.push(await this._prepareItemContext(item));
+    }
+
+    // Filter out unused headers for play mode
+    if (this.isPlayMode) {
+      for (const [key, value] of Object.entries(context)) {
+        if (!value.equipment.length) delete context[key];
+      }
     }
 
     return context;

--- a/templates/actor/character/equipment.hbs
+++ b/templates/actor/character/equipment.hbs
@@ -56,20 +56,20 @@
   {{! Equipments List}}
   {{#each equipment as |equipmentCategory|}}
   {{!-- Don't show the "Other" category if there's no other equipment --}}
-  {{#if (or (ne @key "other") (and (eq @key "other") (gte equipmentCategory.equipment.length 1)))}}
+  {{#if equipmentCategory.showHeader}}
   <section class="item-list-container equipment-list-container">
     <div class="item-header">
       <div class="item-column item-name">{{equipmentCategory.label}}</div>
       <div class="item-column item-echelon">{{@root.equipmentFields.echelon.label}}</div>
       <div class="item-column item-quantity">{{@root.equipmentFields.quantity.label}}</div>
       <div class="item-column item-controls">
-        {{#unless (or (eq @key "other") @root.isPlay)}}
+        {{#if equipmentCategory.showAdd}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.equipment")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="equipment" data-render-sheet="true" data-system.category="{{@key}}" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}
-        {{/unless}}
+        {{/if}}
       </div>
     </div>
     <ol class="item-list2 equipment-list">

--- a/templates/actor/character/equipment.hbs
+++ b/templates/actor/character/equipment.hbs
@@ -14,11 +14,13 @@
       <div class="item-column item-melee-bonus">{{kitFields.bonuses.fields.melee.fields.damage.label}}</div>
       <div class="item-column item-ranged-bonus">{{kitFields.bonuses.fields.ranged.fields.damage.label}}</div>
       <div class="item-column item-controls">
+        {{#unless isPlay}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.kit")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="kit" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}
+        {{/unless}}
       </div>
     </div>
     <ol class="item-list2 kit-list">
@@ -61,7 +63,7 @@
       <div class="item-column item-echelon">{{@root.equipmentFields.echelon.label}}</div>
       <div class="item-column item-quantity">{{@root.equipmentFields.quantity.label}}</div>
       <div class="item-column item-controls">
-        {{#unless (eq @key "other")}}
+        {{#unless (or (eq @key "other") @root.isPlay)}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.equipment")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="equipment" data-render-sheet="true" data-system.category="{{@key}}" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -14,7 +14,7 @@
       <div class="item-column item-distance">{{@root.abilityFields.distance.label}}</div>
       <div class="item-column item-target">{{@root.abilityFields.target.label}}</div>
       <div class="item-column item-controls">
-        {{#unless (eq @key "other")}}
+        {{#unless (or (eq @key "other") @root.isPlay)}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -1,8 +1,7 @@
 {{! Abilities Tab }}
 <section class="tab abilities {{tab.cssClass}}" data-group="primary" data-tab="abilities">
   {{#each abilities as |abilityType|}}
-  {{!-- Don't show the "Other" category if there's no other abilities --}}
-  {{#if (or (ne @key "other") (and (eq @key "other") (gte abilityType.abilities.length 1)))}}
+  {{#if abilityType.showHeader}}
   <section class="item-list-container">
     <div class="item-header">
       <div class="item-column item-name">{{abilityType.label}}</div>
@@ -14,13 +13,13 @@
       <div class="item-column item-distance">{{@root.abilityFields.distance.label}}</div>
       <div class="item-column item-target">{{@root.abilityFields.target.label}}</div>
       <div class="item-column item-controls">
-        {{#unless (or (eq @key "other") @root.isPlay)}}
+        {{#if abilityType.showAdd}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}
-        {{/unless}}
+        {{/if}}
       </div>
     </div>
     <ol class="item-list2 abilities-list">


### PR DESCRIPTION
- Initialized Changelog
- Adjusted display of the actor sheets in play mode
  - Unused ability and equipment sections are no longer displayed in play mode.
  - Add Item buttons only display in edit mode (also functions as a permission check)

![image](https://github.com/user-attachments/assets/7c9b0484-5ddf-4fc1-a776-7b6f814a0938)

![image](https://github.com/user-attachments/assets/a0eaa90c-4986-401d-bdf4-21c1d354e732)