### PR TITLE
Made better use of core css

### DIFF
--- a/src/styles/system/applications/api/roll-dialog.css
+++ b/src/styles/system/applications/api/roll-dialog.css
@@ -5,23 +5,13 @@
     margin-top: 5px;
 
     .roll-mode-buttons {
-      display: flex;
+      button {
+        border-color: var(--button-border-color);
+      }
 
       button.selected {
         background: var(--button-hover-background-color);
-        color: var(--button-hover-text-color)
-      }
-
-      button:not(:first-of-type, :last-of-type) {
-        border-radius: 0px;
-      }
-
-      button:first-of-type {
-        border-radius: 5px 0px 0px 5px;
-      }
-
-      button:last-of-type {
-        border-radius: 0px 5px 5px 0px;
+        color: var(--button-hover-text-color);
       }
     }
 

--- a/templates/rolls/roll-dialog-footer.hbs
+++ b/templates/rolls/roll-dialog-footer.hbs
@@ -2,10 +2,14 @@
   <button type="submit">
     <i class="fa-solid fa-dice-d10"></i> {{localize "DRAW_STEEL.Roll.Button"}}
   </button>
-  <div class="roll-mode-buttons">
+  <div class="roll-mode-buttons split-button">
     {{#each rollModes as |rollMode|}}
-    <button type="button" class="{{ifThen (eq @root.rollMode @key) "selected" ""}}" data-action="setRollMode" data-roll-mode="{{@key}}" data-tooltip="{{rollMode.label}}">
-      <i class="{{rollMode.icon}}"></i>
+    <button
+      type="button"
+      class="{{ifThen (eq @root.rollMode @key) "selected" ""}} ui-control icon {{rollMode.icon}}"
+      data-action="setRollMode"
+      data-roll-mode="{{@key}}"
+      data-tooltip="{{rollMode.label}}">
     </button>
     {{/each}}
   </div>


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/96555510-f090-415a-b565-9b311dbf71c2)

After
![image](https://github.com/user-attachments/assets/d6572bbd-b475-4157-a336-c055c3716d28)

I remembered that the split-button class existed and was useful, so I implemented it.