### PR TITLE
[#712] Advancement Restrictions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -68,7 +68,8 @@
         "requirements": "Requirements",
         "chooseAll": "Choose All",
         "unknownItem": "Unknown Item",
-        "requirePack": "Granted items must come from a compendium pack."
+        "requirePack": "Granted items must come from a compendium pack.",
+        "restrictedType": "{type} items cannot be added as advancements."
       },
       "WARNING": {
         "cannotAddNewType": "You cannot add a new {type} to a character that already has one."

--- a/lang/en.json
+++ b/lang/en.json
@@ -68,8 +68,9 @@
         "requirements": "Requirements",
         "chooseAll": "Choose All",
         "unknownItem": "Unknown Item",
+        "restrictedType": "{type} items cannot be added as advancements.",
         "requirePack": "Granted items must come from a compendium pack.",
-        "restrictedType": "{type} items cannot be added as advancements."
+        "forbidParent": "Granted items cannot be embedded in an actor."
       },
       "WARNING": {
         "cannotAddNewType": "You cannot add a new {type} to a character that already has one."

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -5,7 +5,6 @@ import DocumentSourceInput from "../apps/document-source-input.mjs";
 import BaseAdvancement from "../../data/pseudo-documents/advancements/base-advancement.mjs";
 
 /**
- * @import { FormSelectOption } from "@client/applications/forms/fields.mjs"
  * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs"
  * @import DrawSteelActiveEffect from "../../documents/active-effect.mjs"
  * @import BaseItemModel from "../../data/item/base.mjs"
@@ -552,26 +551,19 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
    * @private
    */
   static async #createCultureAdvancement(event, target) {
-    /** @type {FormSelectOption[]} */
-    const typeOptions = Object.keys(BaseAdvancement.TYPES).map(type => ({
-      value: type,
-      label: game.i18n.localize(`TYPES.Advancement.${type}`),
-    }));
+    const context = BaseAdvancement._prepareCreateDialogContext(this.document);
 
     const aspectPrefix = "cultureAspect";
 
     for (const [key, config] of Object.entries(ds.CONFIG.culture.aspects)) {
-      typeOptions.push({
+      context.typeOptions.push({
         label: config.label,
         group: ds.CONFIG.culture.group[config.group]?.label,
         value: `${aspectPrefix}.${key}`,
       });
     }
 
-    const content = await foundry.applications.handlebars.renderTemplate(systemPath("templates/sheets/pseudo-documents/advancement/create-dialog.hbs"), {
-      typeOptions,
-      fields: BaseAdvancement.schema.fields,
-    });
+    const content = await foundry.applications.handlebars.renderTemplate(BaseAdvancement.CREATE_TEMPLATE, context);
 
     const result = await ds.applications.api.DSDialog.input({
       window: {
@@ -582,8 +574,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
       render: (event, dialog) => {
         const typeInput = dialog.element.querySelector("[name=\"type\"]");
         const nameInput = dialog.element.querySelector("[name=\"name\"]");
-        nameInput.placeholder = typeOptions.find(o => o.value === typeInput.value).label;
-        typeInput.addEventListener("change", () => nameInput.placeholder = typeOptions.find(o => o.value === typeInput.value).label);
+        nameInput.placeholder = context.typeOptions.find(o => o.value === typeInput.value).label;
+        typeInput.addEventListener("change", () => nameInput.placeholder = context.typeOptions.find(o => o.value === typeInput.value).label);
       },
     });
     if (!result) return;

--- a/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
@@ -1,4 +1,7 @@
 import PseudoDocumentSheet from "../../api/pseudo-document-sheet.mjs";
+import ItemGrantAdvancement from "../../../data/pseudo-documents/advancements/item-grant-advancement.mjs";
+
+const { DragDrop, TextEditor } = foundry.applications.ux;
 
 export default class AdvancementSheet extends PseudoDocumentSheet {
   /** @inheritdoc */
@@ -95,7 +98,7 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
   async _onRender(context, options) {
     await super._onRender(context, options);
 
-    new foundry.applications.ux.DragDrop.implementation({
+    new DragDrop.implementation({
       dropSelector: ".drop-target-area",
       callbacks: {
         drop: AdvancementSheet.#onDropTargetArea.bind(this),
@@ -112,10 +115,12 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
    * @param {DragEvent} event   The initiating drag event.
    */
   static async #onDropTargetArea(event) {
-    const item = await fromUuid(foundry.applications.ux.TextEditor.implementation.getDragEventData(event).uuid);
+    const item = await fromUuid(TextEditor.implementation.getDragEventData(event).uuid);
 
-    // TODO: Restrict by item type.
     if (!item || (item.documentName !== "Item")) return;
+    if (ItemGrantAdvancement.RESTRICTED_TYPES.has(item.type)) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.SHEET.restrictedType", {
+      format: { type: game.i18n.localize(CONFIG.Item.typeLabels[item.type]) },
+    });
     if (!item.pack) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.SHEET.requirePack", { localize: true });
 
     const exists = this.pseudoDocument.pool.some(k => k.uuid === item.uuid);

--- a/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
@@ -118,10 +118,11 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
     const item = await fromUuid(TextEditor.implementation.getDragEventData(event).uuid);
 
     if (!item || (item.documentName !== "Item")) return;
-    if (ItemGrantAdvancement.RESTRICTED_TYPES.has(item.type)) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.SHEET.restrictedType", {
+    if (!ItemGrantAdvancement.ALLOWED_TYPES.has(item.type)) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.SHEET.restrictedType", {
       format: { type: game.i18n.localize(CONFIG.Item.typeLabels[item.type]) },
     });
     if (!item.pack) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.SHEET.requirePack", { localize: true });
+    if (item.parent) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.SHEET.forbidParent", { localize: true });
 
     const exists = this.pseudoDocument.pool.some(k => k.uuid === item.uuid);
     if (exists) return;

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1336,7 +1336,7 @@ DRAW_STEEL.Advancement = {
   itemGrant: {
     label: "TYPES.Advancement.itemGrant",
     defaultImage: "icons/svg/item-bag.svg",
-    itemTypes: new Set(["career", "class", "complication", "feature", "kit", "subclass"]),
+    itemTypes: new Set(["ancestry", "career", "class", "complication", "feature", "kit", "subclass"]),
     documentClass: pseudoDocuments.advancements.ItemGrantAdvancement,
   },
   skill: {

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1327,6 +1327,7 @@ preLocalize("PowerRollEffect", { key: "label" });
  * @typedef AdvancementType
  * @property {string} label                                                 Human-readable label.
  * @property {string} defaultImage                                          Default image used by documents of this type.
+ * @property {Set<string>} itemTypes                                        Item types that can hold this advancement type.
  * @property {pseudoDocuments.advancements.BaseAdvancement} documentClass   The pseudo-document class.
  */
 
@@ -1335,19 +1336,23 @@ DRAW_STEEL.Advancement = {
   itemGrant: {
     label: "TYPES.Advancement.itemGrant",
     defaultImage: "icons/svg/item-bag.svg",
+    itemTypes: new Set(["career", "class", "complication", "feature", "kit", "subclass"]),
     documentClass: pseudoDocuments.advancements.ItemGrantAdvancement,
   },
   skill: {
     label: "TYPES.Advancement.skill",
     defaultImage: "icons/svg/hanging-sign.svg",
+    itemTypes: new Set(["career", "class", "complication", "culture", "feature", "subclass"]),
     documentClass: pseudoDocuments.advancements.SkillAdvancement,
   },
   language: {
     label: "TYPES.Advancement.language",
     defaultImage: "icons/svg/village.svg",
+    itemTypes: new Set(["career", "class", "complication", "culture", "feature", "subclass"]),
     documentClass: pseudoDocuments.advancements.LanguageAdvancement,
   },
 };
+preLocalize("Advancement", { key: "label" });
 
 /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/advancements/base-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/base-advancement.mjs
@@ -4,6 +4,7 @@ import { systemPath } from "../../../constants.mjs";
 
 /**
  * @import { DataSchema } from "@common/abstract/_types.mjs"
+ * @import { FormSelectOption } from "@client/applications/forms/fields.mjs"
  */
 
 const { HTMLField, NumberField, SchemaField } = foundry.data.fields;
@@ -54,6 +55,23 @@ export default class BaseAdvancement extends TypedPseudoDocument {
 
   /** @inheritdoc */
   static CREATE_TEMPLATE = systemPath("templates/sheets/pseudo-documents/advancement/create-dialog.hbs");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static _prepareCreateDialogContext(parent) {
+
+    /** @type {FormSelectOption[]} */
+    const typeOptions = Object.entries(ds.CONFIG.Advancement).reduce((arr, [value, config]) => {
+      if (config.itemTypes.has(parent.type)) arr.push({ value, label: config.label });
+      return arr;
+    }, []);
+
+    return {
+      typeOptions,
+      fields: this.schema.fields,
+    };
+  }
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -31,6 +31,14 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
 
   /* -------------------------------------------------- */
 
+  /**
+   * Item types that cannot be added to an Item Grant.
+   * @type {Set<string>}
+   */
+  static RESTRICTED_TYPES = new Set(["ancestry", "career", "class", "complication", "culture", "subclass"]);
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   get levels() {
     return [this.requirements.level];

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -32,10 +32,10 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
   /* -------------------------------------------------- */
 
   /**
-   * Item types that cannot be added to an Item Grant.
+   * Item types that can be added to an Item Grant.
    * @type {Set<string>}
    */
-  static RESTRICTED_TYPES = new Set(["ancestry", "career", "class", "complication", "culture", "subclass"]);
+  static ALLOWED_TYPES = new Set(["ability", "equipment", "feature", "kit", "project"]);
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -262,9 +262,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    */
   static async createDialog(data = {}, { parent, ...operation } = {}) {
     // If there's demand or need we can make the template & context more dynamic
-    const content = await foundry.applications.handlebars.renderTemplate(this.CREATE_TEMPLATE, {
-      fields: this.schema.fields,
-    });
+    const content = await foundry.applications.handlebars.renderTemplate(this.CREATE_TEMPLATE, this._prepareCreateDialogContext(parent));
 
     const result = await ds.applications.api.DSDialog.input({
       content,
@@ -272,10 +270,33 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
         title: game.i18n.format("DOCUMENT.New", { type: game.i18n.localize(`DOCUMENT.${this.metadata.documentName}`) }),
         icon: this.metadata.icon,
       },
+      render: (event, dialog) => this._createDialogRenderCallback(event, dialog),
     });
     if (!result) return null;
     return this.create({ ...data, ...result }, { parent, ...operation });
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepares context for use with {@link CREATE_TEMPLATE}.
+   * @param {foundry.abstract.DataModel} parent
+   * @returns {object}
+   */
+  static _prepareCreateDialogContext(parent) {
+    return {
+      fields: this.schema.fields,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Render callback for dynamic handling on the .
+   * @param {Event} event
+   * @param {ds.applications.api.DSDialog} dialog
+   */
+  static _createDialogRenderCallback(event, dialog) {}
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -282,6 +282,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * Prepares context for use with {@link CREATE_TEMPLATE}.
    * @param {foundry.abstract.DataModel} parent
    * @returns {object}
+   * @protected
    */
   static _prepareCreateDialogContext(parent) {
     return {
@@ -295,6 +296,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * Render callback for dynamic handling on the .
    * @param {Event} event
    * @param {ds.applications.api.DSDialog} dialog
+   * @protected
    */
   static _createDialogRenderCallback(event, dialog) {}
 

--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -79,6 +79,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
   /** @inheritdoc */
   static _prepareCreateDialogContext(parent) {
 
+    /** @type {FormSelectOption[]} */
     const typeOptions = Object.entries(ds.CONFIG[this.metadata.documentName]).map(([value, { label }]) => ({ value, label }));
 
     return {

--- a/templates/sheets/item/advancement.hbs
+++ b/templates/sheets/item/advancement.hbs
@@ -16,7 +16,7 @@
       </label>
       <div class="form-fields">
         <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
-        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled @root.isPlay)}}></button>
+        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled @root.isPlay}}></button>
       </div>
     </div>
     {{/each}}

--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -21,14 +21,14 @@
 
   <fieldset data-pseudo-document-name="PowerRollEffect">
     <legend>{{systemFields.power.fields.effects.label}}</legend>
-      {{#unless isPlay}}
+    {{#unless isPlay}}
     <div class="section-header">
       <button type="button" data-action="createPseudoDocument">
         <i class="{{powerRollEffectIcon}}"></i>
         {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.PowerRollEffect")}}
       </button>
     </div>
-      {{/unless}}
+    {{/unless}}
     {{!-- Using document.system to ensure initialized values in edit mode --}}
     {{#each document.system.power.effects}}
     <div class="form-group" data-pseudo-id="{{id}}">
@@ -36,7 +36,7 @@
       <label> {{name}} </label>
       <div class="form-fields">
         <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
-        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled @root.isPlay)}}></button>
+        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled @root.isPlay}}></button>
       </div>
     </div>
     {{/each}}


### PR DESCRIPTION
- Implemented create-level controls on what advancements can go on what item types.
  - Ancestries & Kits only have Item Grants
  - Cultures only have Skill, Language, and their custom types
  - Everything else (career, class, complication, feature, subclass) has access to all three advancement types
- Implemented restrictions on what can be dropped on an Item Grant. I kept Kits because of the unique Stormwright kits, maybe that was incorrect.
- Refactored our handling of PseudoDocument.createDialog to use more helper functions and no total overrides.

I think we could re-evaluate exactly how we're deciding TypedPseudoDocument.TYPES, seems slightly redundant in construction.

Closes #712 