### PR TITLE
[#673] Attempted fix for end of turn logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - Fixed display of popped out ability messages
 - Fixed display of multi-result abilities
+- Fixed unrequited prompting for end of turn events (#673)
 
 ## 0.7.3
 

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -251,7 +251,7 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
   async _onEndTurn(combatant, context) {
     /** @type {DrawSteelActor} */
     const actor = combatant.actor;
-    if (!actor) return;
+    if (!actor || context.skipped) return;
     /** @type {ActiveEffectData[]} */
     const updates = [];
     for (const effect of actor.appliedEffects) {

--- a/templates/sidebar/tabs/combat/tracker.hbs
+++ b/templates/sidebar/tabs/combat/tracker.hbs
@@ -27,12 +27,12 @@
     </header>
     <ol class="group-turns">
       {{#each turns}}
-      {{> "systems/draw-steel/templates/combat/turn.hbs"}}
+      {{> "systems/draw-steel/templates/sidebar/tabs/combat/turn.hbs"}}
       {{/each}}
     </ol>
   </li>
   {{else}}
-  {{> "systems/draw-steel/templates/combat/turn.hbs"}}
+  {{> "systems/draw-steel/templates/sidebar/tabs/combat/turn.hbs"}}
   {{/if}}
   {{/each}}
 </ol>


### PR DESCRIPTION
Our combat turn management makes Foundry think we're skipping turns all the time; we may need to do a deeper rework if this is causing problem with region logic.