### PR TITLE
Fixed character handling

### DIFF
--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -9,14 +9,14 @@ All items support the @Embed<s></s>[uuid] syntax, which by default share the des
 You can have inline damage enrichers by using `[[/damage]]`; this is the intended way to handle abilities that do damage as part of their effect, such as the Censor's Judgment. The damage is a formula that is evaluated when the text is rendered; closing and re-opening a sheet will recalculate the values. A roll does not have to include dice; Draw Steel frequently involves static damage values.
 
 **Examples:**
-<!-- Extra &nbsp; characters are to prevent these from enriching in the in-game journal -->
+<!-- Extra &ZeroWidthSpace; characters are to prevent these from enriching in the in-game journal or rendering as wiki internal links -->
 
-- [[/damage&nbsp;2*@P]]: You can use roll data in the formula. The available values depend on where the enriched text lies, such as an Ability Description.
-- [[/damage&nbsp;1d6+@level]]{Bleeding}: Brackets will replace the default text for the roll.
-- [[/damage&nbsp;3d6 acid]]: You can include damage types, which are not case sensitive.
-- [[/damage&nbsp;formula=3d6 type=acid]]: You can also specify which parts are which to avoid ambiguity.
-- [[/damage&nbsp;3d6 type=acid/poison]]: If you specify the `type` parameter you can use a `/` or `|` to indicate "or".
-- [[/damage&nbsp;3d6 fire & 2d6 cold]]: You can join any number of damage rolls together in one enricher by using &.
+- [&ZeroWidthSpace;[/damage 2*@P]]: You can use roll data in the formula. The available values depend on where the enriched text lies, such as an Ability Description.
+- [&ZeroWidthSpace;[/damage 1d6+@level]]{Bleeding}: Brackets will replace the default text for the roll.
+- [&ZeroWidthSpace;[/damage 3d6 acid]]: You can include damage types, which are not case sensitive.
+- [&ZeroWidthSpace;[/damage formula=3d6 type=acid]]: You can also specify which parts are which to avoid ambiguity.
+- [&ZeroWidthSpace;[/damage 3d6 type=acid/poison]]: If you specify the `type` parameter you can use a `/` or `|` to indicate "or".
+- [&ZeroWidthSpace;[/damage 3d6 fire & 2d6 cold]]: You can join any number of damage rolls together in one enricher by using &.
 
 ### Healing Enrichers
 
@@ -28,6 +28,6 @@ Healing enrichers work similarly to damage enrichers, except the leading command
 
 **Examples:**
 
-- [[/heal&nbsp;10]]: If no healing type is specified it will default to current stamina.
-- [[/heal&nbsp;10 type=temporary]]: Like damage you can specify the healing type. You must be precise and use "value" or "temporary" here.
-- [[/heal&nbsp;5 heal & 10 temp]]: Also like damage you can combine healing types.
+- [&ZeroWidthSpace;[/heal 10]]: If no healing type is specified it will default to current stamina.
+- [&ZeroWidthSpace;[/heal 10 type=temporary]]: Like damage you can specify the healing type. You must be precise and use "value" or "temporary" here.
+- [&ZeroWidthSpace;[/heal 5 heal & 10 temp]]: Also like damage you can combine healing types.


### PR DESCRIPTION
- Switched from `&nbsp;` to `&ZeroWidthSpace;` so that the wiki rendering would be correct while preserving breaking the regex matching for the in-game journal