### PR TITLE
[#646] Add `name`, `img` properties to base pseudo-document schema

### DIFF
--- a/src/module/data/_types.d.ts
+++ b/src/module/data/_types.d.ts
@@ -18,19 +18,19 @@ export type BarAttribute = {
 export type SubtypeMetadata = {
   /** The registered document subtype in system.json */
   type: string;
-  /* Record of document names of pseudo-documents and the path to the collection. */
+  /** Record of document names of pseudo-documents and the path to the collection. */
   embedded: Record<string, string>;
 };
 
 export type PseudoDocumentMetadata = {
-  /* The document name of this pseudo-document. */
+  /** The document name of this pseudo-document. */
   documentName: string,
-  /** The localization string for this pseudo-document */
-  label: string;
+  /** File path for a default image. */
+  defaultImage: string | null;
   /** The font-awesome icon for this pseudo-document type */
   icon: string;
-  /* Record of document names of pseudo-documents and the path to the collection. */
+  /** Record of document names of pseudo-documents and the path to the collection. */
   embedded: Record<string, string>,
-  /* The class used to render this pseudo-document. */
+  /** The class used to render this pseudo-document. */
   sheetClass?: PseudoDocumentSheet,
 };

--- a/src/module/data/pseudo-documents/advancements/base-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/base-advancement.mjs
@@ -6,23 +6,17 @@ const { FilePathField, StringField } = foundry.data.fields;
 export default class BaseAdvancement extends TypedPseudoDocument {
   /** @type {import("../../../_types").PseudoDocumentMetadata} */
   static get metadata() {
-    return {
-      ...super.metadata,
+    return foundry.utils.mergeObject(super.metadata, {
       documentName: "Advancement",
-      embedded: {},
       sheetClass: ds.applications.sheets.pseudoDocuments.AdvancementSheet,
-      types: ds.data.pseudoDocuments.advancements,
-    };
+    });
   }
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
   static defineSchema() {
-    return Object.assign(super.defineSchema(), {
-      name: new StringField({ required: true }),
-      img: new FilePathField({ categories: ["IMAGE"], initial: this.metadata.defaultImage || null, nullable: true }),
-    });
+    return Object.assign(super.defineSchema(), {});
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -15,7 +15,6 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
     return {
       ...super.metadata,
       documentName: "PowerRollEffect",
-      label: "DOCUMENT.PowerRollEffect",
       icon: "fa-solid fa-dice-d10",
       sheetClass: ds.applications.sheets.pseudoDocuments.PowerRollEffectSheet,
     };
@@ -30,10 +29,7 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
 
   /** @inheritdoc */
   static defineSchema() {
-    return Object.assign(super.defineSchema(), {
-      // TODO: Remove manual label assignment when localization bug is fixed
-      name: new StringField({ required: true, label: "DOCUMENT.FIELDS.name.label" }),
-    });
+    return Object.assign(super.defineSchema(), {});
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -14,9 +14,10 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   static get metadata() {
     return {
       documentName: null,
-      label: "",
+      defaultImage: null,
       icon: "",
       embedded: {},
+      sheetClass: null,
     };
   }
 
@@ -26,6 +27,8 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   static defineSchema() {
     return {
       _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+      name: new StringField({ required: true }),
+      img: new FilePathField({ categories: ["IMAGE"], initial: () => this.metadata.defaultImage, nullable: true }),
     };
   }
 

--- a/src/module/data/pseudo-documents/trait-choices/base-trait-choice.mjs
+++ b/src/module/data/pseudo-documents/trait-choices/base-trait-choice.mjs
@@ -5,8 +5,6 @@ export default class BaseTraitChoice extends TypedPseudoDocument {
   static get metadata() {
     return foundry.utils.mergeObject(super.metadata, {
       documentName: "TraitChoice",
-      embedded: {},
-      sheetClass: null,
     });
   }
 

--- a/system.json
+++ b/system.json
@@ -27,6 +27,9 @@
     },
     "Item": {
       "ability": {
+        "filePathFields": {
+          "power.effects.*.img": ["IMAGE"]
+        },
         "htmlFields": ["effect.before", "effect.after"]
       },
       "ancestry": {
@@ -39,7 +42,8 @@
       },
       "class": {
         "filePathFields": {
-          "advancements.*.img": ["IMAGE"]
+          "advancements.*.img": ["IMAGE"],
+          "advancements.*.traits.*.img": ["IMAGE"]
         },
         "htmlFields": ["description.value", "description.gm"],
         "gmOnlyFields": ["description.gm"]


### PR DESCRIPTION
Closes #646.

Cleaned up metadata a bit too. Opted to add `defaultImage` to metadata cus it did not work well anywhere else. If a module wants to change it, they can use a hook.

Also fun fact: Have to use `/**` in the interfaces to get proper hints.