### PR TITLE
PseudoDocument UI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Certain item types (Class, Subclass, Ancestry, Career, Kit) can no longer be created directly in world. Instead, they must be created inside a compendium. (#716)
   - This enforces good practices for data creation.
   - The buttons on the character sheet header now open the Ancestry, Background, and Class compendiums.
+- Adjusted the display of Power Roll Effects, including adding an image property.
 
 ### Fixed
 

--- a/draw-steel.d.ts
+++ b/draw-steel.d.ts
@@ -16,7 +16,7 @@ declare global {
   const fromUuid = foundry.utils.fromUuid;
   const fromUuidSync = foundry.utils.fromUuidSync;
   /**
-   * The singleton game canvas
+   * The singleton game canvas.
    */
   const canvas: Canvas;
 }

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -216,6 +216,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
       }
       const advancementContext = {
         name: model.name,
+        img: model.img,
         id: model.id,
       };
       if (model.description) advancementContext.enrichedDescription = await enrichHTML(model.description, { relativeTo: this.document });

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -156,6 +156,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
         context.advancementIcon = BaseAdvancement.metadata.icon;
         break;
       case "impact":
+        context.powerRollEffectIcon = ds.data.pseudoDocuments.powerRollEffects.BasePowerRollEffect.metadata.icon;
         context.enrichedBeforeEffect = await enrichHTML(this.item.system.effect.before, { relativeTo: this.item });
         context.enrichedAfterEffect = await enrichHTML(this.item.system.effect.after, { relativeTo: this.item });
         break;
@@ -293,46 +294,6 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
       c.effects.sort((a, b) => (a.sort || 0) - (b.sort || 0));
     }
     return categories;
-  }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  async _onFirstRender(context, options) {
-    await super._onFirstRender(context, options);
-
-    this._createContextMenu(this._powerRollContextOptions, ".power-roll-list .power-roll", {
-      hookName: "getPowerRollEffectContextOptions",
-      fixed: true,
-      parentClassHooks: false,
-    });
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Context menu entries for power rolls.
-   * @returns {ContextMenuEntry}
-   * @protected
-   */
-  _powerRollContextOptions() {
-    return [
-      {
-        name: game.i18n.format("DOCUMENT.Delete", { type: game.i18n.localize("DOCUMENT.PowerRollEffect") }),
-        icon: "<i class=\"fa-solid fa-fw fa-trash-can\"></i>",
-        condition: () => this.isEditable,
-        callback: (target) => {
-          const powerRollEffect = this._getPseudoDocument(target);
-          ui.notifications.info("DRAW_STEEL.PSEUDO.Notifications.DeletedInfo", { format: {
-            pseudoName: game.i18n.localize("DOCUMENT.PowerRollEffect"),
-            id: powerRollEffect.id,
-            type: powerRollEffect.type,
-            name: this.item.name,
-          } });
-          powerRollEffect.delete();
-        },
-      },
-    ];
   }
 
   /* -------------------------------------------------- */

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -685,18 +685,6 @@ preLocalize("languages", { key: "label" });
 
 /* -------------------------------------------------- */
 
-/** @import { AdvancementTypeConfiguration } from "./_types" */
-
-/**
- * Advancement types that can be added to items.
- * @enum {AdvancementTypeConfiguration}
- */
-DRAW_STEEL.advancementTypes = {
-
-};
-
-/* -------------------------------------------------- */
-
 /**
  * Configuration information for negotiations.
  */

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1269,8 +1269,9 @@ Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
 
 /**
  * @typedef PowerRollEffectType
- * @property {string} label
- * @property {pseudoDocuments.powerRollEffects.BasePowerRollEffect} documentClass
+ * @property {string} label                                                         Human-readable label.
+ * @property {string} defaultImage                                                  The default image for PowerRollEffects of this type.
+ * @property {pseudoDocuments.powerRollEffects.BasePowerRollEffect} documentClass   The pseudo-document class.
  * @property {Record<string, PowerRollEffectProperty>} [properties]
  */
 
@@ -1281,6 +1282,7 @@ Object.defineProperty(DRAW_STEEL.abilities.keywords, "optgroups", {
 DRAW_STEEL.PowerRollEffect = {
   damage: {
     label: "TYPES.PowerRollEffect.damage",
+    defaultImage: "icons/svg/fire.svg",
     documentClass: pseudoDocuments.powerRollEffects.DamagePowerRollEffect,
     properties: {
       ignoresImmunity: {
@@ -1290,6 +1292,7 @@ DRAW_STEEL.PowerRollEffect = {
   },
   applied: {
     label: "TYPES.PowerRollEffect.applied",
+    defaultImage: "icons/svg/paralysis.svg",
     documentClass: pseudoDocuments.powerRollEffects.AppliedPowerRollEffect,
     properties: {
       stacking: {
@@ -1299,6 +1302,7 @@ DRAW_STEEL.PowerRollEffect = {
   },
   forced: {
     label: "TYPES.PowerRollEffect.forced",
+    defaultImage: "icons/svg/portal.svg",
     documentClass: pseudoDocuments.powerRollEffects.ForcedMovementPowerRollEffect,
     properties: {
       ignoresImmunity: {
@@ -1311,6 +1315,7 @@ DRAW_STEEL.PowerRollEffect = {
   },
   other: {
     label: "TYPES.PowerRollEffect.other",
+    defaultImage: "icons/svg/sun.svg",
     documentClass: pseudoDocuments.powerRollEffects.OtherPowerRollEffect,
   },
 };
@@ -1320,7 +1325,8 @@ preLocalize("PowerRollEffect", { key: "label" });
 
 /**
  * @typedef AdvancementType
- * @property {string} label   Human-readable label.
+ * @property {string} label                                                 Human-readable label.
+ * @property {string} defaultImage                                          Default image used by documents of this type.
  * @property {pseudoDocuments.advancements.BaseAdvancement} documentClass   The pseudo-document class.
  */
 
@@ -1328,14 +1334,17 @@ preLocalize("PowerRollEffect", { key: "label" });
 DRAW_STEEL.Advancement = {
   itemGrant: {
     label: "TYPES.Advancement.itemGrant",
+    defaultImage: "icons/svg/item-bag.svg",
     documentClass: pseudoDocuments.advancements.ItemGrantAdvancement,
   },
   skill: {
     label: "TYPES.Advancement.skill",
+    defaultImage: "icons/svg/hanging-sign.svg",
     documentClass: pseudoDocuments.advancements.SkillAdvancement,
   },
   language: {
     label: "TYPES.Advancement.language",
+    defaultImage: "icons/svg/village.svg",
     documentClass: pseudoDocuments.advancements.LanguageAdvancement,
   },
 };

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -72,7 +72,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
         ? foundry.utils.getProperty(item, path) ?? []
         : [];
 
-    const content = [];
+    const content = document.createElement("div");
     for (const item of items) {
       const fgroup = `
       <div class="form-group">
@@ -81,7 +81,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
           <input type="checkbox" value="${item.uuid}" name="choices" ${chosen.includes(item.uuid) ? "checked" : ""}>
         </div>
       </div>`;
-      content.push(foundry.utils.parseHTML(fgroup));
+      content.insertAdjacentElement("beforeend", foundry.utils.parseHTML(fgroup));
     }
 
     /**
@@ -102,15 +102,14 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
       checkboxes[0].dispatchEvent(new Event("change"));
     }
 
-    const _content = document.createElement("DIV");
-    for (const fg of content) _content.insertAdjacentElement("beforeend", fg);
     const selection = await DSDialog.input({
+      content,
+      render,
+      classes: ["configure-advancement"],
       window: {
         title: game.i18n.format("DRAW_STEEL.ADVANCEMENT.ConfigureAdvancement.Title", { name: this.name }),
         icon: "fa-solid fa-edit",
       },
-      render,
-      content: _content,
     });
 
     if (!selection) return null;

--- a/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
@@ -122,12 +122,13 @@ export default class TraitAdvancement extends BaseAdvancement {
     }
 
     const selection = await ds.applications.api.DSDialog.input({
+      content,
+      render,
+      classes: ["configure-advancement"],
       window: {
         title: game.i18n.format("DRAW_STEEL.ADVANCEMENT.ConfigureAdvancement.Title", { name: this.name }),
         icon: "fa-solid fa-edit",
       },
-      render,
-      content: content,
     });
 
     if (!selection) return null;

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -18,7 +18,6 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   static get metadata() {
     return {
       documentName: null,
-      defaultImage: null,
       icon: "",
       embedded: {},
       sheetClass: null,
@@ -32,7 +31,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
     return {
       _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
       name: new StringField({ required: true }),
-      img: new FilePathField({ categories: ["IMAGE"], initial: () => this.metadata.defaultImage, nullable: true }),
+      img: new FilePathField({ categories: ["IMAGE"] }),
     };
   }
 

--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -48,6 +48,13 @@ export default class TypedPseudoDocument extends PseudoDocument {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  prepareBaseData() {
+    this.img ||= ds.CONFIG[this.constructor.metadata.documentName][this.type].defaultImage;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
     if (!this.name) {

--- a/src/styles/system/applications/sheets/item-sheet.css
+++ b/src/styles/system/applications/sheets/item-sheet.css
@@ -114,10 +114,9 @@
       display: flex;
       flex-direction: column;
     }
-    .power-roll-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 0.5rem;
+    .pre-img {
+      flex: 0 0 var(--input-height);
+      max-height: var(--input-height);
     }
   }
 }

--- a/src/styles/system/applications/sheets/item-sheet.css
+++ b/src/styles/system/applications/sheets/item-sheet.css
@@ -102,8 +102,11 @@
     }
   }
 
-  section[data-tab="advancements"] {
-    gap: 0.5rem;
+  section[data-tab="advancement"] {
+    .advancement-img {
+      flex: 0 0 var(--input-height);
+      max-height: var(--input-height);
+    }
   }
 
   section[data-tab="impact"] {

--- a/src/styles/system/applications/sheets/pseudo-documents.css
+++ b/src/styles/system/applications/sheets/pseudo-documents.css
@@ -5,7 +5,7 @@
 }
 
 .draw-steel.configure-advancement {
-  multi-checkbox {
+  multi-checkbox:has(fieldset) {
     display: flex;
     flex-wrap: wrap;
     justify-content: stretch;

--- a/src/styles/system/applications/sheets/pseudo-documents.css
+++ b/src/styles/system/applications/sheets/pseudo-documents.css
@@ -3,3 +3,18 @@
     margin: 0;
   }
 }
+
+.draw-steel.configure-advancement {
+  multi-checkbox {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: stretch;
+    gap: 0.75rem;
+    fieldset {
+      width: 100%;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.5rem;
+    }
+  }
+}

--- a/templates/sheets/item/advancement.hbs
+++ b/templates/sheets/item/advancement.hbs
@@ -10,7 +10,10 @@
     <legend>{{section}}</legend>
     {{#each documents}}
     <div class="form-group" data-pseudo-id="{{id}}">
-      <label data-tooltip-html="{{enrichedDescription}}">{{name}}</label>
+      <img class="advancement-img" src="{{img}}" alt="{{name}}">
+      <label data-tooltip-html="{{enrichedDescription}}">
+        {{name}}
+      </label>
       <div class="form-fields">
         <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
         <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled (not @root.editable)}}></button>

--- a/templates/sheets/item/advancement.hbs
+++ b/templates/sheets/item/advancement.hbs
@@ -16,7 +16,7 @@
       </label>
       <div class="form-fields">
         <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
-        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled (not @root.editable)}}></button>
+        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled (or @root.isPlay (not @root.editable))}}></button>
       </div>
     </div>
     {{/each}}

--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -21,20 +21,25 @@
 
   <fieldset data-pseudo-document-name="PowerRollEffect">
     <legend>{{systemFields.power.fields.effects.label}}</legend>
-    {{#unless isPlay}}
-    <button type="button" data-action="createPseudoDocument">
-      <i class="fa-solid fa-plus"></i>
-      {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.PowerRollEffect")}}
-    </button>
-    {{/unless}}
-    {{!-- Using document.system to ensure initialized values in edit mode --}}
-    <div class="power-roll-list">
-      {{#each document.system.power.effects as |effect|}}
-      <button type="button" class="power-roll" data-action="renderPseudoDocumentSheet" data-pseudo-id="{{effect.id}}">
-        {{localize effect.name}}
+      {{#unless isPlay}}
+    <div class="section-header">
+      <button type="button" data-action="createPseudoDocument">
+        <i class="{{powerRollEffectIcon}}"></i>
+        {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.PowerRollEffect")}}
       </button>
-      {{/each}}
     </div>
+      {{/unless}}
+    {{!-- Using document.system to ensure initialized values in edit mode --}}
+    {{#each document.system.power.effects}}
+    <div class="form-group" data-pseudo-id="{{id}}">
+      <img class="pre-img" src="{{img}}" alt="{{name}}">
+      <label> {{name}} </label>
+      <div class="form-fields">
+        <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
+        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled (or @root.isPlay (not @root.editable))}}></button>
+      </div>
+    </div>
+    {{/each}}
   </fieldset>
 
   <fieldset>

--- a/tools/pullJSONtoLDB.mjs
+++ b/tools/pullJSONtoLDB.mjs
@@ -29,8 +29,8 @@ for (const pack of packs) {
 }
 
 /**
- * Add in wiki docs from `src/docs`
- * @param {object} entry The entry data
+ * Add in wiki docs from `src/docs`.
+ * @param {object} entry The entry data.
  * @returns {Promise<false|void>}  Return boolean false to indicate that this entry should be discarded.
  */
 async function transformEntry(entry) {

--- a/tools/pushLDBtoJSON.mjs
+++ b/tools/pushLDBtoJSON.mjs
@@ -35,8 +35,8 @@ for (const pack of packs) {
   );
 }
 /**
- * Prefaces the document with its type
- * @param {object} doc - The document data
+ * Prefaces the document with its type.
+ * @param {object} doc - The document data.
  */
 function transformName(doc, context) {
   const safeFileName = doc.name.replace(/[^a-zA-Z0-9А-я]/g, "_");
@@ -63,8 +63,8 @@ function transformName(doc, context) {
 }
 
 /**
- * Remove text content from wiki journal
- * @param {object} entry The entry data
+ * Remove text content from wiki journal.
+ * @param {object} entry The entry data.
  * @returns {Promise<false|void>}  Return boolean false to indicate that this entry should be discarded.
  */
 async function transformEntry(entry) {


### PR DESCRIPTION
- Adjusted display of multi-checkboxes that are using groups to improve the Skill select display
- Added images to Advancement tab
- Redid Power Roll Effects to match the Advancements display

<img width="399" height="763" alt="image" src="https://github.com/user-attachments/assets/333028cb-1a73-47a1-aafb-4ad83f5e6377" />


<img width="542" height="448" alt="image" src="https://github.com/user-attachments/assets/59041953-5edf-4972-9fb1-23a324137d94" />


<img width="528" height="271" alt="image" src="https://github.com/user-attachments/assets/62249c22-71e2-46a6-9331-47548c9a7568" />


Closes #683