### PR TITLE
[#59] Culture Advancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Added
 
-- Advancements
+- Advancements (#51)
 - Added a button to ability use messages to apply effects from the ability. (#214)
 - Added a Wealth field to Careers. (#535)
 - Adding or removing a career will adjust the amount of renown and wealth your character has.

--- a/lang/en.json
+++ b/lang/en.json
@@ -820,7 +820,7 @@
           "name": "Any Language",
           "description": "You know the language of your chosen culture."
         },
-        "Environments": {
+        "Environment": {
           "label": "Environment",
           "Nomadic": "Nomadic",
           "Rural": "Rural",

--- a/lang/en.json
+++ b/lang/en.json
@@ -816,7 +816,12 @@
       },
       "culture": {
         "FIELDS": {},
+        "AnyLanguageAdvancement": {
+          "name": "Any Language",
+          "description": "You know the language of your chosen culture."
+        },
         "Environments": {
+          "label": "Environment",
           "Nomadic": "Nomadic",
           "Rural": "Rural",
           "Secluded": "Secluded",
@@ -824,11 +829,13 @@
           "Wilderness": "Wilderness"
         },
         "Organization": {
+          "label": "Organization",
           "Anarchic": "Anarchic",
           "Bureaucratic": "Bureaucratic",
           "Communal": "Communal"
         },
         "Upbringing": {
+          "label": "Upbringing",
           "Academic": "Academic",
           "Creative": "Creative",
           "Illegal": "Illegal",

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -4,6 +4,7 @@ import DSDocumentSheetMixin from "../api/document-sheet-mixin.mjs";
 import DocumentSourceInput from "../apps/document-source-input.mjs";
 
 /**
+ * @import { FormSelectOption } from "@client/applications/forms/fields.mjs"
  * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs"
  * @import DrawSteelActiveEffect from "../../documents/active-effect.mjs"
  * @import BaseItemModel from "../../data/item/base.mjs"
@@ -576,7 +577,35 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @private
    */
-  static async #createCultureAdvancement(event, target) {}
+  static async #createCultureAdvancement(event, target) {
+    /** @type {FormSelectOption} */
+    const options = Object.keys(ds.data.pseudoDocuments.advancements.BaseAdvancement.TYPES).map(type => ({
+      value: type,
+      label: game.i18n.localize(`TYPES.Advancement.${type}`),
+    }));
+
+    for (const [key, config] of Object.entries(ds.CONFIG.culture.aspects)) {
+      options.push({
+        label: config.label,
+        group: ds.CONFIG.culture.group[config.group]?.label,
+        value: `${config.group}.${key}`,
+      });
+    }
+
+    const select = foundry.applications.fields.createFormGroup({
+      label: game.i18n.localize("Type"),
+      input: foundry.applications.fields.createSelectInput({ blank: false, name: "type", options }),
+    }).outerHTML;
+    const result = await ds.applications.api.DSDialog.input({
+      window: {
+        title: game.i18n.format("DOCUMENT.New", { type: game.i18n.localize("DOCUMENT.Advancement") }),
+        icon: ds.data.pseudoDocuments.advancements.BaseAdvancement.metadata.icon,
+      },
+      content: `<fieldset>${select}</fieldset>`,
+    });
+    if (!result) return null;
+    console.log(result);
+  }
 
   /* -------------------------------------------------- */
   /*   Helper Functions                                 */

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -584,11 +584,13 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
       label: game.i18n.localize(`TYPES.Advancement.${type}`),
     }));
 
+    const aspectPrefix = "cultureAspect";
+
     for (const [key, config] of Object.entries(ds.CONFIG.culture.aspects)) {
       options.push({
         label: config.label,
         group: ds.CONFIG.culture.group[config.group]?.label,
-        value: `${config.group}.${key}`,
+        value: `${aspectPrefix}.${key}`,
       });
     }
 
@@ -603,8 +605,25 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
       },
       content: `<fieldset>${select}</fieldset>`,
     });
-    if (!result) return null;
-    console.log(result);
+    if (!result) return;
+
+    const [type, aspect] = result.type.split(".");
+    let createData;
+
+    if (type === aspectPrefix) {
+      const config = ds.CONFIG.culture.aspects[aspect];
+
+      createData = {
+        type: "skill",
+        name: config.label,
+        chooseN: 1,
+        skills: {
+          groups: Array.from(config.skillGroups),
+          choices: Array.from(config.skillChoices),
+        },
+      };
+    } else createData = { type };
+    ds.data.pseudoDocuments.advancements.SkillAdvancement.create(createData, { parent: this.document });
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -1,5 +1,4 @@
 import { systemPath } from "../../constants.mjs";
-import BasePowerRollEffect from "../../data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs";
 import enrichHTML from "../../utils/enrich-html.mjs";
 import DSDocumentSheetMixin from "../api/document-sheet-mixin.mjs";
 import DocumentSourceInput from "../apps/document-source-input.mjs";
@@ -35,9 +34,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
       deleteDoc: this.#deleteEffect,
       toggleEffect: this.#toggleEffect,
       toggleEffectDescription: this.#toggleEffectDescription,
-      editPowerRollEffect: this.#editPowerRoll,
-      deletePowerRollEffect: this.#deletePowerRoll,
-      createPowerRollEffect: this.#createPowerRoll,
+      createCultureAdvancement: this.#createCultureAdvancement,
     },
     // Custom property that's merged into `this.options`
     dragDrop: [{ dragSelector: ".draggable", dropSelector: null }],
@@ -311,7 +308,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
         icon: "<i class=\"fa-solid fa-fw fa-trash-can\"></i>",
         condition: () => this.isEditable,
         callback: (target) => {
-          const powerRollEffect = this._getPowerRoll(target);
+          const powerRollEffect = this._getPseudoDocument(target);
           ui.notifications.info("DRAW_STEEL.PSEUDO.Notifications.DeletedInfo", { format: {
             pseudoName: game.i18n.localize("DOCUMENT.PowerRollEffect"),
             id: powerRollEffect.id,
@@ -572,46 +569,14 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
   /* -------------------------------------------------- */
 
   /**
-   * Edits a power roll pseudo document
+   * Creates an advancement on a culture, with additional logic to simplify creating "aspects"
    *
    * @this DrawSteelItemSheet
    * @param {PointerEvent} event   The originating click event
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
    * @private
    */
-  static async #editPowerRoll(event, target) {
-    const powerRollEffect = this._getPowerRoll(target);
-    powerRollEffect.sheet.render({ force: true });
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Deletes a power roll pseudo document
-   *
-   * @this DrawSteelItemSheet
-   * @param {PointerEvent} event   The originating click event
-   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-   * @private
-   */
-  static async #deletePowerRoll(event, target) {
-    const powerRollEffect = this._getPowerRoll(target);
-    powerRollEffect.delete();
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Creates a power roll pseudo document
-   *
-   * @this DrawSteelItemSheet
-   * @param {PointerEvent} event   The originating click event
-   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-   * @private
-   */
-  static async #createPowerRoll(event, target) {
-    BasePowerRollEffect.createDialog({}, { parent: this.item });
-  }
+  static async #createCultureAdvancement(event, target) {}
 
   /* -------------------------------------------------- */
   /*   Helper Functions                                 */
@@ -626,18 +591,6 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
   _getEffect(target) {
     const li = target.closest(".effect");
     return this.item.effects.get(li?.dataset?.effectId);
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Fetches a Power Roll Effect pseudo-document
-   * @param {HTMLElement} target The element with the action
-   * @returns {BasePowerRollEffect} The document
-   */
-  _getPowerRoll(target) {
-    const btn = target.closest(".power-roll");
-    return this.item.getEmbeddedDocument("PowerRollEffect", btn?.dataset?.id);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1348,81 +1348,106 @@ DRAW_STEEL.Advancement = {
 /* -------------------------------------------------- */
 
 /**
+ * @typedef CultureAspect
+ * @property {string} label         Human-readable label
+ * @property {string} skillGroups   A set of skill groups this aspect gives access to
+ * @property {Set<string>} skillChoices  A set of skills this aspect gives access to
+ * @property {Set<string>} group         An entry in culture.groups
+ * TODO: Description as a uuid reference
+ */
+
+/**
  * Configuration details for Culture items
  */
 DRAW_STEEL.culture = {
+  /**  @type {Record<string, CultureAspect>} */
   aspects: {
     nomadic: {
       label: "DRAW_STEEL.Item.culture.Environment.Nomadic",
-      skillOpts: new Set(),
+      skillGroups: new Set(["exploration", "interpersonal"]),
+      skillChoices: new Set(),
       group: "environment",
     },
     rural: {
       label: "DRAW_STEEL.Item.culture.Environment.Rural",
-      skillOpts: new Set(),
+      skillGroups: new Set(["crafting", "lore"]),
+      skillChoices: new Set(),
       group: "environment",
     },
     secluded: {
       label: "DRAW_STEEL.Item.culture.Environment.Secluded",
-      skillOpts: new Set(),
+      skillGroups: new Set(["interpersonal", "lore"]),
+      skillChoices: new Set(),
       group: "environment",
     },
     urban: {
       label: "DRAW_STEEL.Item.culture.Environment.Urban",
-      skillOpts: new Set(),
+      skillGroups: new Set(["interpersonal", "intrigue"]),
+      skillChoices: new Set(),
       group: "environment",
     },
     wilderness: {
       label: "DRAW_STEEL.Item.culture.Environment.Wilderness",
-      skillOpts: new Set(),
+      skillGroups: new Set(["crafting", "exploration"]),
+      skillChoices: new Set(),
       group: "environment",
     },
     anarchic: {
       label: "DRAW_STEEL.Item.culture.Organization.Anarchic",
-      skillOpts: new Set(),
+      skillGroups: new Set(["exploration", "intrigue"]),
+      skillChoices: new Set(),
       group: "organization",
     },
     bureaucratic: {
       label: "DRAW_STEEL.Item.culture.Organization.Bureaucratic",
-      skillOpts: new Set(),
+      skillGroups: new Set(["intrigue", "lore"]),
+      skillChoices: new Set(),
       group: "organization",
     },
     communal: {
       label: "DRAW_STEEL.Item.culture.Organization.Communal",
-      skillOpts: new Set(),
+      skillGroups: new Set(["crafting", "interpersonal"]),
+      skillChoices: new Set(),
       group: "organization",
     },
     academic: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Academic",
-      skillOpts: new Set(),
+      skillGroups: new Set(["lore"]),
+      skillChoices: new Set(),
       group: "upbringing",
     },
     creative: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Creative",
-      skillOpts: new Set(),
+      skillGroups: new Set(["crafting"]),
+      skillChoices: new Set(["music", "perform"]),
       group: "upbringing",
     },
     illegal: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Illegal",
-      skillOpts: new Set(),
+      skillGroups: new Set(["intrigue"]),
+      skillChoices: new Set(),
       group: "upbringing",
     },
     labor: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Labor",
-      skillOpts: new Set(),
+      skillGroups: new Set(["exploration"]),
+      skillChoices: new Set(["blacksmithing", "handleAnimals"]),
       group: "upbringing",
     },
     martial: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Martial",
-      skillOpts: new Set(),
+      skillGroups: new Set(),
+      skillChoices: new Set(["alertness", "blacksmithing", "climb", "endurance", "fletching", "intimidate", "monsters", "ride", "strategy", "track"]),
       group: "upbringing",
     },
     noble: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Noble",
-      skillOpts: new Set(),
+      skillGroups: new Set(["interpersonal"]),
+      skillChoices: new Set(),
       group: "upbringing",
     },
   },
+  /** @type {Record<string, { label: string }>} */
   group: {
     environment: {
       label: "DRAW_STEEL.Item.culture.Environment.label",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1349,75 +1349,94 @@ DRAW_STEEL.Advancement = {
 
 /**
  * Configuration details for Culture items
- * @type {Record<string, Record<string, {label: string, skillOpts: Set<string>}>>}
  */
 DRAW_STEEL.culture = {
-  environments: {
+  aspects: {
     nomadic: {
-      label: "DRAW_STEEL.Item.culture.Environments.Nomadic",
+      label: "DRAW_STEEL.Item.culture.Environment.Nomadic",
       skillOpts: new Set(),
+      group: "environment",
     },
     rural: {
-      label: "DRAW_STEEL.Item.culture.Environments.Rural",
+      label: "DRAW_STEEL.Item.culture.Environment.Rural",
       skillOpts: new Set(),
+      group: "environment",
     },
     secluded: {
-      label: "DRAW_STEEL.Item.culture.Environments.Secluded",
+      label: "DRAW_STEEL.Item.culture.Environment.Secluded",
       skillOpts: new Set(),
+      group: "environment",
     },
     urban: {
-      label: "DRAW_STEEL.Item.culture.Environments.Urban",
+      label: "DRAW_STEEL.Item.culture.Environment.Urban",
       skillOpts: new Set(),
+      group: "environment",
     },
     wilderness: {
-      label: "DRAW_STEEL.Item.culture.Environments.Wilderness",
+      label: "DRAW_STEEL.Item.culture.Environment.Wilderness",
       skillOpts: new Set(),
+      group: "environment",
     },
-  },
-  organization: {
     anarchic: {
       label: "DRAW_STEEL.Item.culture.Organization.Anarchic",
       skillOpts: new Set(),
+      group: "organization",
     },
     bureaucratic: {
       label: "DRAW_STEEL.Item.culture.Organization.Bureaucratic",
       skillOpts: new Set(),
+      group: "organization",
     },
     communal: {
       label: "DRAW_STEEL.Item.culture.Organization.Communal",
       skillOpts: new Set(),
+      group: "organization",
     },
-  },
-  upbringing: {
     academic: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Academic",
       skillOpts: new Set(),
+      group: "upbringing",
     },
     creative: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Creative",
       skillOpts: new Set(),
+      group: "upbringing",
     },
     illegal: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Illegal",
       skillOpts: new Set(),
+      group: "upbringing",
     },
     labor: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Labor",
       skillOpts: new Set(),
+      group: "upbringing",
     },
     martial: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Martial",
       skillOpts: new Set(),
+      group: "upbringing",
     },
     noble: {
       label: "DRAW_STEEL.Item.culture.Upbringing.Noble",
       skillOpts: new Set(),
+      group: "upbringing",
+    },
+  },
+  group: {
+    environment: {
+      label: "DRAW_STEEL.Item.culture.Environment.label",
+    },
+    organization: {
+      label: "DRAW_STEEL.Item.culture.Organization.label",
+    },
+    upbringing: {
+      label: "DRAW_STEEL.Item.culture.Upbringing.label",
     },
   },
 };
-preLocalize("culture.environments", { key: "label" });
-preLocalize("culture.organization", { key: "label" });
-preLocalize("culture.upbringing", { key: "label" });
+preLocalize("culture.aspects", { key: "label" });
+preLocalize("culture.group", { key: "label" });
 
 /* -------------------------------------------------- */
 

--- a/src/module/data/item/culture.mjs
+++ b/src/module/data/item/culture.mjs
@@ -19,6 +19,7 @@ export default class CultureModel extends AdvancementModel {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
   async _preCreate(data, options, user) {
     const allowed = await super._preCreate(data, options, user);
     if (allowed === false) return false;

--- a/src/module/data/item/culture.mjs
+++ b/src/module/data/item/culture.mjs
@@ -26,8 +26,8 @@ export default class CultureModel extends AdvancementModel {
       const lang = {
         type: "language",
         chooseN: 1,
-        name: "Any Language",
-        description: "<p>You know the language of your chosen culture.</p>",
+        name: game.i18n.localize("DRAW_STEEL.Item.culture.AnyLanguageAdvancement.name"),
+        description: `<p>${game.i18n.localize("DRAW_STEEL.Item.culture.AnyLanguageAdvancement.description")}</p>`,
         requirements: {
           level: 1,
         },

--- a/src/module/data/item/culture.mjs
+++ b/src/module/data/item/culture.mjs
@@ -19,6 +19,26 @@ export default class CultureModel extends AdvancementModel {
 
   /* -------------------------------------------------- */
 
+  async _preCreate(data, options, user) {
+    const allowed = await super._preCreate(data, options, user);
+    if (allowed === false) return false;
+    if (!this.advancements.size) {
+      const lang = {
+        type: "language",
+        chooseN: 1,
+        name: "Any Language",
+        description: "<p>You know the language of your chosen culture.</p>",
+        requirements: {
+          level: 1,
+        },
+        _id: "anyLang".padEnd(16, "0"),
+      };
+      this.parent.updateSource({ [`system.advancements.${lang._id}`]: lang });
+    }
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   async applyAdvancements({ actor, ...options }) {
     if (!this.actor && actor.system.culture) throw new Error(`${actor.name} already has a culture!`);

--- a/templates/sheets/item/advancement.hbs
+++ b/templates/sheets/item/advancement.hbs
@@ -3,7 +3,12 @@
 
     <h3 class="section-header">
       <span>{{localize "DOCUMENT.AdvancementPl"}}</span>
-      <button type="button" data-action="createPseudoDocument" class="icon fa-fw fa-solid fa-circle-plus" {{disabled (not @root.editable)}}></button>
+      <button
+        type="button"
+        data-action="{{ifThen (eq document.type "culture") "createCultureAdvancement" "createPseudoDocument" }}"
+        class="icon fa-fw fa-solid fa-circle-plus" {{disabled (not @root.editable)}}
+      >
+      </button>
     </h3>
 
     {{#each advancements}}

--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -19,10 +19,10 @@
     {{/with}}
   </fieldset>
 
-  <fieldset>
+  <fieldset data-pseudo-document-name="PowerRollEffect">
     <legend>{{systemFields.power.fields.effects.label}}</legend>
     {{#unless isPlay}}
-    <button type="button" data-action="createPowerRollEffect">
+    <button type="button" data-action="createPseudoDocument">
       <i class="fa-solid fa-plus"></i>
       {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.PowerRollEffect")}}
     </button>
@@ -30,7 +30,7 @@
     {{!-- Using document.system to ensure initialized values in edit mode --}}
     <div class="power-roll-list">
       {{#each document.system.power.effects as |effect|}}
-      <button type="button" class="power-roll" data-action="editPowerRollEffect" data-id="{{effect.id}}">
+      <button type="button" class="power-roll" data-action="renderPseudoDocumentSheet" data-pseudo-id="{{effect.id}}">
         {{localize effect.name}}
       </button>
       {{/each}}

--- a/templates/sidebar/tabs/combat/tracker.hbs
+++ b/templates/sidebar/tabs/combat/tracker.hbs
@@ -27,12 +27,12 @@
     </header>
     <ol class="group-turns">
       {{#each turns}}
-      {{> "systems/draw-steel/templates/combat/turn.hbs"}}
+      {{> "systems/draw-steel/templates/sidebar/tabs/combat/turn.hbs"}}
       {{/each}}
     </ol>
   </li>
   {{else}}
-  {{> "systems/draw-steel/templates/combat/turn.hbs"}}
+  {{> "systems/draw-steel/templates/sidebar/tabs/combat/turn.hbs"}}
   {{/if}}
   {{/each}}
 </ol>


### PR DESCRIPTION
- Creating a new culture now adds an "Any Language" advancement that can be adjusted as desired
- Cultures now have a bespoke variant of the "create advancement" listeners on the Item Sheet
  - All are variants of a Skill advancement, but with preconfigured data to align with the core book's "Culture Aspects" structure
- Unified Power Roll Effects to use the inherited "Create PseudoDocument" functionality

<img width="402" height="589" alt="image" src="https://github.com/user-attachments/assets/55ae67eb-925d-4a7b-aa85-a41e8937f700" />


Closes #59