### PR TITLE
Fix malice generation double applying first round bonus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 ### Fixed
 
 - Fixed various color issues on sheets that had their theme set individually. (#599)
+- Fixed malice generation applying the first round bonus twice.
 
 ## 0.7.2
 

--- a/src/module/data/settings/malice.mjs
+++ b/src/module/data/settings/malice.mjs
@@ -58,8 +58,7 @@ export class MaliceModel extends foundry.abstract.DataModel {
       return victories;
     }, 0);
     const avgVictories = Math.floor(totalVictories / heroes.length) || 0;
-    // Also work in the first round of combat bonus
-    return game.settings.set(systemID, "malice", { value: avgVictories + 1 + heroes.length });
+    return game.settings.set(systemID, "malice", { value: avgVictories });
   }
 
   /**


### PR DESCRIPTION
Closes [this issue](https://discordapp.com/channels/332362513368875008/1342298358664138805/1386425633541722162) from the discord. The `MaliceModel#startCombat` was applying the first round bonus in addition to `MaliceModel#_onStartRound` firing for the first round.