### PR TITLE
Remove `Hero#stamina#max` from schema

### DIFF
--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -32,11 +32,10 @@ export default class CharacterModel extends BaseActorModel {
   static defineSchema() {
     const schema = super.defineSchema();
 
-    // TODO: Improve the handling of TokenDocument._getTrackedAttributesFromSchema
-    // So that it recognizes derived max stamina & recovery values without them being in the schema
-    const maxStamina = schema.stamina.getField("max");
-    maxStamina.options.max = 0;
-    maxStamina.max = 0;
+    schema.stamina = new fields.SchemaField({
+      value: new fields.NumberField({ initial: 20, nullable: false, integer: true }),
+      temporary: new fields.NumberField({ initial: 0, nullable: false, integer: true }),
+    }, { trackedAttribute: true });
 
     schema.recoveries = new fields.SchemaField({
       value: requiredInteger(),
@@ -130,7 +129,7 @@ export default class CharacterModel extends BaseActorModel {
       }
     }
 
-    this.stamina.max += kitBonuses["stamina"] * this.echelon;
+    this.stamina.max = kitBonuses["stamina"] * this.echelon;
     this.movement.value += kitBonuses["speed"];
     this.combat.stability += kitBonuses["stability"];
     this.movement.disengage += kitBonuses["disengage"];

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -76,7 +76,23 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
 
   /** @inheritdoc */
   getBarAttribute(barName, { alternative } = {}) {
-    const barData = super.getBarAttribute(barName, { alternative });
+    const bar = super.getBarAttribute(barName, { alternative });
+    if (bar === null) return null;
+
+    let { type, attribute, value, max, editable } = bar;
+
+    // Adjustments made for things that use "spent" instead of "value" in the schema.
+    if ((type === "value") && attribute.endsWith(".spent")) {
+      const object = foundry.utils.getProperty(this.actor.system, attribute.slice(0, attribute.lastIndexOf(".")));
+      value = object.value;
+      max = object.max;
+      type = "bar";
+      editable = true;
+    } else if (type === "bar") {
+      editable = true;
+    }
+
+    const barData = { type, attribute, value, max, editable };
     if (barData?.attribute !== "stamina") return barData;
 
     barData.min = this.actor.system.stamina.min;
@@ -90,5 +106,29 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
     barData.value = combatGroup.system.staminaValue;
 
     return barData;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static _getTrackedAttributesFromSchema(schema, _path = []) {
+    const attributes = { bar: [], value: [] };
+    for (const [name, field] of Object.entries(schema.fields)) {
+      const p = _path.concat([name]);
+      if (field instanceof foundry.data.fields.NumberField) attributes.value.push(p);
+      const isSchema = field instanceof foundry.data.fields.SchemaField;
+      const isModel = field instanceof foundry.data.fields.EmbeddedDataField;
+      if (isSchema || isModel) {
+        const schema = isModel ? field.model.schema : field;
+        const isBar = ((schema.has("value") || schema.has("spent")) && schema.has("max")) || schema.options.trackedAttribute;
+        if (isBar) attributes.bar.push(p);
+        else {
+          const inner = this.getTrackedAttributes(schema, p);
+          attributes.bar.push(...inner.bar);
+          attributes.value.push(...inner.value);
+        }
+      }
+    }
+    return attributes;
   }
 }


### PR DESCRIPTION
Closes #738.

Ported functionality from artichron, allowing for tracking any object in the schema if
- it has `value` and `max` in the schema
- it has `spent` and `max` in the schema
- the `SchemaField` has `options.trackedAttribute: true`

Removed `stamina.max` from the hero schema entirely.