### PR TITLE
Aligned tooltip usage to correct standards

### DIFF
--- a/templates/actor/character/equipment.hbs
+++ b/templates/actor/character/equipment.hbs
@@ -16,7 +16,7 @@
       <div class="item-column item-controls">
         {{#unless isPlay}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.kit")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="kit" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="kit" data-render-sheet="true" data-tooltip-text="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}
@@ -30,7 +30,7 @@
           <div class="item-column item-name" data-action="useAbility">
             <img class="item-image" src="{{kitContext.item.img}}" alt="{{kitContext.item.name}}">
             {{#if (eq @root.system.hero.preferredKit kitContext.item.id)}}
-            <i data-tooltip="{{localize "DRAW_STEEL.Item.Kit.PreferredKit.Label"}}" class="fa-solid fa-star"></i>
+            <i data-tooltip="DRAW_STEEL.Item.Kit.PreferredKit.Label" class="fa-solid fa-star"></i>
             {{/if}}
             <div class="name">
               <div class="label">{{kitContext.item.name}}</div>
@@ -65,7 +65,7 @@
       <div class="item-column item-controls">
         {{#if equipmentCategory.showAdd}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.equipment")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="equipment" data-render-sheet="true" data-system.category="{{@key}}" data-tooltip="{{addItemTooltip}}">
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="equipment" data-render-sheet="true" data-system.category="{{@key}}" data-tooltip-text="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}

--- a/templates/actor/character/projects.hbs
+++ b/templates/actor/character/projects.hbs
@@ -8,7 +8,7 @@
       <div class="item-column item-controls">
         {{#unless isPlay}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.project")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="project" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="project" data-render-sheet="true" data-tooltip-text="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}

--- a/templates/actor/shared/abilities.hbs
+++ b/templates/actor/shared/abilities.hbs
@@ -15,7 +15,7 @@
       <div class="item-column item-controls">
         {{#if abilityType.showAdd}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip="{{addItemTooltip}}">
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip-text="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}

--- a/templates/actor/shared/features.hbs
+++ b/templates/actor/shared/features.hbs
@@ -8,7 +8,7 @@
       <div class="item-column item-controls">
         {{#unless isPlay}}
         {{#with (localize "DRAW_STEEL.Sheet.Add" itemName=(localize "TYPES.Item.feature")) as |addItemTooltip|}}
-        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip="{{addItemTooltip}}">
+        <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="feature" data-render-sheet="true" data-tooltip-text="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
         </a>
         {{/with}}

--- a/templates/actor/shared/partials/stats/characteristics.hbs
+++ b/templates/actor/shared/partials/stats/characteristics.hbs
@@ -2,7 +2,7 @@
   <legend>{{systemFields.characteristics.label}}</legend>
   {{#each characteristics as |chr key|}}
   {{#if @root.isPlay}}
-  <a class="characteristic play" data-action="roll" data-roll-type="characteristic" data-characteristic="{{key}}" data-tooltip="{{localize "DRAW_STEEL.Roll.Prompt" prompt=chr.field.hint}}">
+  <a class="characteristic play" data-action="roll" data-roll-type="characteristic" data-characteristic="{{key}}" data-tooltip-text="{{localize "DRAW_STEEL.Roll.Prompt" prompt=chr.field.label}}">
     {{chr.field.label}} {{numberFormat chr.value sign=true}}
   </a>
   {{else}}

--- a/templates/actor/shared/partials/stats/combat.hbs
+++ b/templates/actor/shared/partials/stats/combat.hbs
@@ -1,6 +1,6 @@
 {{#if isPlay}}
 <fieldset class="combat flexrow">
-  <legend data-tooltip="{{combatTooltip}}">{{systemFields.combat.label}}</legend>
+  <legend data-tooltip-html="{{combatTooltip}}">{{systemFields.combat.label}}</legend>
   <span class="play">
     {{systemFields.combat.fields.size.label}} {{system.combat.size}}
   </span>
@@ -13,7 +13,7 @@
 </fieldset>
 {{else}}
 <fieldset class="combat flexrow">
-  <legend data-tooltip="{{combatTooltip}}">{{systemFields.combat.label}}</legend>
+  <legend data-tooltip-html="{{combatTooltip}}">{{systemFields.combat.label}}</legend>
   <div class="size flexrow">
     <label class="size">{{systemFields.combat.fields.size.label}}</label>
     {{formInput systemFields.combat.fields.size.fields.value value=systemSource.combat.size.value rootId=document.uuid dataset=datasets.isSource}}
@@ -22,6 +22,6 @@
     {{/if}}
   </div>
   {{formGroup systemFields.combat.fields.stability value=systemSource.combat.stability rootId=document.uuid}}
-  <button type="button" class="icon fa-solid fa-gear" data-action="editCombat" data-tooltip="{{localize "DRAW_STEEL.Actor.base.NicheCombatDialog.EditTooltip"}}"></button>
+  <button type="button" class="icon fa-solid fa-gear" data-action="editCombat" data-tooltip="DRAW_STEEL.Actor.base.NicheCombatDialog.EditTooltip"></button>
 </fieldset>
 {{/if}}

--- a/templates/combat/turn.hbs
+++ b/templates/combat/turn.hbs
@@ -23,7 +23,7 @@
       <button type="button" class="inline-control combatant-control icon fa-solid fa-arrows-to-eye" data-action="panToCombatant" data-tooltip="COMBAT.PanToCombatant" aria-label="{{ localize " COMBAT.PanToCombatant" }}"></button>
       {{/unless}}
       {{!-- Foundry TODO: Target Control --}}
-      <div class="token-effects" data-tooltip="{{ effects.tooltip }}">
+      <div class="token-effects" data-tooltip-html="{{ effects.tooltip }}">
         {{#each effects.icons}}
         <img class="token-effect" src="{{ img }}" alt="{{ name }}">
         {{/each}}

--- a/templates/item/effects.hbs
+++ b/templates/item/effects.hbs
@@ -53,6 +53,7 @@
               {{#if @root.editable}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
               <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.Effect.Name")}}"></a>
+              {{/if}}
               <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
             </div>
           </div>

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -15,7 +15,7 @@
   {{#if flavor}}
   <div class="dice-flavor">{{flavor}}</div>
   {{/if}}
-  <div class="dice-result" data-tooltip="{{formula}}">
+  <div class="dice-result" data-tooltip-text="{{formula}}">
     <div class="inline-result">
       <div class="dice-formula">{{flavorlessFormula}}</div>
       <div class="dice-total {{critical}}">{{total}}</div>


### PR DESCRIPTION
- Fixed a missing `#If` in the Item effects tab
- Cleaned up tooltip usage; double localization, added usage of -text and -html