### PR TITLE
Player UI malice controls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1249,7 +1249,12 @@
       },
       "Malice": {
         "Label": "Malice",
-        "Hint": "Malice is a resource gained by the Director. You use malice to let enemies in the game activate their most powerful abilities and throw surprises at the heroes during combat."
+        "Hint": "Malice is a resource gained by the Director. You use malice to let enemies in the game activate their most powerful abilities and throw surprises at the heroes during combat.",
+        "AdjustMalice": {
+          "label": "Adjust Malice",
+          "hint": "Positive numbers will increase the value and negative numbers will decrease the value."
+        },
+        "ResetMalice": "Reset Malice"
       },
       "ShowPlayerMalice": {
         "Label": "Show Malice Value To Players",

--- a/src/module/applications/ui/players.mjs
+++ b/src/module/applications/ui/players.mjs
@@ -2,6 +2,7 @@ import { systemID, systemPath } from "../../constants.mjs";
 
 /** @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs" */
 /** @import { HeroTokenModel } from "../../data/settings/hero-tokens.mjs"; */
+/** @import { MaliceModel } from "../../data/settings/malice.mjs"; */
 
 /**
  * An extension of the core Players display that adds controls for hero tokens and malice
@@ -13,7 +14,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
 
     // Can adjust if it makes sense to have hero token controls for non-GMs (e.g. a more generic hero action)
     if (game.user.isGM) {
-      this._createContextMenu(this._heroTokenContextMenuOptions, ".hero-tokens .context-menu", {
+      this._createContextMenu(this._heroTokenContextMenuOptions, "#meta-currency .context-menu", {
         eventName: "click",
         hookName: "getHeroTokenContextOptions",
         parentClassHooks: false,
@@ -64,6 +65,26 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
           /** @type {HeroTokenModel} */
           const heroTokens = game.actors.heroTokens;
           await heroTokens.resetTokens();
+        },
+      },
+      {
+        name: "DRAW_STEEL.Setting.Malice.AdjustMalice.label",
+        icon: "<i class=\"fa-solid fa-plus-minus\"></i>",
+        condition: li => game.user.isGM && game.combat,
+        callback: async li => {
+          /** @type {MaliceModel} */
+          const malice = game.actors.malice;
+          await malice.adjustMalice();
+        },
+      },
+      {
+        name: "DRAW_STEEL.Setting.Malice.ResetMalice",
+        icon: "<i class=\"fa-solid fa-rotate\"></i>",
+        condition: li => game.user.isGM && game.combat,
+        callback: async li => {
+          /** @type {MaliceModel} */
+          const malice = game.actors.malice;
+          await malice.resetMalice();
         },
       },
     ];

--- a/src/module/applications/ui/players.mjs
+++ b/src/module/applications/ui/players.mjs
@@ -14,9 +14,9 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
 
     // Can adjust if it makes sense to have hero token controls for non-GMs (e.g. a more generic hero action)
     if (game.user.isGM) {
-      this._createContextMenu(this._heroTokenContextMenuOptions, "#meta-currency .context-menu", {
+      this._createContextMenu(this._metaCurrencyContextMenuOptions, "#meta-currency .context-menu", {
         eventName: "click",
-        hookName: "getHeroTokenContextOptions",
+        hookName: "getMetaCurrencyContextOptions",
         parentClassHooks: false,
         fixed: true,
       });
@@ -45,7 +45,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
    * Context menu entries for the Hero Token menu button
    * @returns {ContextMenuEntry}
    */
-  _heroTokenContextMenuOptions() {
+  _metaCurrencyContextMenuOptions() {
     return [
       {
         name: "DRAW_STEEL.Setting.HeroTokens.GiveToken",

--- a/src/module/data/settings/malice.mjs
+++ b/src/module/data/settings/malice.mjs
@@ -76,7 +76,36 @@ export class MaliceModel extends foundry.abstract.DataModel {
    * Reset malice to 0
    * @returns {Promise<MaliceModel>}
    */
-  async endCombat() {
+  async resetMalice() {
     return game.settings.set(systemID, "malice", { value: 0 });
+  }
+
+  /**
+   * Prompt an input dialog to adjust the current malice value.
+   * @returns {Promise<MaliceModel>}
+   */
+  async adjustMalice() {
+    const input = foundry.applications.fields.createNumberInput({ name: "maliceAdjustment", value: 0 });
+    const adjustmentGroup = foundry.applications.fields.createFormGroup({
+      label: "DRAW_STEEL.Setting.Malice.AdjustMalice.label",
+      hint: "DRAW_STEEL.Setting.Malice.AdjustMalice.hint",
+      input,
+      localize: true,
+    });
+
+    const fd = await ds.applications.api.DSDialog.input({
+      window: { title: "DRAW_STEEL.Setting.Malice.AdjustMalice.label", icon: "fa-solid fa-plus-minus" },
+      content: adjustmentGroup.outerHTML,
+      ok: {
+        label: "DRAW_STEEL.Setting.Malice.AdjustMalice.label",
+        icon: "fa-solid fa-plus-minus",
+      },
+    });
+
+    if (!fd.maliceAdjustment) return this;
+
+    const newMaliceValue = Math.max(0, this.value + fd.maliceAdjustment);
+
+    return game.settings.set(systemID, "malice", { value: newMaliceValue });
   }
 }

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -145,7 +145,7 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
       actor.updateEmbeddedDocuments("ActiveEffect", updates);
     }
 
-    /** If malice is already 0, the {@linkcode MaliceModel.onChange} won't fire to hide the malice value. */
+    /** If malice is already 0, the {@linkcode MaliceModel.onChange} won't fire at the end of combat to render the player UI. */
     ui.players.render();
   }
 

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -84,7 +84,7 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
     if (deletedCombat) {
       /** @type {MaliceModel} */
       const malice = game.actors.malice;
-      await malice.endCombat();
+      await malice.resetMalice();
 
       await this.awardVictories();
     }

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -131,6 +131,10 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
   /** @inheritdoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
+
+    /** If malice is already 0, the {@linkcode MaliceModel.onChange} won't fire at the end of combat to render the player UI. */
+    ui.players.render();
+
     if (!game.user.isActiveGM) return;
 
     for (const combatant of this.combatants) {
@@ -145,8 +149,6 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
       actor.updateEmbeddedDocuments("ActiveEffect", updates);
     }
 
-    /** If malice is already 0, the {@linkcode MaliceModel.onChange} won't fire at the end of combat to render the player UI. */
-    ui.players.render();
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -120,6 +120,15 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+
+    ui.players.render();
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if (!game.user.isActiveGM) return;
@@ -135,6 +144,9 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
       }
       actor.updateEmbeddedDocuments("ActiveEffect", updates);
     }
+
+    /** If malice is already 0, the {@linkcode MaliceModel.onChange} won't fire to hide the malice value. */
+    ui.players.render();
   }
 
   /* -------------------------------------------------- */

--- a/src/styles/system/applications/ui/players.css
+++ b/src/styles/system/applications/ui/players.css
@@ -4,8 +4,11 @@
   border-radius: 8px;
   padding: 6px 8px;
   pointer-events: all;
+  display: flex;
+  .currency-values {
+    flex-grow: 1;
+  }
   .context-menu {
-    float: right;
     border: none;
   }
 }

--- a/templates/ui/players.hbs
+++ b/templates/ui/players.hbs
@@ -1,17 +1,19 @@
 <div id="meta-currency">
-  <div class="hero-tokens">
-    <span>
-      {{heroTokens.value}} <label>{{heroTokens.label}}</label>
-    </span>
-    {{#if gm}}
-    <button class="context-menu icon fa-solid fa-ellipsis-vertical" type="button"></button>
+  <div class="currency-values">
+    <div class="hero-tokens">
+      <span>
+        {{heroTokens.value}} <label>{{heroTokens.label}}</label>
+      </span>
+    </div>
+    {{#if showMalice}}
+    <div class="malice">
+      <span>
+        {{malice.value}} <label>{{malice.label}}</label>
+      </span>
+    </div>
     {{/if}}
   </div>
-  {{#if showMalice}}
-  <div class="malice">
-    <span>
-      {{malice.value}} <label>{{malice.label}}</label>
-    </span>
-  </div>
+  {{#if gm}}
+  <button class="context-menu icon fa-solid fa-ellipsis-vertical" type="button"></button>
   {{/if}}
 </div>


### PR DESCRIPTION
Closes #515
Closes #498

- Adds an Adjust Malice and Reset Malice option to the player UI context menu.
   - updated the context menu methods to `_metaCurrencyContextMenuOptions` to reflect both malice and HT instead of just HT.
   - Adjust Malice prompts an input to increase/decrease the current malice value.
   - Malice options only show if there's a combat which is when the malice value only shows too
- Renders the player ui on combat create/delete.
   - Previously the render relied on the `MaliceModel.onChange` method rendering it, so it only rendered on Begin Combat. 
   - Rendering on delete is because if the malice was already 0, `MaliceModel.onChange` wouldn't trigger a render.

![Screenshot 2025-06-22 113342](https://github.com/user-attachments/assets/a12fbea9-ded3-4731-a98a-e1f911b2734e)
