### PR TITLE
Updated system minimums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 ### Known Issues
 -->
 
+## 0.8.0
+
+### Added
+
+- Advancements
+
 ## 0.7.3
 
 ### Added

--- a/system.json
+++ b/system.json
@@ -83,9 +83,9 @@
     "url": "systems/draw-steel/assets/anvil-impact.png",
     "thumbnail": "systems/draw-steel/assets/anvil-impact.png"
   }],
-  "version": "0.7.3",
+  "version": "0.8.0",
   "compatibility": {
-    "minimum": "13.340",
+    "minimum": "13.346",
     "verified": "13"
   },
   "esmodules": ["draw-steel.mjs"],
@@ -120,7 +120,7 @@
   ],
   "socket": true,
   "manifest": "https://raw.githubusercontent.com/MetaMorphic-Digital/draw-steel/refs/heads/main/system.json",
-  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.7.3/draw-steel-release-0.7.3.zip",
+  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.8.0/draw-steel-release-0.8.0.zip",
   "background": "systems/draw-steel/assets/anvil-impact.png",
   "grid": {
     "type": 1,


### PR DESCRIPTION
Increased minimums to 13.346 so we can rely on various v13 era features without worrying about compatibility errors