### PR TITLE
Refactored _onDropFolder handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Certain item types (Class, Subclass, Ancestry, Career, Kit) can no longer be created directly in world. Instead, they must be created inside a compendium. (#716)
   - This enforces good practices for data creation.
   - The buttons on the character sheet header now open the Ancestry, Background, and Class compendiums.
+- Items with advancements can no longer be mass-created as part of dropping a folder onto an actor sheet. (#736)
 
 ### Fixed
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -106,7 +106,7 @@
       "Other": "Other",
       "LevelUp": "Level Up Available",
       "ToggleMode": "Toggle Play/Edit Mode",
-      "NoCreateAdvancement": "{name} could not be created as part of the folder drop because it has advancements"
+      "NoCreateAdvancement": "{name} could not be created as part of the folder drop because it has advancements."
     },
     "EDITOR": {
       "Enrichers": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -105,7 +105,8 @@
       "Resources": "Resources",
       "Other": "Other",
       "LevelUp": "Level Up Available",
-      "ToggleMode": "Toggle Play/Edit Mode"
+      "ToggleMode": "Toggle Play/Edit Mode",
+      "NoCreateAdvancement": "{name} could not be created as part of the folder drop because it has advancements"
     },
     "EDITOR": {
       "Enrichers": {

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -972,22 +972,17 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
   async _onDropFolder(event, data) {
     if (!this.actor.isOwner) return [];
     const folder = await Folder.implementation.fromDropData(data);
-    if (folder.type !== "Item") return [];
-    const projectDropTarget = event.target.closest("[data-application-part='projects'");
+    if (folder.type !== "Item") return []; // V14 - handle ActiveEffect
     const droppedItemData = await Promise.all(
       folder.contents.map(async (item) => {
         if (!(document instanceof Item)) item = await fromUuid(item.uuid);
 
-        // If it's an equipment dropped on the project tab, create the item as a project
-        if (projectDropTarget && (item.type === "equipment")) {
-          const name = game.i18n.format("DRAW_STEEL.Item.project.Craft.ItemName", { name: item.name });
-          item = { name, type: "project", "system.yield.item": item.uuid };
-        }
+        const keepId = !this.actor.items.has(item.id);
 
-        return item;
+        return game.items.fromCompendium(item, { keepId, clearFolder: true });
       }),
     );
-    this.actor.createEmbeddedDocuments("Item", droppedItemData);
+    this.actor.createEmbeddedDocuments("Item", droppedItemData, { keepId: true });
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -983,6 +983,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
       }),
     );
     this.actor.createEmbeddedDocuments("Item", droppedItemData, { keepId: true });
+    return folder;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/character.mjs
+++ b/src/module/data/actor/character.mjs
@@ -183,7 +183,7 @@ export default class CharacterModel extends BaseActorModel {
     if (!stats.duplicateSource && !stats.compendiumSource && !stats.exportSource) {
       const items = await Promise.all(ds.CONFIG.hero.defaultItems.map(uuid => fromUuid(uuid)));
       // updateSource will merge the arrays for embedded collections
-      updates.items = items.map(i => game.items.fromCompendium(i, { clearFolder: true }));
+      updates.items = items.map(i => game.items.fromCompendium(i, { keepId: true, clearFolder: true }));
     }
 
     this.parent.updateSource(updates);


### PR DESCRIPTION
- Made sure we're using `game.items.fromCompendium`
- Now filters out items with advancements
- Most items that support advancements will have them, but there's room for a folder of features with no advancements to work fine if preferred

Closes #736 