### PR TITLE
[#765] Value adjustments on Kit Signature Abilities 

### DIFF
--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Double_Strike_WObnlBIDDMWoNhVn.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Double_Strike_WObnlBIDDMWoNhVn.json
@@ -45,7 +45,7 @@
           "_id": "XHLjxoi4udUZ2rrJ",
           "damage": {
             "tier1": {
-              "value": "4",
+              "value": "2",
               "types": [],
               "properties": [],
               "potency": {
@@ -54,7 +54,7 @@
               }
             },
             "tier2": {
-              "value": "6",
+              "value": "4",
               "types": [],
               "properties": [],
               "potency": {
@@ -63,7 +63,7 @@
               }
             },
             "tier3": {
-              "value": "8",
+              "value": "6",
               "types": [],
               "properties": [],
               "potency": {
@@ -77,7 +77,7 @@
     },
     "effect": {
       "before": "",
-      "after": "<p>Effect: If you use this ability on your turn, you can use it against one target, then use your maneuver and your move action for that turn before using the ability against a second target. You still use the same power roll for both targets.</p>"
+      "after": "<p>If you use this ability on your turn, you can use it against one target, then use your maneuver and your move action for that turn before using the ability against a second target. You still use the same power roll for both targets.</p>"
     },
     "spend": {
       "text": "",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Exploding_Arrow_efaX6kreuPliD9Fd.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Exploding_Arrow_efaX6kreuPliD9Fd.json
@@ -23,7 +23,7 @@
     "trigger": "",
     "distance": {
       "type": "ranged",
-      "primary": 15
+      "primary": 5
     },
     "damageDisplay": "melee",
     "target": {
@@ -48,19 +48,19 @@
           "_id": "fYrplP2lLMh1CkGW",
           "damage": {
             "tier1": {
-              "value": "5 + @chr",
+              "value": "3 + @chr",
               "types": [
                 "fire"
               ]
             },
             "tier2": {
-              "value": "7 + @chr",
+              "value": "5 + @chr",
               "types": [
                 "fire"
               ]
             },
             "tier3": {
-              "value": "10 + @chr",
+              "value": "8 + @chr",
               "types": [
                 "fire"
               ]
@@ -71,7 +71,7 @@
     },
     "effect": {
       "before": "",
-      "after": "<p><strong>Effect:</strong> One creature or object of your choice within 2 squares of the target takes fire damage equal to the characteristic score used for this ability’s power roll.</p>"
+      "after": "<p>One creature or object of your choice within 2 squares of the target takes fire damage equal to the characteristic score used for this ability’s power roll.</p>"
     },
     "spend": {
       "text": "",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fade_ZWx0BbPE3GitPTXJ.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fade_ZWx0BbPE3GitPTXJ.json
@@ -24,7 +24,7 @@
     "distance": {
       "type": "meleeRanged",
       "primary": 1,
-      "secondary": 10
+      "secondary": 5
     },
     "damageDisplay": "melee",
     "target": {
@@ -47,7 +47,7 @@
           "_id": "fm9HgAGlqlQNyc0a",
           "damage": {
             "tier1": {
-              "value": "3 + @chr",
+              "value": "2 + @chr",
               "types": [],
               "properties": [],
               "potency": {
@@ -56,7 +56,7 @@
               }
             },
             "tier2": {
-              "value": "6 + @chr",
+              "value": "5 + @chr",
               "types": [],
               "properties": [],
               "potency": {
@@ -65,7 +65,7 @@
               }
             },
             "tier3": {
-              "value": "8 + @chr",
+              "value": "7 + @chr",
               "types": [],
               "properties": [],
               "potency": {

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Protective_Attack_3G70A9bFAJzp7nxD.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Protective_Attack_3G70A9bFAJzp7nxD.json
@@ -45,13 +45,13 @@
           "_id": "PYG6jE7eJ6CbbxDI",
           "damage": {
             "tier1": {
-              "value": "5 + @chr"
+              "value": "3 + @chr"
             },
             "tier2": {
-              "value": "8 + @chr"
+              "value": "6 + @chr"
             },
             "tier3": {
-              "value": "11 + @chr"
+              "value": "9 + @chr"
             }
           }
         }

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Unmooring_a8GtSVHtRJXKObRj.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Unmooring_a8GtSVHtRJXKObRj.json
@@ -48,7 +48,7 @@
           "_id": "R9zctOREjtLxuFoJ",
           "damage": {
             "tier1": {
-              "value": "5 + @chr",
+              "value": "3 + @chr",
               "types": [],
               "properties": [],
               "potency": {
@@ -57,7 +57,7 @@
               }
             },
             "tier2": {
-              "value": "8 + @chr",
+              "value": "6 + @chr",
               "types": [],
               "properties": [],
               "potency": {
@@ -66,7 +66,7 @@
               }
             },
             "tier3": {
-              "value": "11 + @chr",
+              "value": "9 + @chr",
               "types": [],
               "properties": [],
               "potency": {
@@ -80,7 +80,7 @@
     },
     "effect": {
       "before": "",
-      "after": "<p><strong>Effect:</strong> Until the end of the target’s next turn, any forced movement that affects the target has its distance increased by 2.</p>"
+      "after": "<p>Until the end of the target’s next turn, any forced movement that affects the target has its distance increased by 2.</p>"
     },
     "spend": {
       "text": "",


### PR DESCRIPTION
Damage and range values of signature abilities include the kit's damage and range bonuses and the system adds those automatically. 
So they were added twice. 

I've adjusted the signature base values so that they're correct after the system adds the kit bonuses. 


Details in #792 