### PR TITLE
Add project and roll table compendiums with 1 item each

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -11,7 +11,9 @@
       "classes": "Classes",
       "kits": "Kits",
       "abilities": "Abilities",
-      "journals": "System Journals"
+      "journals": "System Journals",
+      "projects": "Projects",
+      "tables": "Roll Tables"
     },
     "ADVANCEMENT": {
       "FIELDS": {

--- a/src/packs/projects/Crafting_T4atnhMHm4PGlGhs/project_Build_or_Repair_Road_nrGhQfeeUvIHA5u9.json
+++ b/src/packs/projects/Crafting_T4atnhMHm4PGlGhs/project_Build_or_Repair_Road_nrGhQfeeUvIHA5u9.json
@@ -1,0 +1,54 @@
+{
+  "folder": "T4atnhMHm4PGlGhs",
+  "name": "Build or Repair Road",
+  "type": "project",
+  "_id": "nrGhQfeeUvIHA5u9",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": {
+      "value": "<p>When you start this project, you hire a crew of masons, engineers, and guards who start work at the location where the project begins and build or repair the road for you. You can make a project roll whenever you are overseeing the project, whether you do so in person or remotely through the use of magic or psionics.</p><p>The number of project points required to complete work on the road equals 10 × the road’s length in miles. The goal is cut in half if you are repairing an existing road, or if someone else starts work on a second road project that connects to your project.</p><p>When you complete the project, you earn Renown among people in the area where the road is built, depending on the length of the road.</p><p>Time spent traveling between locations on the road is cut in half. Access to resources and knowledge is improved in locations along the road, giving you and your allies an edge on project rolls to discover lore while you are in those areas.</p><h4>Build or Repair Road Renown</h4><table><thead><tr><th><strong>Length</strong></th><th><strong>Renown Earned</strong></th></tr></thead><tbody><tr><td><p>50 miles or less</p></td><td><p>1</p></td></tr><tr><td><p>51–100 miles</p></td><td><p>2</p></td></tr><tr><td><p>More than 100 miles</p></td><td><p>3</p></td></tr></tbody></table><p></p><h4>Build or Repair Roads Events</h4><p>@Embed[Compendium.draw-steel.tables.RollTable.tXtAQLmmJP1vHK6R]</p><p></p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "build-or-repair-road",
+    "type": "crafting",
+    "prerequisites": "Three writs of approval, from an engineers’ guild, a masons’ guild, and a guards’ guild",
+    "projectSource": "Texts or lore in Caelian",
+    "rollCharacteristic": [
+      "might",
+      "reason",
+      "presence"
+    ],
+    "goal": 1,
+    "points": 0,
+    "yield": {
+      "item": null,
+      "amount": "1",
+      "display": ""
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "lRkxYszShOLYPqDd": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754344362362,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!nrGhQfeeUvIHA5u9"
+}

--- a/src/packs/projects/Crafting_T4atnhMHm4PGlGhs/project_Build_or_Repair_Road_nrGhQfeeUvIHA5u9.json
+++ b/src/packs/projects/Crafting_T4atnhMHm4PGlGhs/project_Build_or_Repair_Road_nrGhQfeeUvIHA5u9.json
@@ -3,7 +3,7 @@
   "name": "Build or Repair Road",
   "type": "project",
   "_id": "nrGhQfeeUvIHA5u9",
-  "img": "icons/svg/item-bag.svg",
+  "img": "icons/environment/wilderness/terrain-rocky-ground.webp",
   "system": {
     "description": {
       "value": "<p>When you start this project, you hire a crew of masons, engineers, and guards who start work at the location where the project begins and build or repair the road for you. You can make a project roll whenever you are overseeing the project, whether you do so in person or remotely through the use of magic or psionics.</p><p>The number of project points required to complete work on the road equals 10 × the road’s length in miles. The goal is cut in half if you are repairing an existing road, or if someone else starts work on a second road project that connects to your project.</p><p>When you complete the project, you earn Renown among people in the area where the road is built, depending on the length of the road.</p><p>Time spent traveling between locations on the road is cut in half. Access to resources and knowledge is improved in locations along the road, giving you and your allies an edge on project rolls to discover lore while you are in those areas.</p><h4>Build or Repair Road Renown</h4><table><thead><tr><th><strong>Length</strong></th><th><strong>Renown Earned</strong></th></tr></thead><tbody><tr><td><p>50 miles or less</p></td><td><p>1</p></td></tr><tr><td><p>51–100 miles</p></td><td><p>2</p></td></tr><tr><td><p>More than 100 miles</p></td><td><p>3</p></td></tr></tbody></table><p></p><h4>Build or Repair Roads Events</h4><p>@Embed[Compendium.draw-steel.tables.RollTable.tXtAQLmmJP1vHK6R]</p><p></p>",

--- a/src/packs/projects/folders_Crafting_T4atnhMHm4PGlGhs.json
+++ b/src/packs/projects/folders_Crafting_T4atnhMHm4PGlGhs.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Crafting",
+  "color": null,
+  "sorting": "a",
+  "_id": "T4atnhMHm4PGlGhs",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754344153876,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!T4atnhMHm4PGlGhs"
+}

--- a/src/packs/projects/folders_Other_BENe8K7l3sgJhHyY.json
+++ b/src/packs/projects/folders_Other_BENe8K7l3sgJhHyY.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Other",
+  "color": null,
+  "sorting": "a",
+  "_id": "BENe8K7l3sgJhHyY",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754345236300,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!BENe8K7l3sgJhHyY"
+}

--- a/src/packs/projects/folders_Research_d4ZRwtKptm3Rr4F6.json
+++ b/src/packs/projects/folders_Research_d4ZRwtKptm3Rr4F6.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Research",
+  "color": null,
+  "sorting": "a",
+  "_id": "d4ZRwtKptm3Rr4F6",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754344158755,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!d4ZRwtKptm3Rr4F6"
+}

--- a/src/packs/tables/Project_Events_Tgb2Z68gf9SJ5VIg/tables_Build_or_Repair_Road_Events_tXtAQLmmJP1vHK6R.json
+++ b/src/packs/tables/Project_Events_Tgb2Z68gf9SJ5VIg/tables_Build_or_Repair_Road_Events_tXtAQLmmJP1vHK6R.json
@@ -1,7 +1,7 @@
 {
   "name": "Build or Repair Road Events",
   "_id": "tXtAQLmmJP1vHK6R",
-  "img": "icons/svg/d20-grey.svg",
+  "img": "icons/environment/wilderness/terrain-rocky-ground.webp",
   "description": "",
   "results": [
     {

--- a/src/packs/tables/Project_Events_Tgb2Z68gf9SJ5VIg/tables_Build_or_Repair_Road_Events_tXtAQLmmJP1vHK6R.json
+++ b/src/packs/tables/Project_Events_Tgb2Z68gf9SJ5VIg/tables_Build_or_Repair_Road_Events_tXtAQLmmJP1vHK6R.json
@@ -1,0 +1,300 @@
+{
+  "name": "Build or Repair Road Events",
+  "_id": "tXtAQLmmJP1vHK6R",
+  "img": "icons/svg/d20-grey.svg",
+  "description": "",
+  "results": [
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        1,
+        1
+      ],
+      "_id": "2PAlqJ9b4DiXk4DB",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>Before the roll, crews uncover an ancient road following the intended route, crafted with remarkable techniques that make it a sturdy base on which to build. The project gains an automatic breakthrough and the project goal is halved if it was not already halved.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345278636,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.2PAlqJ9b4DiXk4DB"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        2,
+        2
+      ],
+      "_id": "HeVC7Wd65IyNYboN",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>After the roll, the local population grows in excitement with each completed portion of the road. The name of the hero making the project roll spreads as a builder of bridges both literal and social. If the project roll is 12 or higher, the local community comes together to complete the project alongside the hero’s hired crew. The hero doubles the renown earned at the end of the project.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345279955,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.HeVC7Wd65IyNYboN"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        3,
+        3
+      ],
+      "_id": "HCsezcsDwzJaugtp",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>Before the roll, a local religious or civic authority hears of the project and sends laborers to accelerate it—in exchange for a future favor. The hero gains an immediate 50 project points for the project if they accept the help.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345280225,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.HCsezcsDwzJaugtp"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        4,
+        4
+      ],
+      "_id": "Ddny12YAYVvdK29A",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>After the roll, local hired hands and the project engineers find themselves at odds, hindering the project. If the hero can’t help defuse the situation, the project requires an additional 50 project points to complete. </p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345280517,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.Ddny12YAYVvdK29A"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        5,
+        5
+      ],
+      "_id": "qfiksDIjQLMgMR6U",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>Before the roll, supply caravans are disrupted by bandits, requiring extra guards. If the hero can’t deal with the bandit threat personally, the project requires an additional 50 project points to complete.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345280783,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.qfiksDIjQLMgMR6U"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        6,
+        6
+      ],
+      "_id": "qPYvoNOfjypVBZmQ",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>After the roll, word is heard that not everyone in the local area is happy about the road being built. The project is hindered by supernatural curses that cause stones to move, vines and overgrowth to reclaim sections already built, or churning earth to restore the road back to its previous form. The hero must make amends to the local supernatural community or have the renown earned by completing the project not extend to that community.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345281088,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.qPYvoNOfjypVBZmQ"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        7,
+        7
+      ],
+      "_id": "qF5T4yzTVRb658b3",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>After the roll, ditchers working on the project hit an ancient well, retaining wall, or hidden stream that results in an immediate flood. The work is delayed, but the new water source ultimately provides a boon to local farming communities. Project points earned by this roll are halved, but upon the project’s completion, the hero earns 1 additional renown.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345281478,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.qF5T4yzTVRb658b3"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        8,
+        8
+      ],
+      "_id": "L5fXdDYLhvkI1YNd",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>Before the roll, a new engineer arrives with specialist experience such as building sturdy wooden bridges, using bilge pumps to keep rainwater from slowing the work, and so forth. They want to work on the project, but insist on receiving a consumable treasure first. If they are hired, the project gains an automatic breakthrough.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345281942,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.L5fXdDYLhvkI1YNd"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        9,
+        9
+      ],
+      "_id": "bhRcmFP4haTscR9N",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>Before the roll, the proposed road touches on a supernatural intersection—a crossing place between multiple worlds that draws interest from a powerful devil. The completion of the project becomes the personal interest of this being, who offers to increase progress—but demands a future favor from the hero. If the deal is accepted, each project roll for the project is doubled until its completion.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345282313,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.bhRcmFP4haTscR9N"
+    },
+    {
+      "type": "text",
+      "weight": 1,
+      "range": [
+        10,
+        10
+      ],
+      "_id": "kx8Ybq6D2s3D1JFm",
+      "name": "",
+      "img": "icons/svg/d20-black.svg",
+      "description": "<p>After the roll, a guildmaster has it out for the hero. Whether from a past conflict or something about the way this project has unfolded, the guildmaster has made it their mission to hinder the project by dragging the hero’s name through the mud. The hero’s renown is treated as 1 less than usual while these rumors persist.</p>",
+      "drawn": false,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754345282759,
+        "modifiedTime": 1754345429287,
+        "lastModifiedBy": "lRkxYszShOLYPqDd"
+      },
+      "documentUuid": null,
+      "_key": "!tables.results!tXtAQLmmJP1vHK6R.kx8Ybq6D2s3D1JFm"
+    }
+  ],
+  "replacement": true,
+  "displayRoll": true,
+  "folder": "Tgb2Z68gf9SJ5VIg",
+  "sort": 100000,
+  "ownership": {
+    "default": 0,
+    "lRkxYszShOLYPqDd": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754345262423,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "formula": "1d10",
+  "_key": "!tables!tXtAQLmmJP1vHK6R"
+}

--- a/src/packs/tables/folders_Project_Events_Tgb2Z68gf9SJ5VIg.json
+++ b/src/packs/tables/folders_Project_Events_Tgb2Z68gf9SJ5VIg.json
@@ -1,0 +1,23 @@
+{
+  "type": "RollTable",
+  "folder": null,
+  "name": "Project Events",
+  "color": null,
+  "sorting": "a",
+  "_id": "Tgb2Z68gf9SJ5VIg",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754345267098,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!Tgb2Z68gf9SJ5VIg"
+}

--- a/system.json
+++ b/system.json
@@ -172,13 +172,23 @@
       "name": "journals",
       "label": "DRAW_STEEL.COMPENDIUM.journals",
       "type": "JournalEntry"
+    },
+    {
+      "name": "projects",
+      "label": "DRAW_STEEL.COMPENDIUM.projects",
+      "type": "Item"
+    },
+    {
+      "name": "tables",
+      "label": "DRAW_STEEL.COMPENDIUM.tables",
+      "type": "RollTable"
     }
   ],
   "packFolders": [
     {
       "name": "Draw Steel System",
       "color": "#483D8B",
-      "packs": ["ancestries", "backgrounds", "classes", "kits", "abilities", "journals"]
+      "packs": ["ancestries", "backgrounds", "classes", "kits", "abilities", "journals", "projects", "tables"]
     }
   ],
   "socket": true,


### PR DESCRIPTION
Adds project and roll table compendiums. Used the Build or Repair a Road project and its corresponding events roll table as the initial items in the compendiums.

Sets up further work for #768.