### PR TITLE
Overhauled Actor and Item Effects Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ### Changed
 
+- Overhauled the Effects tab of the Item & Actor sheets. (#146)
+  - Actor sheets now feature a "Status Conditions" section which lists the conditions specific to Draw Steel.
+    - Clicking the buttons will toggle the status
+    - If you have a status, it will be highlighted in orange
+    - If the status is granted by a non-canonical condition, the button will be disabled
+  - Hitting "New Effect" in the "Temporary Effects" section will now set the duration to End of Turn, instead of 1 round.
 - Replaced the default token status menu with a new one that allows applying a status with one of Draw Steel's unique durations. (#261)
 - Adjusted display of the actor sheets in play mode. (#609)
   - Unused ability and equipment sections are no longer displayed in play mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     - If you have a status, it will be highlighted in orange
     - If the status is granted by a non-canonical condition, the button will be disabled
   - Hitting "New Effect" in the "Temporary Effects" section will now set the duration to End of Turn, instead of 1 round.
+  - An effect's enriched description is now available by toggling the carat, like already existed for items.
 - Replaced the default token status menu with a new one that allows applying a status with one of Draw Steel's unique durations. (#261)
 - Adjusted display of the actor sheets in play mode. (#609)
   - Unused ability and equipment sections are no longer displayed in play mode.

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -59,10 +59,10 @@ Hooks.once("init", function () {
   CONFIG.statusEffects = CONFIG.statusEffects.filter(effect => !toRemove.includes(effect.id));
   // Status Effect Transfer
   for (const [id, value] of Object.entries(DRAW_STEEL.conditions)) {
-    CONFIG.statusEffects.push({ id, ...value });
+    CONFIG.statusEffects.push({ id, _id: id.padEnd(16, "0"), ...value });
   }
   for (const [id, value] of Object.entries(DS_CONST.staminaEffects)) {
-    CONFIG.statusEffects.push({ id, ...value });
+    CONFIG.statusEffects.push({ id, _id: id.padEnd(16, "0"), ...value });
   }
 
   // Destructuring some pieces for simplification

--- a/lang/en.json
+++ b/lang/en.json
@@ -982,6 +982,7 @@
     },
     "Effect": {
       "Name": "Effect",
+      "StatusConditions": "Status Conditions",
       "Source": "Source",
       "Toggle": "Toggle Effect",
       "Temporary": "Temporary Effects",

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -383,7 +383,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
    * @property {string} _id
    * @property {string} name
    * @property {string} img
-   * @property {"disabled" | ""} disabled
+   * @property {boolean} disabled
    * @property {"active" | ""} active
    * @property {string} [tooltip]
    */
@@ -402,7 +402,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
         _id: status._id,
         name: status.name,
         img: status.img,
-        disabled: "",
+        disabled: false,
         active: "",
       };
 
@@ -418,7 +418,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
       for (const id of effect.statuses) {
         if (!(id in statusInfo)) continue;
         statusInfo[id].active = "active";
-        if (!Object.values(statusInfo).some(s => s._id === effect._id)) statusInfo[id].disabled = "disabled";
+        if (!Object.values(statusInfo).some(s => s._id === effect._id)) statusInfo[id].disabled = true;
       }
     }
 
@@ -743,6 +743,8 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
 
     await docCls.create(docData, { parent: this.actor, renderSheet: target.dataset.renderSheet });
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Creates or deletes a configured status effect

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -828,7 +828,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
 
   /**
    * Toggle the effect description between visible and hidden. Only visible descriptions are generated in the HTML
-   *
+   * TODO: Refactor re-rendering to instead use CSS transitions
    * @this DrawSteelActorSheet
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
@@ -848,7 +848,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
 
   /**
    * Toggle the item embed between visible and hidden. Only visible embeds are generated in the HTML
-   *
+   * TODO: Refactor re-rendering to instead use CSS transitions
    * @this DrawSteelActorSheet
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -219,25 +219,26 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     };
 
     // Iterate over active effects, classifying them into categories
-    for (const e of this.item.effects) { const effectContext = {
-      id: e.id,
-      name: e.name,
-      img: e.img,
-      sourceName: e.sourceName,
-      duration: e.duration,
-      disabled: e.disabled,
-      expanded: false,
-    };
+    for (const e of this.item.effects) {
+      const effectContext = {
+        id: e.id,
+        name: e.name,
+        img: e.img,
+        sourceName: e.sourceName,
+        duration: e.duration,
+        disabled: e.disabled,
+        expanded: false,
+      };
 
-    if (this.#expanded.has(e.id)) {
-      effectContext.expanded = true;
-      effectContext.enrichedDescription = await enrichHTML(e.description, { relativeTo: e });
-    }
+      if (this.#expanded.has(e.id)) {
+        effectContext.expanded = true;
+        effectContext.enrichedDescription = await enrichHTML(e.description, { relativeTo: e });
+      }
 
-    if (!e.transfer) categories.applied.effects.push(effectContext);
-    else if (!e.active) categories.inactive.effects.push(effectContext);
-    else if (e.isTemporary) categories.temporary.effects.push(effectContext);
-    else categories.passive.effects.push(effectContext);
+      if (!e.transfer) categories.applied.effects.push(effectContext);
+      else if (!e.active) categories.inactive.effects.push(effectContext);
+      else if (e.isTemporary) categories.temporary.effects.push(effectContext);
+      else categories.passive.effects.push(effectContext);
     }
 
     // Sort each category

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -147,7 +147,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
         context.enrichedAfterEffect = await enrichHTML(this.item.system.effect.after, { relativeTo: this.item });
         break;
       case "effects":
-        context.effects = this.prepareActiveEffectCategories();
+        context.effects = this._prepareActiveEffectCategories();
         break;
     }
     return context;
@@ -182,8 +182,9 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
   /**
    * Prepare the data structure for Active Effects which are currently embedded in an Item.
    * @return {Record<string, ActiveEffectCategory>} Data for rendering
+   * @protected
    */
-  prepareActiveEffectCategories() {
+  _prepareActiveEffectCategories() {
     /** @type {Record<string, ActiveEffectCategory>} */
     const categories = {
       temporary: {
@@ -239,6 +240,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
   /**
    * Context menu entries for power rolls
    * @returns {ContextMenuEntry}
+   * @protected
    */
   _powerRollContextOptions() {
     return [

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -512,7 +512,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
 
   /**
    * Toggle the effect description between visible and hidden. Only visible descriptions are generated in the HTML
-   *
+   * TODO: Refactor re-rendering to instead use CSS transitions
    * @this DrawSteelItemSheet
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -156,6 +156,7 @@ preLocalize("healingTypes", { key: "label" });
 /**
  * Condition definitions provided by the system that are merged in during the `init` hook
  * Afterwards all references *should* use the core-provided CONFIG.statusEffects
+ * The `_id` property is handled as part of the merging process
  * @type {Record<string, {
  *  img: string,
  *  name: string,

--- a/src/module/constants.mjs
+++ b/src/module/constants.mjs
@@ -28,11 +28,13 @@ export const initiativeModes = Object.freeze({
 export const staminaEffects = Object.freeze({
   dying: {
     name: "DRAW_STEEL.Effect.StaminaEffects.Dying",
+    hud: false,
     img: "icons/svg/stoned.svg",
     threshold: 0,
   },
   winded: {
     name: "DRAW_STEEL.Effect.StaminaEffects.Winded",
+    hud: false,
     img: "icons/svg/windmill.svg",
     threshold: "system.stamina.winded",
   },

--- a/src/module/data/_types.d.ts
+++ b/src/module/data/_types.d.ts
@@ -16,8 +16,10 @@ export type BarAttribute = {
 };
 
 export type SubtypeMetadata = {
+  /** The registered document subtype in system.json */
+  type: string;
   /* Record of document names of pseudo-documents and the path to the collection. */
-  embedded: Record<string, string>
+  embedded: Record<string, string>;
 };
 
 export type PseudoDocumentMetadata = {

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -11,7 +11,10 @@ const fields = foundry.data.fields;
  * Characters are controlled by players and have heroic resources and advancement
  */
 export default class CharacterModel extends BaseActorModel {
-  /** @inheritdoc */
+  /**
+   * @inheritdoc
+   * @type {import("../_types").SubtypeMetadata}
+   */
   static get metadata() {
     return foundry.utils.mergeObject(super.metadata, {
       type: "character",

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -12,7 +12,10 @@ import SourceModel from "../models/source.mjs";
  * NPCs are created and controlled by the director
  */
 export default class NPCModel extends BaseActorModel {
-  /** @inheritdoc */
+  /**
+   * @inheritdoc
+   * @type {import("../_types").SubtypeMetadata}
+   */
   static get metadata() {
     return foundry.utils.mergeObject(super.metadata, {
       type: "npc",

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -1,11 +1,22 @@
 import TargetedConditionPrompt from "../applications/apps/targeted-condition-prompt.mjs";
 
+/** @import { StatusEffectConfig } from "@client/config.mjs" */
 /** @import DrawSteelActor from "./actor.mjs"; */
 
 /**
  * A document subclass adding system-specific behavior and registered in CONFIG.ActiveEffect.documentClass
  */
 export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffect {
+  /**
+   * Checks if a status condition applies to the actor
+   * @param {StatusEffectConfig} status
+   * @param {DrawSteelActor} actor
+   * @returns {boolean} Will be shown on the token hud for the actor
+   */
+  static validHud(status, actor) {
+    return (status.hud !== false) && ((foundry.utils.getType(status.hud) !== "Object") || (status.hud.actorTypes?.includes(actor.type)));
+  }
+
   /** @inheritdoc */
   static async _fromStatusEffect(statusId, effectData, options) {
     if (effectData.rule) effectData.description = `@Embed[${effectData.rule} inline]`;

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -9,13 +9,16 @@ import TargetedConditionPrompt from "../applications/apps/targeted-condition-pro
 export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffect {
   /**
    * Checks if a status condition applies to the actor
-   * @param {StatusEffectConfig} status
-   * @param {DrawSteelActor} actor
+   * @param {StatusEffectConfig} status An entry in CONFIG.statusEffects
+   * @param {DrawSteelActor} actor      The actor to check against for rendering
    * @returns {boolean} Will be shown on the token hud for the actor
    */
   static validHud(status, actor) {
-    return (status.hud !== false) && ((foundry.utils.getType(status.hud) !== "Object") || (status.hud.actorTypes?.includes(actor.type)));
+    return (status.hud !== false) &&
+      ((foundry.utils.getType(status.hud) !== "Object") || (status.hud.actorTypes?.includes(actor.type)));
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static async _fromStatusEffect(statusId, effectData, options) {
@@ -25,6 +28,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     const effect = await super._fromStatusEffect(statusId, effectData, options);
     return effect;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Modify the effectData for the new effect with the changes to include the imposing actor's UUID in the appropriate flag.
@@ -48,6 +53,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     }
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Determine if the affected actor has the status and if the source is the one imposing it
    * @param {DrawSteelActor} affected The actor affected by the status
@@ -61,6 +68,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     return affected.system.statuses?.[statusId]?.sources.has(source.uuid) ?? null;
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Automatically deactivate effects with expired durations
    * @inheritdoc
@@ -71,11 +80,15 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     else return super.isSuppressed;
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
     Hooks.callAll("ds.prepareActiveEffectData", this);
   }
+
+  /* -------------------------------------------------- */
 
   /** @import { ActiveEffectDuration, EffectDurationData } from "../data/effect/_types" */
 
@@ -89,6 +102,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     return this.system._prepareDuration ?? super._prepareDuration();
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Check if the effect's subtype has special handling, otherwise fallback to normal `duration` and `statuses` check
    * @inheritdoc
@@ -96,6 +111,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
   get isTemporary() {
     return this.system._isTemporary ?? super.isTemporary;
   }
+
+  /* -------------------------------------------------- */
 
   /** @inheritdoc */
   _applyAdd(actor, change, current, delta, changes) {
@@ -120,6 +137,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     }
   }
 
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   _applyOverride(actor, change, current, delta, changes) {
     // If the property is a condition or a Set, convert the delta to a Set
@@ -131,6 +150,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
 
     super._applyOverride(actor, change, current, delta, changes);
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Return a data object which defines the data schema against which dice rolls can be evaluated.

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -1,137 +1,85 @@
 .draw-steel {
-  /* Section Header */
-  .effects-header {
-    height: 28px;
-    margin: 2px 0;
-    padding: 0;
-    align-items: center;
-    background: rgba(0, 0, 0, 0.05);
-    border: var(--border-groove);
-    font-weight: bold;
-    > * {
-      font-size: 14px;
+  .effect-list-container {
+    margin: 10px 0px;
+
+    .effect-row,
+    .effect-header {
+      display: flex;
+      align-items: center;
       text-align: center;
     }
-    .effect-name {
-      font-weight: bold;
-      padding-left: 5px;
-      text-align: left;
-      display: flex;
-      /* font-size: 16px; */
+
+    .effect-header {
+      background-color: var(--draw-steel-c-item-header-bg);
+      border-radius: 5px 5px 0px 0px;
+      position: sticky;
+      top: 0px;
+
+      .effect-name {
+        font-weight: bold;
+        font-size: var(--font-size-16);
+      }
     }
-  }
 
-  /* -----------------------------------------
-  /* Items Lists
-  /* ----------------------------------------- */
+    .effect-name {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      text-align: left;
+      padding: 5px 0px 5px 5px;
+    }
 
-  .effects-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    overflow-y: auto;
-    scrollbar-width: thin;
-    color: var(--draw-steel-c-tan);
+    .effect-source {
+      width: 200px;
+      padding: 0 1rem;
+    }
 
-    /* Child lists */
+    .effect-duration {
+      /* Makes "X Rounds, Y Turns" wrap at the comma */
+      width: 65px;
+    }
+
+    .effect-controls {
+      display: flex;
+      width: 100px;
+      justify-content: space-evenly;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      > * {
+        flex: 1;
+      }
+    }
+
     .effect-list {
       list-style: none;
-      margin: 0;
       padding: 0;
-    }
-
-    /* Item Name */
-    .effect-name {
-      flex: 2;
       margin: 0;
-      overflow: hidden;
-      font-size: 13px;
-      text-align: left;
-      align-items: center;
-      display: flex;
-      h3, h4 {
-        margin: 0;
-        white-space: nowrap;
-        overflow-x: hidden;
-      }
-    }
 
-    /* Control Buttons */
-    .effect-controls {
-      display: flex;
-      flex: 0 0 100px;
-      justify-content: flex-end;
-      a {
-        font-size: 12px;
-        text-align: center;
-        margin: 0 6px;
-      }
-    }
+      .effect {
+        &:nth-child(even) {
+          background-color: var(--draw-steel-c-item-alternating-bg);
+        }
 
-    /* Individual Item */
-    .effect {
-      align-items: center;
-      padding: 0 2px; /* to align with the header border */
-      border-bottom: 1px solid var(--draw-steel-c-faint);
-      &:last-child { border-bottom: none; }
-      .effect-name {
-        color: var(--draw-steel-c-dark);
-        .effect-image {
-          flex: 0 0 30px;
-          height: 30px;
-          background-size: 30px;
-          border: none;
-          margin-right: 5px;
+        .effect-row {
+          .effect-name {
+            gap: 5px;
+
+            img {
+              width: 30px;
+              height: 30px;
+              border: none;
+            }
+
+            .name {
+              .label {
+                font-weight: bold;
+                font-size: var(--font-size-15);
+              }
+            }
+          }
         }
       }
-    }
-
-    .effect-prop {
-      text-align: center;
-      border-left: 1px solid #c9c7b8;
-      border-right: 1px solid #c9c7b8;
-      font-size: 12px;
-    }
-
-    /* Section Header */
-    .effects-header {
-      height: 28px;
-      margin: 2px 0;
-      padding: 0;
-      align-items: center;
-      background: rgba(0, 0, 0, 0.05);
-      border: var(--border-groove);
-      font-weight: bold;
-      > * {
-        font-size: 12px;
-        text-align: center;
-      }
-      .effect-name {
-        padding-left: 5px;
-        text-align: left;
-        /* font-size: 16px; */
-      }
-    }
-  }
-
-  /* Example style for DrawSteel (can be removed if not needed). */
-  .effect-formula {
-    flex: 0 0 200px;
-    padding: 0 8px;
-  }
-
-  .effects .item {
-    .effect-source,
-    .effect-duration,
-    .effect-controls {
-      text-align: center;
-      border-left: 1px solid #c9c7b8;
-      border-right: 1px solid #c9c7b8;
-      font-size: 12px;
-    }
-
-    .effect-controls {
-      border: none;
     }
   }
 }

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -41,6 +41,7 @@
 
     .effect-controls {
       display: flex;
+      padding-left: 10px;
       width: 100px;
       justify-content: space-evenly;
       flex-direction: row;

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -1,34 +1,4 @@
 .draw-steel {
-  .item-list {
-    display: grid;
-    --grid-distance: 184px;
-    grid-template-columns: repeat(auto-fit, minmax(var(--grid-distance), 1em));
-    grid-gap: 6px;
-    &.kits {
-      --grid-distance: 267px;
-      margin: 5px 0 0;
-    }
-    .item {
-      width: var(--grid-distance);
-      padding: 3px;
-      .img {
-        flex: 0 0 30px;
-        max-width: 30px;
-        border-color: var(--button-border-color);
-        border-style: outset;
-        border-width: 2px;
-        margin-right: 2px;
-      }
-      .name {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .delete {
-        flex: 0 0 10px;
-      }
-    }
-  }
   .item-list-container {
     margin: 10px 0px;
 
@@ -65,7 +35,7 @@
       justify-content: space-evenly;
     }
 
-    .item-list2 {
+    .item-list {
       list-style: none;
       padding: 0;
       margin: 0;

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -65,8 +65,8 @@
             }
 
             img {
-              width: 30px;
-              height: 30px;
+              width: 24px;
+              /* height: 30px; */
               border: none;
             }
           }

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -299,8 +299,10 @@
   }
 
   [data-application-part="effects"] {
+    gap: 0;
+
     .status-container {
-      padding: 0.5rem;
+      padding-top: 0.25rem;
       gap: 0.5rem;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -302,7 +302,14 @@
     .status-container {
       padding: 0.5rem;
       gap: 0.5rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
       .status-control {
+        &.active {
+          outline-width: 2px;
+          border-width: 0;
+        }
+
         padding: 0.25rem 1rem;
         img {
           max-height: 100%;

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -203,7 +203,7 @@
     }
   }
 
-  .tab.abilities .item-list-container {
+  [data-application-part="abilities"] .item-list-container {
 
     .item-cost,
     .item-distance,
@@ -244,7 +244,7 @@
     }
   }
 
-  .tab.features {
+  [data-application-part="features"] {
 
     .feature-list-container {
 
@@ -255,7 +255,7 @@
     }
   }
 
-  .tab.equipment {
+  [data-application-part="equipment"] {
     .kit-list-container {
 
       .item-melee-bonus,
@@ -288,7 +288,7 @@
     }
   }
 
-  .tab.projects .item-list-container {
+  [data-application-part="projects"] .item-list-container {
     .item-type {
       width: 75px;
     }

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -299,22 +299,26 @@
   }
 
   [data-application-part="effects"] {
+    &.standard-form { padding-top: 0; }
     gap: 0;
 
-    .status-container {
-      padding-top: 0.25rem;
-      gap: 0.5rem;
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      .status-control {
-        &.active {
-          outline-width: 2px;
-          border-width: 0;
-        }
+    .status-effects {
+      margin-top: 0.5rem;
+      .status-container {
+        padding-top: 0.25rem;
+        gap: 0.5rem;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        .status-control {
+          &.active {
+            outline-width: 2px;
+            border-width: 0;
+          }
 
-        padding: 0.25rem 1rem;
-        img {
-          max-height: 100%;
+          padding: 0.25rem 1rem;
+          img {
+            max-height: 100%;
+          }
         }
       }
     }

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -298,7 +298,20 @@
     }
   }
 
-  .tab.biography {
+  [data-application-part="effects"] {
+    .status-container {
+      padding: 0.5rem;
+      gap: 0.5rem;
+      .status-control {
+        padding: 0.25rem 1rem;
+        img {
+          max-height: 100%;
+        }
+      }
+    }
+  }
+
+  [data-application-part="biography"] {
     .negotiation {
       .fixed-stats {
         margin-top: 0;

--- a/templates/actor/character/equipment.hbs
+++ b/templates/actor/character/equipment.hbs
@@ -23,7 +23,7 @@
         {{/unless}}
       </div>
     </div>
-    <ol class="item-list2 kit-list">
+    <ol class="item-list kit-list">
       {{#each kits as |kitContext|}}
       <li class="item feature draggable" data-item-id="{{kitContext.item.id}}" data-document-class="Item">
         <div class="item-row">
@@ -72,7 +72,7 @@
         {{/if}}
       </div>
     </div>
-    <ol class="item-list2 equipment-list">
+    <ol class="item-list equipment-list">
       {{#each equipmentCategory.equipment as |equipmentContext|}}
       <li class="item equipment draggable" data-item-id="{{equipmentContext.item.id}}" data-document-class="Item">
         <div class="item-row">

--- a/templates/actor/character/projects.hbs
+++ b/templates/actor/character/projects.hbs
@@ -15,7 +15,7 @@
         {{/unless}}
       </div>
     </div>
-    <ol class="item-list2 project-list">
+    <ol class="item-list project-list">
       {{#each projects as |projectContext|}}
       <li class="item project draggable" data-item-id="{{projectContext.item.id}}" data-document-class="Item">
         <div class="item-row">

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -22,7 +22,7 @@
         {{/if}}
       </div>
     </div>
-    <ol class="item-list2 abilities-list">
+    <ol class="item-list abilities-list">
       {{#each abilityType.abilities as |abilityContext|}}
       <li class="item ability draggable" data-item-id="{{abilityContext.item.id}}" data-document-class="Item">
         <div class="item-row">

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -2,12 +2,11 @@
 <section class="tab effects flexcol {{tab.cssClass}}" data-group="primary" data-tab="effects">
   <div class="status-effects">
     <h4>{{localize "EFFECT.FIELDS.statuses.label"}}</h4>
-    {{log this}}
-    <div class="flexrow">
+    <div class="status-container flexrow">
       {{#each statuses as |status id|}}
-      <button type="button" class="{{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip="{{status.tooltip}}">
-        {{!-- <img src="{{status.img}}" alt="{{status.name}}"> --}}
-        {{status.name}}
+      <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip="{{status.tooltip}}" data-action="toggleStatus">
+        <img src="{{status.img}}" alt="{{status.name}}">
+        <span>{{status.name}}</span>
       </button>
       {{/each}}
 

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -4,7 +4,7 @@
     <legend>{{localize "EFFECT.FIELDS.statuses.label"}}</legend>
     <div class="status-container">
       {{#each statuses as |status id|}}
-      <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip="{{status.tooltip}}" data-action="toggleStatus">
+      <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip-html="{{status.tooltip}}" data-action="toggleStatus">
         <img src="{{status.img}}" alt="{{status.name}}">
         <span>{{status.name}}</span>
       </button>
@@ -35,7 +35,7 @@
             {{else if (eq section.type "temporary")}}
             data-system.end.type="turn"
             {{/if}}
-            data-tooltip="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
+            data-tooltip-text="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
           >
             <i class="fa-solid fa-plus"></i>
             {{localize "DOCUMENT.New" type=(localize "DRAW_STEEL.Effect.Name")}}
@@ -58,9 +58,11 @@
               {{#if @root.editable}}
               <a class="effect-control fa-fw fas fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
               {{/if}}
-              <a class="effect-control fa-fw fas fa-edit" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}"></a>
+              {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
+              <a class="effect-control fa-fw fas fa-edit" data-action="viewDoc" data-tooltip-text="{{localize "DOCUMENT.Update" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               {{#if @root.editable}}
-              <a class="effect-control fa-fw fas fa-trash" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}"></a>
+              {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
+              <a class="effect-control fa-fw fas fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
               {{/if}}
             </div>

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -67,8 +67,14 @@
               <a class="effect-control" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
                 <i class="fa-solid fa-trash"></i>
               </a>
+              <a data-action="toggleEffectDescription">
+                <i class="fa-solid fa-angle-{{ifThen effect.expanded "down" "right"}}"></i>
+              </a>
               {{/if}}
             </div>
+          </div>
+          <div class="effect-embed">
+            {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
           </div>
         </li>
         {{/each}}

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -1,7 +1,7 @@
 {{! Effects Tab }}
-<section class="tab effects flexcol {{tab.cssClass}}" data-group="primary" data-tab="effects">
-  <div class="status-effects">
-    <h4>{{localize "EFFECT.FIELDS.statuses.label"}}</h4>
+<section class="tab effects {{tab.cssClass}} standard-form" data-group="primary" data-tab="effects">
+  <fieldset class="status-effects">
+    <legend>{{localize "EFFECT.FIELDS.statuses.label"}}</legend>
     <div class="status-container">
       {{#each statuses as |status id|}}
       <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip="{{status.tooltip}}" data-action="toggleStatus">
@@ -9,67 +9,71 @@
         <span>{{status.name}}</span>
       </button>
       {{/each}}
-
     </div>
-  </div>
-  <ol class="effects-list">
-    {{#each effects as |section sid|}}
-    <li class="effects-header flexrow draggable" data-effect-type="{{section.type}}">
-      <div class="effect-name flexrow">
-        {{localize section.label}}
-      </div>
-      <div class="effect-source">
-        {{localize "DRAW_STEEL.Effect.Source"}}
-      </div>
-      <div class="effect-duration">{{localize "EFFECT.TABS.duration"}}</div>
-      <div class="effect-controls flexrow">
-        <a
-          class="effect-control"
-          data-action="createDoc"
-          data-document-class="ActiveEffect"
-          data-origin="{{@root.document.uuid}}"
-          data-img="icons/svg/aura.svg"
-          {{#if (eq section.type "inactive")}}
-          data-disabled="true"
-          {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
-          {{else if (eq section.type "temporary")}}
-          data-duration.rounds="1"
-          {{/if}}
-          data-tooltip="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
-          >
-          <i class="fa-solid fa-plus"></i>
-          {{localize "DOCUMENT.New" type=(localize "DRAW_STEEL.Effect.Name")}}
-        </a>
-      </div>
-    </li>
-
+  </fieldset>
+  <div class="effect-list-container">
     <ol class="effect-list">
-      {{#each section.effects as |effect|}}
-      <li class="effect effect flexrow draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+      {{#each effects as |section sid|}}
+      <li class="effect-header" data-effect-type="{{section.type}}">
         <div class="effect-name flexrow">
-          <img class="effect-image" src="{{effect.img}}" height="24" width="24" alt="{{effect.name}}">
-          <div>{{effect.name}}</div>
+          {{localize section.label}}
         </div>
-        <div class="effect-source">{{effect.sourceName}}</div>
-        <div class="effect-duration">{{effect.duration.label}}</div>
+        <div class="effect-source">
+          {{localize "DRAW_STEEL.Effect.Source"}}
+        </div>
+        <div class="effect-duration">{{localize "EFFECT.TABS.duration"}}</div>
         <div class="effect-controls flexrow">
-          {{#if @root.editable}}
-          <a class="effect-control" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle">
-            <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+          <a
+            class="effect-control"
+            data-action="createDoc"
+            data-document-class="ActiveEffect"
+            data-origin="{{@root.document.uuid}}"
+            data-img="icons/svg/aura.svg"
+            {{#if (eq section.type "inactive")}}
+            data-disabled="true"
+            {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
+            {{else if (eq section.type "temporary")}}
+            data-system.end.type="turn"
+            {{/if}}
+            data-tooltip="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
+          >
+            <i class="fa-solid fa-plus"></i>
+            {{localize "DOCUMENT.New" type=(localize "DRAW_STEEL.Effect.Name")}}
           </a>
-          {{/if}}
-          <a class="effect-control" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}">
-            <i class="fa-solid fa-edit"></i>
-          </a>
-          {{#if @root.editable}}
-          <a class="effect-control" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
-            <i class="fa-solid fa-trash"></i>
-          </a>
-          {{/if}}
         </div>
       </li>
+      <ol class="effect-list">
+        {{#each section.effects as |effect|}}
+        <li class="effect draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+          <div class="effect-row">
+            <div class="effect-name">
+              <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
+              <div class="name">
+                <div class="label">{{effect.name}}</div>
+              </div>
+            </div>
+            <div class="effect-source">{{effect.sourceName}}</div>
+            <div class="effect-duration">{{effect.duration.label}}</div>
+            <div class="effect-controls">
+              {{#if @root.editable}}
+              <a class="effect-control" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle">
+                <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+              </a>
+              {{/if}}
+              <a class="effect-control" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}">
+                <i class="fa-solid fa-edit"></i>
+              </a>
+              {{#if @root.editable}}
+              <a class="effect-control" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
+                <i class="fa-solid fa-trash"></i>
+              </a>
+              {{/if}}
+            </div>
+          </div>
+        </li>
+        {{/each}}
+      </ol>
       {{/each}}
     </ol>
-    {{/each}}
-  </ol>
+  </div>
 </section>

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -56,20 +56,12 @@
             <div class="effect-duration">{{effect.duration.label}}</div>
             <div class="effect-controls">
               {{#if @root.editable}}
-              <a class="effect-control" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle">
-                <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
-              </a>
+              <a class="effect-control fa-fw fas fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
               {{/if}}
-              <a class="effect-control" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}">
-                <i class="fa-solid fa-edit"></i>
-              </a>
+              <a class="effect-control fa-fw fas fa-edit" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}"></a>
               {{#if @root.editable}}
-              <a class="effect-control" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
-                <i class="fa-solid fa-trash"></i>
-              </a>
-              <a data-action="toggleEffectDescription">
-                <i class="fa-solid fa-angle-{{ifThen effect.expanded "down" "right"}}"></i>
-              </a>
+              <a class="effect-control fa-fw fas fa-trash" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}"></a>
+              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
               {{/if}}
             </div>
           </div>

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -1,7 +1,7 @@
 {{! Effects Tab }}
 <section class="tab effects {{tab.cssClass}} standard-form" data-group="primary" data-tab="effects">
   <fieldset class="status-effects">
-    <legend>{{localize "EFFECT.FIELDS.statuses.label"}}</legend>
+    <legend>{{localize "DRAW_STEEL.Effect.StatusConditions"}}</legend>
     <div class="status-container">
       {{#each statuses as |status id|}}
       <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip-html="{{status.tooltip}}" data-action="toggleStatus">
@@ -56,13 +56,13 @@
             <div class="effect-duration">{{effect.duration.label}}</div>
             <div class="effect-controls">
               {{#if @root.editable}}
-              <a class="effect-control fa-fw fas fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
+              <a class="effect-control fa-fw fa-solid fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
               {{/if}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
-              <a class="effect-control fa-fw fas fa-edit" data-action="viewDoc" data-tooltip-text="{{localize "DOCUMENT.Update" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
+              <a class="effect-control fa-fw fa-solid fa-edit" data-action="viewDoc" data-tooltip-text="{{localize "DOCUMENT.Update" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               {{#if @root.editable}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
-              <a class="effect-control fa-fw fas fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
+              <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
               {{/if}}
             </div>

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -4,7 +4,7 @@
     <legend>{{localize "DRAW_STEEL.Effect.StatusConditions"}}</legend>
     <div class="status-container">
       {{#each statuses as |status id|}}
-      <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip-html="{{status.tooltip}}" data-action="toggleStatus">
+      <button type="button" class="status-control {{status.active}}" {{disabled status.disabled}} data-status-id="{{id}}" data-tooltip-html="{{status.tooltip}}" data-action="toggleStatus">
         <img src="{{status.img}}" alt="{{status.name}}">
         <span>{{status.name}}</span>
       </button>

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -73,7 +73,7 @@
               {{/if}}
             </div>
           </div>
-          <div class="effect-embed">
+          <div class="effect-description">
             {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
           </div>
         </li>

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -1,5 +1,18 @@
 {{! Effects Tab }}
 <section class="tab effects flexcol {{tab.cssClass}}" data-group="primary" data-tab="effects">
+  <div class="status-effects">
+    <h4>{{localize "EFFECT.FIELDS.statuses.label"}}</h4>
+    {{log this}}
+    <div class="flexrow">
+      {{#each statuses as |status id|}}
+      <button type="button" class="{{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip="{{status.tooltip}}">
+        {{!-- <img src="{{status.img}}" alt="{{status.name}}"> --}}
+        {{status.name}}
+      </button>
+      {{/each}}
+
+    </div>
+  </div>
   <ol class="effects-list">
     {{#each effects as |section sid|}}
     <li class="effects-header flexrow draggable" data-effect-type="{{section.type}}">
@@ -9,7 +22,7 @@
       <div class="effect-source">
         {{localize "DRAW_STEEL.Effect.Source"}}
       </div>
-      <div class="effect-source">{{localize "EFFECT.TABS.duration"}}</div>
+      <div class="effect-duration">{{localize "EFFECT.TABS.duration"}}</div>
       <div class="effect-controls flexrow">
         <a
           class="effect-control"

--- a/templates/actor/shared/effects.hbs
+++ b/templates/actor/shared/effects.hbs
@@ -2,7 +2,7 @@
 <section class="tab effects flexcol {{tab.cssClass}}" data-group="primary" data-tab="effects">
   <div class="status-effects">
     <h4>{{localize "EFFECT.FIELDS.statuses.label"}}</h4>
-    <div class="status-container flexrow">
+    <div class="status-container">
       {{#each statuses as |status id|}}
       <button type="button" class="status-control {{status.active}}" {{status.disabled}} data-status-id="{{id}}" data-tooltip="{{status.tooltip}}" data-action="toggleStatus">
         <img src="{{status.img}}" alt="{{status.name}}">

--- a/templates/actor/shared/features.hbs
+++ b/templates/actor/shared/features.hbs
@@ -15,7 +15,7 @@
         {{/unless}}
       </div>
     </div>
-    <ol class="item-list2 feature-list">
+    <ol class="item-list feature-list">
       {{#each features as |featureContext|}}
       <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
         <div class="item-row">

--- a/templates/item/effects.hbs
+++ b/templates/item/effects.hbs
@@ -46,13 +46,13 @@
             <div class="effect-duration">{{effect.duration.label}}</div>
             <div class="effect-controls">
               {{#if @root.editable}}
-              <a class="effect-control fa-fw fas fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
+              <a class="effect-control fa-fw fa-solid fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
               {{/if}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
-              <a class="effect-control fa-fw fas fa-edit" data-action="viewDoc" data-tooltip-text="{{localize "DOCUMENT.Update" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
+              <a class="effect-control fa-fw fa-solid fa-edit" data-action="viewDoc" data-tooltip-text="{{localize "DOCUMENT.Update" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               {{#if @root.editable}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
-              <a class="effect-control fa-fw fas fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
+              <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
             </div>
           </div>

--- a/templates/item/effects.hbs
+++ b/templates/item/effects.hbs
@@ -25,7 +25,7 @@
             {{else if (eq section.type "applied")}}
             data-transfer="false"
             {{/if}}
-            data-tooltip="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
+            data-tooltip-text="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
           >
             <i class="fa-solid fa-plus"></i>
             {{localize "DOCUMENT.New" type=(localize "DRAW_STEEL.Effect.Name")}}
@@ -46,21 +46,14 @@
             <div class="effect-duration">{{effect.duration.label}}</div>
             <div class="effect-controls">
               {{#if @root.editable}}
-              <a class="effect-control" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle">
-                <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
-              </a>
+              <a class="effect-control fa-fw fas fa-{{ifThen effect.disabled 'check' 'times'}}" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle"></a>
               {{/if}}
-              <a class="effect-control" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}">
-                <i class="fa-solid fa-edit"></i>
-              </a>
+              {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
+              <a class="effect-control fa-fw fas fa-edit" data-action="viewDoc" data-tooltip-text="{{localize "DOCUMENT.Update" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
               {{#if @root.editable}}
-              <a class="effect-control" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
-                <i class="fa-solid fa-trash"></i>
-              </a>
-              {{/if}}
-              <a data-action="toggleEffectDescription">
-                <i class="fa-solid fa-angle-{{ifThen effect.expanded "down" "right"}}"></i>
-              </a>
+              {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
+              <a class="effect-control fa-fw fas fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
+              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
             </div>
           </div>
           <div class="effect-description">

--- a/templates/item/effects.hbs
+++ b/templates/item/effects.hbs
@@ -15,7 +15,6 @@
           <a
             class="effect-control"
             data-action="createDoc"
-            data-document-class="ActiveEffect"
             data-origin="{{@root.document.uuid}}"
             data-img="icons/svg/aura.svg"
             {{#if (eq section.type "inactive")}}
@@ -35,7 +34,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+        <li class="effect draggable" data-effect-id="{{effect.id}}">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -59,7 +58,13 @@
                 <i class="fa-solid fa-trash"></i>
               </a>
               {{/if}}
+              <a data-action="toggleEffectDescription">
+                <i class="fa-solid fa-angle-{{ifThen effect.expanded "down" "right"}}"></i>
+              </a>
             </div>
+          </div>
+          <div class="effect-description">
+            {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
           </div>
         </li>
         {{/each}}

--- a/templates/item/effects.hbs
+++ b/templates/item/effects.hbs
@@ -1,64 +1,70 @@
 {{! Effects Tab }}
 <section class="tab effects {{tab.cssClass}}" data-group="primary" data-tab="effects">
-  <ol class="effects-list">
-    {{#each effects as |section sid|}}
-    <li class="effects-header flexrow" data-effect-type="{{section.type}}">
-      <div class="effect-name effect-name flexrow">
-        {{localize section.label}}
-      </div>
-      <div class="effect-source">
-        {{localize "DRAW_STEEL.Effect.Source"}}
-      </div>
-      <div class="effect-source">{{localize "EFFECT.TABS.duration"}}</div>
-      <div class="effect-controls effect-controls flexrow">
-        <a
-          class="effect-control"
-          data-action="createDoc"
-          data-document-class="ActiveEffect"
-          data-origin="{{@root.document.uuid}}"
-          data-img="icons/svg/aura.svg"
-          {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
-          {{#if (eq section.type "inactive")}}
-          data-disabled="true"
-          {{else if (eq section.type "temporary")}}
-          data-duration.rounds="1"
-          {{else if (eq section.type "applied")}}
-          data-transfer="false"
-          {{/if}}
-          data-tooltip="{{localize "DOCUMENT.Create" type="Effect"}}"
-          >
-          <i class="fa-solid fa-plus"></i>
-          {{localize "DOCUMENT.New" type="Effect"}}
-        </a>
-      </div>
-    </li>
+  <div class="effect-list-container">
     <ol class="effect-list">
-      {{#each section.effects as |effect|}}
-      <li class="item effect flexrow draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
-        <div class="effect-name effect-name flexrow">
-          <img class="effect-image" src="{{effect.img}}" height="24" width="24" alt="{{effect.name}}">
-          <div>{{effect.name}}</div>
+      {{#each effects as |section sid|}}
+      <li class="effect-header" data-effect-type="{{section.type}}">
+        <div class="effect-name flexrow">
+          {{localize section.label}}
         </div>
-        <div class="effect-source">{{effect.sourceName}}</div>
-        <div class="effect-duration">{{effect.duration.label}}</div>
-        <div class="effect-controls effect-controls flexrow">
-          {{#if @root.editable}}
-          <a class="effect-control" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle">
-            <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+        <div class="effect-source">
+          {{localize "DRAW_STEEL.Effect.Source"}}
+        </div>
+        <div class="effect-duration">{{localize "EFFECT.TABS.duration"}}</div>
+        <div class="effect-controls flexrow">
+          <a
+            class="effect-control"
+            data-action="createDoc"
+            data-document-class="ActiveEffect"
+            data-origin="{{@root.document.uuid}}"
+            data-img="icons/svg/aura.svg"
+            {{#if (eq section.type "inactive")}}
+            data-disabled="true"
+            {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
+            {{else if (eq section.type "temporary")}}
+            data-system.end.type="turn"
+            {{else if (eq section.type "applied")}}
+            data-transfer="false"
+            {{/if}}
+            data-tooltip="{{localize "DOCUMENT.Create" type=(localize "DRAW_STEEL.Effect.Name")}}"
+          >
+            <i class="fa-solid fa-plus"></i>
+            {{localize "DOCUMENT.New" type=(localize "DRAW_STEEL.Effect.Name")}}
           </a>
-          {{/if}}
-          <a class="effect-control" data-action="viewDoc" data-document-class="ActiveEffect" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}">
-            <i class="fa-solid fa-edit"></i>
-          </a>
-          {{#if @root.editable}}
-          <a class="effect-control" data-action="deleteDoc" data-document-class="ActiveEffect" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
-            <i class="fa-solid fa-trash"></i>
-          </a>
-          {{/if}}
         </div>
       </li>
+      <ol class="effect-list">
+        {{#each section.effects as |effect|}}
+        <li class="effect draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+          <div class="effect-row">
+            <div class="effect-name">
+              <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
+              <div class="name">
+                <div class="label">{{effect.name}}</div>
+              </div>
+            </div>
+            <div class="effect-source">{{effect.sourceName}}</div>
+            <div class="effect-duration">{{effect.duration.label}}</div>
+            <div class="effect-controls">
+              {{#if @root.editable}}
+              <a class="effect-control" data-action="toggleEffect" data-tooltip="DRAW_STEEL.Effect.Toggle">
+                <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+              </a>
+              {{/if}}
+              <a class="effect-control" data-action="viewDoc" data-tooltip="{{localize "DOCUMENT.Update" type="Effect"}}">
+                <i class="fa-solid fa-edit"></i>
+              </a>
+              {{#if @root.editable}}
+              <a class="effect-control" data-action="deleteDoc" data-tooltip="{{localize "DOCUMENT.Delete" type="Effect"}}">
+                <i class="fa-solid fa-trash"></i>
+              </a>
+              {{/if}}
+            </div>
+          </div>
+        </li>
+        {{/each}}
+      </ol>
       {{/each}}
     </ol>
-    {{/each}}
-  </ol>
+  </div>
 </section>


### PR DESCRIPTION
Major rework in functionality & display to align the Effects tab with others
- Actor sheets now feature a "Status Conditions" section which lists the conditions specific to Draw Steel.
  - Clicking the buttons will toggle the status
  - If you have a status, it will be highlighted in orange
  - If the status is granted by a non-canonical condition, the button will be disabled
- Hitting "New Effect" in the "Temporary Effects" section will now set the duration to End of Turn, instead of 1 round.
- An effect's enriched description is now available by toggling the carat, like already existed for items.
- Also included a lot of CSS cleanup

![image](https://github.com/user-attachments/assets/b6f0e030-d0db-442d-a7f5-840a918b39ac)

![image](https://github.com/user-attachments/assets/16a7485e-819e-4706-9315-89d324d834ab)


Closes #146 