### PR TITLE
Enrich HTML logic fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Fixed display of multi-result abilities
 - Fixed unrequited prompting for end of turn events (#673)
 - Fixed project and save rolls not respecting roll mode settings. (#734)
+- Secret blocks will now display in enriched descriptions for owned documents.
 
 ## 0.7.3
 

--- a/src/module/utils/enrich-html.mjs
+++ b/src/module/utils/enrich-html.mjs
@@ -10,8 +10,8 @@
 export default async function enrichHTML(content, options = {}) {
   // Override document-related options with the relative document's info
   if (options.relativeTo) {
-    // allow secrets=false to prevent secret display
-    options.secrets &&= options.relativeTo.isOwner;
+    // Don't reveal secrets of unowned documents, but allow explicit false to prevent sharing secrets of owned documents
+    if (options.secrets !== false) options.secrets = options.relativeTo.isOwner;
     if (options.relativeTo.getRollData instanceof Function) options.rollData = options.relativeTo.getRollData();
   }
   return foundry.applications.ux.TextEditor.implementation.enrichHTML(content, options);


### PR DESCRIPTION
I realized that `secrets: undefined` would not add the secrets. I think we want to default to showing them for owned documents.

Practical note: This means secret blocks will show up in Chat Messages; we could switch back to using the &&= and instead just insert secrets: true for the sheet calls