### PR TITLE
Major refactor of DS Rolls & type updates

### DIFF
--- a/src/module/applications/apps/power-roll-dialog.mjs
+++ b/src/module/applications/apps/power-roll-dialog.mjs
@@ -1,5 +1,5 @@
 import { systemPath } from "../../constants.mjs";
-import { PowerRoll } from "../../rolls/power.mjs";
+import PowerRoll from "../../rolls/power.mjs";
 import RollDialog from "../api/roll-dialog.mjs";
 
 const { FormDataExtended } = foundry.applications.ux;

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -429,7 +429,7 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
 
   /**
    * Fetch information about the core resource for this actor subtype.
-   * {@linkcode AbilityModel.use | AbilityModel#use}
+   * @see {@linkcode AbilityModel.use | AbilityModel#use}
    * @abstract
    * @returns {{
    *  name: string;
@@ -443,7 +443,7 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
 
   /**
    * Update the core resource for this actor subtype
-   * {@linkcode AbilityModel.use | AbilityModel#use}
+   * @see {@linkcode AbilityModel.use | AbilityModel#use}
    * @param {number} delta Change in value
    */
   async updateResource(delta) {

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -1,5 +1,5 @@
 import DrawSteelChatMessage from "../../documents/chat-message.mjs";
-import { PowerRoll } from "../../rolls/power.mjs";
+import PowerRoll from "../../rolls/power.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import { damageTypes, requiredInteger, setOptions } from "../helpers.mjs";
 import SizeModel from "../models/size.mjs";
@@ -429,7 +429,7 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
 
   /**
    * Fetch information about the core resource for this actor subtype.
-   * {@link AbilityModel#use}
+   * {@linkcode AbilityModel.use | AbilityModel#use}
    * @abstract
    * @returns {{
    *  name: string;
@@ -443,7 +443,7 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
 
   /**
    * Update the core resource for this actor subtype
-   * {@link AbilityModel#use}
+   * {@linkcode AbilityModel.use | AbilityModel#use}
    * @param {number} delta Change in value
    */
   async updateResource(delta) {

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -1,5 +1,5 @@
 import { DrawSteelActor, DrawSteelChatMessage } from "../../documents/_module.mjs";
-import { DSRoll } from "../../rolls/base.mjs";
+import DSRoll from "../../rolls/base.mjs";
 import { barAttribute, requiredInteger, setOptions } from "../helpers.mjs";
 import BaseActorModel from "./base.mjs";
 

--- a/src/module/data/effect/base.mjs
+++ b/src/module/data/effect/base.mjs
@@ -1,5 +1,5 @@
 import SavingThrowDialog from "../../applications/apps/saving-throw-dialog.mjs";
-import { SavingThrowRoll } from "../../rolls/_module.mjs";
+import SavingThrowRoll from "../../rolls/saving-throw.mjs";
 import enrichHTML from "../../utils/enrich-html.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -500,8 +500,7 @@ export default class AbilityModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /**
-   * An alias of use.
-   * @see {AbilityModel#use}
+   * An alias of {@linkcode use}.
    */
   async roll(options = {}) {
     this.use(options);

--- a/src/module/data/message/ability-use.mjs
+++ b/src/module/data/message/ability-use.mjs
@@ -1,4 +1,4 @@
-import { DamageRoll } from "../../rolls/damage.mjs";
+import DamageRoll from "../../rolls/damage.mjs";
 import BaseMessageModel from "./base.mjs";
 
 /** @import AbilityModel from "../item/ability.mjs" */
@@ -79,7 +79,7 @@ export default class AbilityUseModel extends BaseMessageModel {
   /* -------------------------------------------------- */
 
   /**
-   * Create an array of damage buttons based on each {@link DamageRoll} in this message's rolls.
+   * Create an array of damage buttons based on each {@linkcode DamageRoll} in this message's rolls.
    * @returns {HTMLButtonElement[]}
    * @protected
    */

--- a/src/module/data/message/base.mjs
+++ b/src/module/data/message/base.mjs
@@ -47,7 +47,7 @@ export default class BaseMessageModel extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------------- */
 
   /**
-   * Add event listeners. Guaranteed to run after all alterations in {@link alterMessageHTML}
+   * Add event listeners. Guaranteed to run after all alterations in {@linkcode alterMessageHTML}
    * Called by the renderChatMessageHTML hook
    * @param {HTMLLIElement} html The pending HTML
    */

--- a/src/module/data/message/saving-throw.mjs
+++ b/src/module/data/message/saving-throw.mjs
@@ -1,6 +1,6 @@
 import BaseMessageModel from "./base.mjs";
 
-/** @import { SavingThrowRoll } from "../../rolls/savingThrow.mjs" */
+/** @import { SavingThrowRoll } from "../../rolls/saving-throw.mjs" */
 /** @import DrawSteelActiveEffect from "../../documents/active-effect.mjs"; */
 
 const fields = foundry.data.fields;

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -1,11 +1,9 @@
-import { DSRoll } from "../../../rolls/base.mjs";
-import FormulaField from "../../fields/formula-field.mjs";
 import { setOptions } from "../../helpers.mjs";
 import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 
 /** @import { AppliedEffectSchema } from "./_types" */
 
-const { SetField, StringField, SchemaField } = foundry.data.fields;
+const { SetField, StringField } = foundry.data.fields;
 
 /**
  * For abilities that apply an ActiveEffect

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -1,4 +1,3 @@
-import { DSRoll } from "../../../rolls/base.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 import { setOptions } from "../../helpers.mjs";
 import BasePowerRollEffect from "./base-power-roll-effect.mjs";

--- a/src/module/documents/advancement/advancement.mjs
+++ b/src/module/documents/advancement/advancement.mjs
@@ -1,8 +1,10 @@
 // import AdvancementConfig from "../../applications/advancement/advancement-config.mjs";
 // import AdvancementFlow from "../../applications/advancement/advancement-flow.mjs";
 import BaseAdvancement from "../../data/advancement/base.mjs";
-/** @import { DrawSteelActor } from "../actor.mjs" */
-/** @import { DrawSteelItem } from "../item.mjs" */
+
+/** @import Application from "@client/applications/api/application.mjs" */
+/** @import ClientDocumentMixin from "@client/documents/abstract/client-document.mjs" */
+/** @import { DrawSteelActor, DrawSteelItem } from "../_module.mjs" */
 /** @import { AdvancementMetadata } from "./_types" */
 
 /**
@@ -30,8 +32,8 @@ export default class Advancement extends BaseAdvancement {
     /**
      * A collection of Application instances which should be re-rendered whenever this document is updated.
      * The keys of this object are the application ids and the values are Application instances. Each
-     * Application in this object will have its render method called by {@link Document#render}.
-     * @type {Object<Application>}
+     * Application in this object will have its render method called by {@linkcode ClientDocumentMixin | ClientDocument#render}.
+     * @type {Record<string, Application>}
      */
     Object.defineProperty(this, "apps", {
       value: {},

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -1,7 +1,7 @@
 import SavingThrowManager from "../applications/apps/saving-throw-manager.mjs";
 import { systemID } from "../constants.mjs";
 import BaseEffectModel from "../data/effect/base.mjs";
-import { DSRoll } from "../rolls/base.mjs";
+import DSRoll from "../rolls/base.mjs";
 
 /** @import ActiveEffectData from "@common/documents/_types.mjs" */
 /** @import { MaliceModel } from "../data/settings/malice.mjs" */
@@ -97,7 +97,7 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
   /**
    * @param {DrawSteelCombatant | DrawSteelCombatantGroup} a Some combatant
    * @param {DrawSteelCombatant | DrawSteelCombatantGroup} b Some other combatant
-   * @returns {number} The sort for an {@link Array#sort} callback
+   * @returns {number} The sort for an {@linkcode Array.sort | Array#sort} callback
    * @protected
    * @inheritdoc
    */

--- a/src/module/helpers/dsn.mjs
+++ b/src/module/helpers/dsn.mjs
@@ -1,5 +1,5 @@
 /** @import DrawSteelUser from "../documents/user.mjs"; */
-/** @import { DSRoll } from "../rolls/base.mjs"; */
+/** @import DSRoll from "../rolls/base.mjs"; */
 
 /**
  * Called when a 3D roll starts from the hook of the Chat message or when showForRoll is called directly from the API.

--- a/src/module/rolls/_module.mjs
+++ b/src/module/rolls/_module.mjs
@@ -1,5 +1,5 @@
-export { DSRoll } from "./base.mjs";
-export { DamageRoll } from "./damage.mjs";
-export { PowerRoll } from "./power.mjs";
-export { ProjectRoll } from "./project.mjs";
-export { SavingThrowRoll } from "./savingThrow.mjs";
+export { default as DSRoll } from "./base.mjs";
+export { default as DamageRoll } from "./damage.mjs";
+export { default as PowerRoll } from "./power.mjs";
+export { default as ProjectRoll } from "./project.mjs";
+export { default as SavingThrowRoll } from "./saving-throw.mjs";

--- a/src/module/rolls/base.mjs
+++ b/src/module/rolls/base.mjs
@@ -2,28 +2,4 @@
 /**
  * Base roll class for Draw Steel
  */
-export class DSRoll extends foundry.dice.Roll {
-  /** @inheritdoc */
-  async render({ flavor, template = this.constructor.CHAT_TEMPLATE, isPrivate = false } = {}) {
-    if (!this._evaluated) await this.evaluate({ allowInteractive: !isPrivate });
-    const chatData = await this._prepareContext({ flavor, isPrivate });
-    return foundry.applications.handlebars.renderTemplate(template, chatData);
-  }
-
-  /**
-   * Helper function to generate render context in use with `static CHAT_TEMPLATE`
-   * @param {object} options
-   * @param {string} [options.flavor]     Flavor text to include
-   * @param {boolean} [options.isPrivate] Is the Roll displayed privately?
-   * @returns An object to be used in `renderTemplate`
-   */
-  async _prepareContext({ flavor, isPrivate }) {
-    return {
-      formula: isPrivate ? "???" : this._formula,
-      flavor: isPrivate ? null : flavor ?? this.options.flavor,
-      user: game.user.id,
-      tooltip: isPrivate ? "" : await this.getTooltip(),
-      total: isPrivate ? "?" : Math.round(this.total * 100) / 100,
-    };
-  }
-}
+export default class DSRoll extends foundry.dice.Roll { }

--- a/src/module/rolls/damage.mjs
+++ b/src/module/rolls/damage.mjs
@@ -1,9 +1,9 @@
-import { DSRoll } from "./base.mjs";
+import DSRoll from "./base.mjs";
 
 /**
  * Contains damage-specific info like damage types
  */
-export class DamageRoll extends DSRoll {
+export default class DamageRoll extends DSRoll {
   /**
    * The damage type
    * @type {keyof typeof ds["CONFIG"]["damageTypes"]}

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -1,13 +1,13 @@
 import { systemPath } from "../constants.mjs";
 import DrawSteelChatMessage from "../documents/chat-message.mjs";
-import { DSRoll } from "./base.mjs";
+import DSRoll from "./base.mjs";
 
 /** @import { PowerRollPrompt, PowerRollPromptOptions } from "../_types.js" */
 
 /**
  * Augments the Roll class with specific functionality for power rolls
  */
-export class PowerRoll extends DSRoll {
+export default class PowerRoll extends DSRoll {
   constructor(formula = "2d10", data = {}, options = {}) {
     super(formula, data, options);
     foundry.utils.mergeObject(this.options, this.constructor.DEFAULT_OPTIONS, {
@@ -277,8 +277,9 @@ export class PowerRoll extends DSRoll {
     return flavorlessRoll.formula;
   }
 
-  async _prepareContext({ flavor, isPrivate }) {
-    const context = await super._prepareContext({ flavor, isPrivate });
+  /** @inheritdoc */
+  async _prepareChatRenderContext({ flavor, isPrivate = false, ...options } = {}) {
+    const context = await super._prepareChatRenderContext({ flavor, isPrivate, ...options });
 
     context.tier = {
       label: game.i18n.localize(this.constructor.RESULT_TIERS[this.tier].label),

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -1,4 +1,4 @@
-import { DSRoll } from "./base.mjs";
+import DSRoll from "./base.mjs";
 import { systemPath } from "../constants.mjs";
 import PowerRollDialog from "../applications/apps/power-roll-dialog.mjs";
 import DrawSteelChatMessage from "../documents/chat-message.mjs";
@@ -8,7 +8,7 @@ import DrawSteelChatMessage from "../documents/chat-message.mjs";
 /**
  * Special test used during downtime
  */
-export class ProjectRoll extends DSRoll {
+export default class ProjectRoll extends DSRoll {
   constructor(formula = "2d10", data = {}, options = {}) {
     super(formula, data, options);
     foundry.utils.mergeObject(this.options, this.constructor.DEFAULT_OPTIONS, {
@@ -175,8 +175,9 @@ export class ProjectRoll extends DSRoll {
     return this.isCritical;
   }
 
-  async _prepareContext({ flavor, isPrivate }) {
-    const context = await super._prepareContext({ flavor, isPrivate });
+  /** @inheritdoc */
+  async _prepareChatRenderContext({ flavor, isPrivate = false, ...options } = {}) {
+    const context = await super._prepareChatRenderContext({ flavor, isPrivate, ...options });
 
     let modString = "";
 

--- a/src/module/rolls/saving-throw.mjs
+++ b/src/module/rolls/saving-throw.mjs
@@ -1,10 +1,10 @@
-import { DSRoll } from "./base.mjs";
+import DSRoll from "./base.mjs";
 import { systemPath } from "../constants.mjs";
 
 /**
  * Usually a flat d10 roll to shake free of a persistent condition
  */
-export class SavingThrowRoll extends DSRoll {
+export default class SavingThrowRoll extends DSRoll {
   /**
    * @param {string} [formula="1d10"]        Default saving throw is a flat 1d10
    * @param {Record<string, any>} [data]     Roll data
@@ -34,22 +34,15 @@ export class SavingThrowRoll extends DSRoll {
     return this.total >= this.successThreshold;
   }
 
-  /**
-   * Helper function to generate render context in use with `static CHAT_TEMPLATE`
-   * @param {object} options
-   * @param {string} [options.flavor]     Flavor text to include
-   * @param {boolean} [options.isPrivate] Is the Roll displayed privately?
-   * @returns An object to be used in `renderTemplate`
-   */
-  async _prepareContext({ flavor, isPrivate }) {
-    return {
-      formula: isPrivate ? "???" : this._formula,
-      flavor: isPrivate ? null : flavor ?? this.options.flavor ?? game.i18n.localize("DRAW_STEEL.Roll.Save.Label"),
-      user: game.user.id,
-      tooltip: isPrivate ? "" : await this.getTooltip(),
-      total: isPrivate ? "?" : Math.round(this.total * 100) / 100,
-      result: this.product ? "critical" : "failure",
-    };
+  /** @inheritdoc */
+  async _prepareChatRenderContext({ flavor, isPrivate = false, ...options } = {}) {
+    const context = await super._prepareChatRenderContext({ flavor, isPrivate, ...options });
+
+    if (!isPrivate) context.flavor ??= game.i18n.localize("DRAW_STEEL.Roll.Save.Label");
+
+    context.result = this.product ? "critical" : "failure";
+
+    return context;
   }
 
   /** @inheritdoc */

--- a/src/module/utils/evaluate-formula.mjs
+++ b/src/module/utils/evaluate-formula.mjs
@@ -1,4 +1,4 @@
-import { DSRoll } from "../rolls/base.mjs";
+import DSRoll from "../rolls/base.mjs";
 
 /**
  * Helper function to perform synchronous evaluation of a user-input formula


### PR DESCRIPTION
- Removed _prepareContext in favor of core's _prepareChatContext, which has identical behavior to what we had but with a slightly different function name
- Adjusted Rolls to use default exports
- General migration of `@link` to `@linkcode` in the doc strings
- Ensured consistency for links pointing to instance methods; VSCode has its own standard of *only* using . methods, so need to use the pipe labels 
![image](https://github.com/user-attachments/assets/ba47b316-b18c-4c03-a2f3-e862a1df08d2)
