### PR TITLE
[#684] Localization prefixes adjustment

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -12,14 +12,7 @@
       "journals": "System Journals"
     },
     "ADVANCEMENT": {
-      "FIELDS": {
-        "name": {
-          "label": "Name"
-        },
-        "img": {
-          "label": "Image"
-        }
-      },
+      "FIELDS": {},
       "ITEM_GRANT": {
         "FIELDS": {
           "requirements": {
@@ -1170,6 +1163,14 @@
       "Temporary": "Temporary Stamina"
     },
     "PSEUDO": {
+      "FIELDS": {
+        "name": {
+          "label": "Name"
+        },
+        "img": {
+          "label": "Image"
+        }
+      },
       "POWER_ROLL_EFFECT": {
         "FIELDS": {
           "damage": {

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -64,6 +64,11 @@ export default class BaseActorModel extends SubtypeModelMixin(foundry.abstract.T
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = ["DRAW_STEEL.Actor.base"];
+
+  /* -------------------------------------------------- */
+
   /**
    * Helper function to fill in the `biography` property
    * @protected

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -24,10 +24,7 @@ export default class CharacterModel extends BaseActorModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Actor.base",
-    "DRAW_STEEL.Actor.Character",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Actor.Character");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -25,11 +25,10 @@ export default class NPCModel extends BaseActorModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat([
     "DRAW_STEEL.Source",
-    "DRAW_STEEL.Actor.base",
     "DRAW_STEEL.Actor.NPC",
-  ];
+  ]);
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -16,9 +16,7 @@ export default class SquadModel extends BaseCombatantGroupModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.CombatantGroup.squad",
-  ];
+  static LOCALIZATION_PREFIXES = ["DRAW_STEEL.CombatantGroup.squad"];
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -30,11 +30,7 @@ export default class AbilityModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.Ability",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Ability");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/advancement.mjs
+++ b/src/module/data/item/advancement.mjs
@@ -19,4 +19,9 @@ export default class AdvancementModel extends BaseItemModel {
       advancements: new ds.data.fields.CollectionField(ds.data.pseudoDocuments.advancements.BaseAdvancement),
     });
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.advancement");
 }

--- a/src/module/data/item/ancestry.mjs
+++ b/src/module/data/item/ancestry.mjs
@@ -15,10 +15,5 @@ export default class AncestryModel extends AdvancementModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.advancement",
-    "DRAW_STEEL.Item.Ancestry",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Ancestry");
 }

--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -46,6 +46,14 @@ export default class BaseItemModel extends SubtypeModelMixin(foundry.abstract.Ty
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    "DRAW_STEEL.Item.base",
+    "DRAW_STEEL.Source",
+  ];
+
+  /* -------------------------------------------------- */
+
   /**
    * Convenient access to the item's actor, if it exists.
    * @returns {DrawSteelActor | null}

--- a/src/module/data/item/career.mjs
+++ b/src/module/data/item/career.mjs
@@ -17,12 +17,7 @@ export default class CareerModel extends AdvancementModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.advancement",
-    "DRAW_STEEL.Item.Career",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Career");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/class.mjs
+++ b/src/module/data/item/class.mjs
@@ -19,12 +19,7 @@ export default class ClassModel extends AdvancementModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.advancement",
-    "DRAW_STEEL.Item.Class",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Class");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/complication.mjs
+++ b/src/module/data/item/complication.mjs
@@ -1,4 +1,3 @@
-import { systemPath } from "../../constants.mjs";
 import AdvancementModel from "./advancement.mjs";
 
 /**
@@ -16,10 +15,5 @@ export default class ComplicationModel extends AdvancementModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.advancement",
-    "DRAW_STEEL.Item.Complication",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Complication");
 }

--- a/src/module/data/item/culture.mjs
+++ b/src/module/data/item/culture.mjs
@@ -15,10 +15,5 @@ export default class CultureModel extends AdvancementModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.advancement",
-    "DRAW_STEEL.Item.Culture",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Culture");
 }

--- a/src/module/data/item/equipment.mjs
+++ b/src/module/data/item/equipment.mjs
@@ -20,11 +20,7 @@ export default class EquipmentModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.Equipment",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Equipment");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/feature.mjs
+++ b/src/module/data/item/feature.mjs
@@ -16,11 +16,7 @@ export default class FeatureModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.Feature",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Feature");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -19,11 +19,7 @@ export default class KitModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.Kit",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Kit");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -24,11 +24,7 @@ export default class ProjectModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    "DRAW_STEEL.Source",
-    "DRAW_STEEL.Item.base",
-    "DRAW_STEEL.Item.Project",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Item.Project");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/advancements/base-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/base-advancement.mjs
@@ -24,7 +24,7 @@ export default class BaseAdvancement extends TypedPseudoDocument {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = ["DRAW_STEEL.ADVANCEMENT"];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.ADVANCEMENT");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -29,10 +29,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    ...super.LOCALIZATION_PREFIXES,
-    "DRAW_STEEL.ADVANCEMENT.ITEM_GRANT",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.ADVANCEMENT.ITEM_GRANT");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
@@ -36,10 +36,7 @@ export default class TraitAdvancement extends BaseAdvancement {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [
-    ...super.LOCALIZATION_PREFIXES,
-    "DRAW_STEEL.ADVANCEMENT.TRAIT",
-  ];
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.ADVANCEMENT.TRAIT");
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -34,7 +34,8 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
 
   /* -------------------------------------------------- */
 
-  static LOCALIZATION_PREFIXES = ["DOCUMENT"];
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = ["DRAW_STEEL.PSEUDO"];
 
   /* -------------------------------------------------- */
 


### PR DESCRIPTION
Adjusted `LOCALIZATION_PREFIXES` to use `Array#concat`. Did some minor research and the most updated results I could find was that the spread operator was faster than `Array#concat` when the arrays are small (<10), but that `Array#concat` is generally always recommended, and it depends on Node and whichever compiler.

Adjusted i18n such that all pseudo-documents inherit the same labels from `DRAW_STEEL.PSEUDO` (for `name` and `img`).

Adjustes some classes' `LOCALIZATION_PREFIXES` to reduce copied strings in subclasses (eg base actor, base item, item advancement model).

Closes #684.