### PR TITLE
16 remaining kits & kit abilities

### DIFF
--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Battle_Grace_aj6ZWyqY9cqpdpyV.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Battle_Grace_aj6ZWyqY9cqpdpyV.json
@@ -57,12 +57,12 @@
             }
           }
         },
-        "MtvQXRMrO2CgPem0": {
-          "name": "",
+        "FDbgYX6exoXLTkNR": {
+          "name": "Other",
           "img": null,
-          "type": "applied",
-          "_id": "MtvQXRMrO2CgPem0",
-          "applied": {
+          "type": "other",
+          "_id": "FDbgYX6exoXLTkNR",
+          "other": {
             "tier2": {
               "display": "you can swap places with the target"
             },

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Battle_Grace_aj6ZWyqY9cqpdpyV.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Battle_Grace_aj6ZWyqY9cqpdpyV.json
@@ -6,9 +6,9 @@
   "img": "icons/weapons/fist/fist-knuckles-brass.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "battle-grace",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Battle_Grace_aj6ZWyqY9cqpdpyV.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Battle_Grace_aj6ZWyqY9cqpdpyV.json
@@ -1,0 +1,104 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Battle Grace",
+  "type": "ability",
+  "_id": "aj6ZWyqY9cqpdpyV",
+  "img": "icons/weapons/fist/fist-knuckles-brass.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "battle-grace",
+    "story": "You feint to move your enemies into perfect position.",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "EOsCDcdiELdqs420": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "EOsCDcdiELdqs420",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "9 + @chr"
+            }
+          }
+        },
+        "MtvQXRMrO2CgPem0": {
+          "name": "",
+          "img": null,
+          "type": "applied",
+          "_id": "MtvQXRMrO2CgPem0",
+          "applied": {
+            "tier2": {
+              "display": "you can swap places with the target"
+            },
+            "tier3": {
+              "display": "you can swap places with the target"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>If you obtain a tier 2 or tier 3 outcome and can’t swap places with the target because one or both of you is too big to fit into the swapped space, you both remain in your original spaces and the target takes 1 extra damage</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754361020219,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!aj6ZWyqY9cqpdpyV"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Devastating_Rush_qenjWplO46ZaPjdb.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Devastating_Rush_qenjWplO46ZaPjdb.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/movement/figure-running-gray.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "devastating-rush",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Devastating_Rush_qenjWplO46ZaPjdb.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Devastating_Rush_qenjWplO46ZaPjdb.json
@@ -1,0 +1,90 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Devastating Rush",
+  "type": "ability",
+  "_id": "qenjWplO46ZaPjdb",
+  "img": "icons/skills/movement/figure-running-gray.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "devastating-rush",
+    "story": "The faster you move, the harder you hit",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "pBG5yZ7NwCPyN8zp": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "pBG5yZ7NwCPyN8zp",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "9 + @chr"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>You can move up to 3 squares straight toward the target before this strike, which deals extra damage equal to the number of squares you move this way</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754421457163,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!qenjWplO46ZaPjdb"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Double_Strike_WObnlBIDDMWoNhVn.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Double_Strike_WObnlBIDDMWoNhVn.json
@@ -4,9 +4,9 @@
   "img": "icons/skills/melee/swords-parry-block-blue.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "double-strike",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Exploding_Arrow_efaX6kreuPliD9Fd.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Exploding_Arrow_efaX6kreuPliD9Fd.json
@@ -4,9 +4,9 @@
   "img": "icons/skills/ranged/arrows-flying-salvo-yellow.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "219",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "exploding-arrow",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Extension_of_My_Arm_CFbMg5w74VW3nvGM.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Extension_of_My_Arm_CFbMg5w74VW3nvGM.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/melee/strike-flail-spiked-red.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "224",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "extension-of-my-arm",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Extension_of_My_Arm_CFbMg5w74VW3nvGM.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Extension_of_My_Arm_CFbMg5w74VW3nvGM.json
@@ -1,0 +1,124 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Extension of My Arm",
+  "type": "ability",
+  "_id": "CFbMg5w74VW3nvGM",
+  "img": "icons/skills/melee/strike-flail-spiked-red.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "extension-of-my-arm",
+    "story": "When you draw your whip back after an attack, your enemy is drawn ever closer",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 2
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "ilwvOSeCikrmqdXn": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "ilwvOSeCikrmqdXn",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "9 + @chr"
+            }
+          }
+        },
+        "xUFQM2onRFudgQye": {
+          "name": "Pull",
+          "img": null,
+          "type": "forced",
+          "_id": "xUFQM2onRFudgQye",
+          "forced": {
+            "tier1": {
+              "movement": [
+                "pull"
+              ],
+              "properties": [
+                "vertical"
+              ]
+            },
+            "tier2": {
+              "movement": [
+                "pull"
+              ],
+              "properties": [
+                "vertical"
+              ],
+              "distance": "2"
+            },
+            "tier3": {
+              "movement": [
+                "pull"
+              ],
+              "distance": "3",
+              "properties": [
+                "vertical"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754449048284,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!CFbMg5w74VW3nvGM"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fade_ZWx0BbPE3GitPTXJ.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fade_ZWx0BbPE3GitPTXJ.json
@@ -4,9 +4,9 @@
   "img": "icons/skills/melee/maneuver-sword-katana-yellow.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "219",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "fade",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fancy_Footwork_71TsqYgxWvTBBTZt.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fancy_Footwork_71TsqYgxWvTBBTZt.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/movement/feet-winged-boots-brown.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "fancy-footwork",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fancy_Footwork_71TsqYgxWvTBBTZt.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fancy_Footwork_71TsqYgxWvTBBTZt.json
@@ -67,6 +67,9 @@
               "display": "",
               "movement": []
             },
+            "tier2": {
+              "distance": "1"
+            },
             "tier3": {
               "distance": "2"
             }

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fancy_Footwork_71TsqYgxWvTBBTZt.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Fancy_Footwork_71TsqYgxWvTBBTZt.json
@@ -1,0 +1,105 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Fancy Footwork",
+  "type": "ability",
+  "_id": "71TsqYgxWvTBBTZt",
+  "img": "icons/skills/movement/feet-winged-boots-brown.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "fancy-footwork",
+    "story": "All combat is a dance—and you’ll be the one leading",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "gW8ZNLQSQFBThmaK": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "gW8ZNLQSQFBThmaK",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "5 + @chr"
+            },
+            "tier3": {
+              "value": "8 + @chr"
+            }
+          }
+        },
+        "5zi5cT6uxGbRH4KZ": {
+          "name": "Push",
+          "img": null,
+          "type": "forced",
+          "_id": "5zi5cT6uxGbRH4KZ",
+          "forced": {
+            "tier1": {
+              "display": "",
+              "movement": []
+            },
+            "tier3": {
+              "distance": "2"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>You can shift into any square the target leaves after you push them</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754448245155,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!71TsqYgxWvTBBTZt"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Forward_Thrust__Backward_Smash_W7dUzE5qItPz4iuR.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Forward_Thrust__Backward_Smash_W7dUzE5qItPz4iuR.json
@@ -1,0 +1,90 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Forward Thrust, Backward Smash",
+  "type": "ability",
+  "_id": "W7dUzE5qItPz4iuR",
+  "img": "icons/weapons/polearms/pike-flared-brown.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "forward-thrust-backward-smash",
+    "story": "In your hands, the haft is as good as the head.",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 2
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "XYdBmDoFCI4wJVqa": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "XYdBmDoFCI4wJVqa",
+          "damage": {
+            "tier1": {
+              "value": "2"
+            },
+            "tier2": {
+              "value": "5"
+            },
+            "tier3": {
+              "value": "7"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754359934045,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!W7dUzE5qItPz4iuR"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Forward_Thrust__Backward_Smash_W7dUzE5qItPz4iuR.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Forward_Thrust__Backward_Smash_W7dUzE5qItPz4iuR.json
@@ -6,9 +6,9 @@
   "img": "icons/weapons/polearms/pike-flared-brown.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "forward-thrust-backward-smash",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Hamstring_Shot_gnF2ThmDpSNTnjhE.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Hamstring_Shot_gnF2ThmDpSNTnjhE.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/wounds/bone-broken-knee-beam.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "hamstring-shot",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Hamstring_Shot_gnF2ThmDpSNTnjhE.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Hamstring_Shot_gnF2ThmDpSNTnjhE.json
@@ -1,0 +1,125 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Hamstring Shot",
+  "type": "ability",
+  "_id": "gnF2ThmDpSNTnjhE",
+  "img": "icons/skills/wounds/bone-broken-knee-beam.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "hamstring-shot",
+    "story": "A well-placed shot leaves your enemy struggling to move",
+    "keywords": [
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "dz26cT1hJwbDuWg1": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "dz26cT1hJwbDuWg1",
+          "damage": {
+            "tier2": {
+              "value": "4 + @chr"
+            },
+            "tier3": {
+              "value": "6 + @chr"
+            }
+          }
+        },
+        "NsGLHSzmKm8kX34F": {
+          "name": "Slow",
+          "img": null,
+          "type": "applied",
+          "_id": "NsGLHSzmKm8kX34F",
+          "applied": {
+            "tier3": {
+              "display": "{{potency}}, slowed (save ends)",
+              "effects": {
+                "slowed": {
+                  "condition": "failure",
+                  "end": "save"
+                }
+              }
+            },
+            "tier1": {
+              "effects": {
+                "slowed": {
+                  "condition": "failure",
+                  "end": "save"
+                }
+              },
+              "display": "{{potency}}, slowed (save ends)",
+              "potency": {
+                "characteristic": "agility"
+              }
+            },
+            "tier2": {
+              "effects": {
+                "slowed": {
+                  "condition": "failure",
+                  "end": "save"
+                }
+              },
+              "display": "{{potency}}, slowed (save ends)"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754424173898,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!gnF2ThmDpSNTnjhE"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Leaping_Lightning_itkIo48j0JRCukWY.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Leaping_Lightning_itkIo48j0JRCukWY.json
@@ -1,0 +1,102 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Leaping Lightning",
+  "type": "ability",
+  "_id": "itkIo48j0JRCukWY",
+  "img": "icons/magic/lightning/bolt-forked-blue.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "leaping-lightning",
+    "story": "Lightning jumps from your weapon as you strike to harm a nearby foe",
+    "keywords": [
+      "magic",
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "reason",
+          "intuition",
+          "presence"
+        ]
+      },
+      "effects": {
+        "bbvohMHUYj4INoSH": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "bbvohMHUYj4INoSH",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr",
+              "types": [
+                "lightning"
+              ]
+            },
+            "tier2": {
+              "value": "6 + @chr",
+              "types": [
+                "lightning"
+              ]
+            },
+            "tier3": {
+              "value": "9 + @chr",
+              "types": [
+                "lightning"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>A creature or object of your choice within 2 squares of the target takes lightning damage equal to the characteristic score used for this ability’s power roll.</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754446726107,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!itkIo48j0JRCukWY"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Leaping_Lightning_itkIo48j0JRCukWY.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Leaping_Lightning_itkIo48j0JRCukWY.json
@@ -6,9 +6,9 @@
   "img": "icons/magic/lightning/bolt-forked-blue.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "leaping-lightning",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Leaping_Lightning_itkIo48j0JRCukWY.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Leaping_Lightning_itkIo48j0JRCukWY.json
@@ -73,7 +73,7 @@
     },
     "effect": {
       "before": "",
-      "after": "<p>A creature or object of your choice within 2 squares of the target takes lightning damage equal to the characteristic score used for this ability’s power roll.</p>"
+      "after": "<p>A creature or object of your choice within 2 squares of the target takes lightning damage equal to the characteristic score used for this ability’s power roll ([[/damage @chr]]).</p>"
     },
     "spend": {
       "text": "",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Let_s_Dance_ivplHkJEvRq8fr4U.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Let_s_Dance_ivplHkJEvRq8fr4U.json
@@ -1,0 +1,111 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Let’s Dance",
+  "type": "ability",
+  "_id": "ivplHkJEvRq8fr4U",
+  "img": "icons/skills/melee/unarmed-punch-fist.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "lets-dance",
+    "story": "Keeping your enemies stumbling around the battlefield is second",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "NzzDSnmolUMymVmp": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "NzzDSnmolUMymVmp",
+          "damage": {
+            "tier2": {
+              "value": "5 + @chr"
+            },
+            "tier3": {
+              "value": "7 + @chr"
+            }
+          }
+        },
+        "cEReIDIpRHcBkKxV": {
+          "name": "Slide",
+          "img": null,
+          "type": "forced",
+          "_id": "cEReIDIpRHcBkKxV",
+          "forced": {
+            "tier1": {
+              "movement": [],
+              "distance": "",
+              "display": ""
+            },
+            "tier2": {
+              "movement": [
+                "slide"
+              ]
+            },
+            "tier3": {
+              "movement": [
+                "slide"
+              ],
+              "distance": "2"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>You can shift into any square the target leaves after you slide them</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754421683845,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!ivplHkJEvRq8fr4U"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Let_s_Dance_ivplHkJEvRq8fr4U.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Let_s_Dance_ivplHkJEvRq8fr4U.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/melee/unarmed-punch-fist.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "lets-dance",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Net_and_Stab_wTEHcR8iEyJfvQZO.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Net_and_Stab_wTEHcR8iEyJfvQZO.json
@@ -6,9 +6,9 @@
   "img": "icons/weapons/polearms/trident-curved-steel.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "222",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "net-and-stab",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Net_and_Stab_wTEHcR8iEyJfvQZO.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Net_and_Stab_wTEHcR8iEyJfvQZO.json
@@ -1,0 +1,200 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Net and Stab",
+  "type": "ability",
+  "_id": "wTEHcR8iEyJfvQZO",
+  "img": "icons/weapons/polearms/trident-curved-steel.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "net-and-stab",
+    "story": "The well-thrown net that follows your main attack leaves your foes right where you want them",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "aqW1nVMW5g1RJJHL": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "aqW1nVMW5g1RJJHL",
+          "damage": {
+            "tier2": {
+              "value": "4 + @chr"
+            },
+            "tier3": {
+              "value": "6 + @chr"
+            }
+          }
+        },
+        "di2TGvRsz8cxCrNN": {
+          "name": "Slow",
+          "img": null,
+          "type": "applied",
+          "_id": "di2TGvRsz8cxCrNN",
+          "applied": {
+            "tier1": {
+              "display": "{{potency}} slowed (EoT)",
+              "potency": {
+                "characteristic": "agility"
+              },
+              "effects": {
+                "slowed": {
+                  "condition": "failure",
+                  "end": "turn"
+                }
+              }
+            },
+            "tier2": {
+              "display": "{{potency}} slowed (EoT)",
+              "effects": {
+                "slowed": {
+                  "condition": "failure",
+                  "end": "turn"
+                }
+              }
+            },
+            "tier3": {
+              "display": "{{potency}} restrained (EoT)",
+              "effects": {
+                "restrained": {
+                  "condition": "failure",
+                  "end": "turn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Active Effect",
+      "img": "icons/weapons/polearms/trident-curved-steel.webp",
+      "transfer": false,
+      "_id": "D4eVIzGhCktg9FFC",
+      "type": "base",
+      "system": {
+        "end": {
+          "type": "",
+          "roll": "1d10 + @combat.save.bonus"
+        }
+      },
+      "changes": [],
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754490436158,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      },
+      "_key": "!items.effects!wTEHcR8iEyJfvQZO.D4eVIzGhCktg9FFC"
+    },
+    {
+      "name": "Active Effect (2)",
+      "img": "icons/weapons/polearms/trident-curved-steel.webp",
+      "transfer": false,
+      "_id": "LwWvPSPpUnGylCSG",
+      "type": "base",
+      "system": {
+        "end": {
+          "type": "",
+          "roll": "1d10 + @combat.save.bonus"
+        }
+      },
+      "changes": [],
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "createdTime": 1754490440469,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      },
+      "_key": "!items.effects!wTEHcR8iEyJfvQZO.LwWvPSPpUnGylCSG"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754426474462,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!wTEHcR8iEyJfvQZO"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Net_and_Stab_wTEHcR8iEyJfvQZO.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Net_and_Stab_wTEHcR8iEyJfvQZO.json
@@ -93,14 +93,6 @@
           }
         }
       }
-    },
-    "effect": {
-      "before": "",
-      "after": ""
-    },
-    "spend": {
-      "text": "",
-      "value": null
     }
   },
   "effects": [

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Pain_for_Pain_5f12S6WJGYTV3oK5.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Pain_for_Pain_5f12S6WJGYTV3oK5.json
@@ -6,9 +6,9 @@
   "img": "icons/weapons/swords/greatsword-crossguard-barbed.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "pain-for-pain",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Pain_for_Pain_5f12S6WJGYTV3oK5.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Pain_for_Pain_5f12S6WJGYTV3oK5.json
@@ -1,0 +1,90 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Pain for Pain",
+  "type": "ability",
+  "_id": "5f12S6WJGYTV3oK5",
+  "img": "icons/weapons/swords/greatsword-crossguard-barbed.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "pain-for-pain",
+    "story": "An enemy who tagged you will pay for that",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "2puO1Aom4997HRC7": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "2puO1Aom4997HRC7",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "5 + @chr"
+            },
+            "tier3": {
+              "value": "9 + @chr"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>If the target dealt damage to you since the end of your last turn, this strike deals additional damage equal to your Might or Agility score (your choice)</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754421165095,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!5f12S6WJGYTV3oK5"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Patient_Shot_0GI2L1gzkcXTPogJ.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Patient_Shot_0GI2L1gzkcXTPogJ.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/targeting/crosshair-ringed-gray.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "patient-shot",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Patient_Shot_0GI2L1gzkcXTPogJ.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Patient_Shot_0GI2L1gzkcXTPogJ.json
@@ -1,0 +1,90 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Patient Shot",
+  "type": "ability",
+  "_id": "0GI2L1gzkcXTPogJ",
+  "img": "icons/skills/targeting/crosshair-ringed-gray.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "patient-shot",
+    "story": "Breathe … aim … wait … then strike!",
+    "keywords": [
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "55HqeGKbIGS3d8ln": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "55HqeGKbIGS3d8ln",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "9 + @chr"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>If you don’t take a move action this turn, this strike deals extra damage equal to your Might or Agility score (your choice)</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754427079650,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!0GI2L1gzkcXTPogJ"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Protective_Attack_3G70A9bFAJzp7nxD.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Protective_Attack_3G70A9bFAJzp7nxD.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/melee/shield-block-gray-orange.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "222",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "protective-attack",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shield_Bash_qmoH5kdmy0Quwirq.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shield_Bash_qmoH5kdmy0Quwirq.json
@@ -1,0 +1,123 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Shield Bash",
+  "type": "ability",
+  "_id": "qmoH5kdmy0Quwirq",
+  "img": "icons/skills/melee/shield-block-bash-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "shield-bash",
+    "story": "In your hands, a shield isn’t just for protection",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "fptrZEJxl0ZFrbCt": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "fptrZEJxl0ZFrbCt",
+          "damage": {
+            "tier2": {
+              "value": "5 + @chr"
+            },
+            "tier3": {
+              "value": "7 + @chr"
+            }
+          }
+        },
+        "eb1HaQwUBIp8OUaa": {
+          "name": "Push",
+          "img": null,
+          "type": "forced",
+          "_id": "eb1HaQwUBIp8OUaa",
+          "forced": {
+            "tier2": {
+              "distance": "2"
+            },
+            "tier3": {
+              "distance": "3"
+            }
+          }
+        },
+        "CZ3vpjVexOB52bBq": {
+          "name": "prone",
+          "img": null,
+          "type": "applied",
+          "_id": "CZ3vpjVexOB52bBq",
+          "applied": {
+            "tier1": {
+              "display": "",
+              "potency": {
+                "characteristic": "might"
+              }
+            },
+            "tier3": {
+              "display": "{{potency}}, prone",
+              "effects": {
+                "prone": {
+                  "condition": "failure"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754448564410,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!qmoH5kdmy0Quwirq"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shield_Bash_qmoH5kdmy0Quwirq.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shield_Bash_qmoH5kdmy0Quwirq.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/melee/shield-block-bash-yellow.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "224",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shield-bash",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shock_and_Awe_9qEPqlWu8YaKeYl7.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shock_and_Awe_9qEPqlWu8YaKeYl7.json
@@ -1,0 +1,89 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Shock and Awe",
+  "type": "ability",
+  "_id": "9qEPqlWu8YaKeYl7",
+  "img": "icons/skills/ranged/arrow-flying-gray-brown.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "shock-and-awe",
+    "story": "You execute a brutal strike that leaves your foe reeling",
+    "keywords": [
+      "melee",
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": 1,
+      "secondary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "OlwlVM5uitUAcIrg": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "OlwlVM5uitUAcIrg",
+          "damage": {
+            "tier2": {
+              "value": "5 + @chr"
+            },
+            "tier3": {
+              "value": "7 + @chr"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>The target takes a bane on their next power roll made before the end of their next turn</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754422026019,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!9qEPqlWu8YaKeYl7"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shock_and_Awe_9qEPqlWu8YaKeYl7.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Shock_and_Awe_9qEPqlWu8YaKeYl7.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/ranged/arrow-flying-gray-brown.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shock-and-awe",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Two_Shot_Sl7RrvSQ3idV8Dok.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Two_Shot_Sl7RrvSQ3idV8Dok.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/targeting/target-strike-triple-blue.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "222",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "two-shot",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Two_Shot_Sl7RrvSQ3idV8Dok.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Two_Shot_Sl7RrvSQ3idV8Dok.json
@@ -1,0 +1,90 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Two Shot",
+  "type": "ability",
+  "_id": "Sl7RrvSQ3idV8Dok",
+  "img": "icons/skills/targeting/target-strike-triple-blue.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "two-shot",
+    "story": "When you fire two arrows back-to-back, both hit their mark.",
+    "keywords": [
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 2
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "EPqGAwi2gWRjoJg1": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "EPqGAwi2gWRjoJg1",
+          "damage": {
+            "tier1": {
+              "value": "2"
+            },
+            "tier2": {
+              "value": "4"
+            },
+            "tier3": {
+              "value": "6"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754426300755,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!Sl7RrvSQ3idV8Dok"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Unmooring_a8GtSVHtRJXKObRj.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Unmooring_a8GtSVHtRJXKObRj.json
@@ -4,9 +4,9 @@
   "img": "icons/skills/melee/sword-engraved-glow-purple.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "219",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "unmooring",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Weakening_Brand_UxnX9shM9QMWvfpw.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Weakening_Brand_UxnX9shM9QMWvfpw.json
@@ -1,0 +1,101 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Weakening Brand",
+  "type": "ability",
+  "_id": "UxnX9shM9QMWvfpw",
+  "img": "icons/magic/light/projectile-bolts-salvo-white.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "weakening-brand",
+    "story": "The impact of your weapon brands your target for destruction",
+    "keywords": [
+      "magic",
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "reason",
+          "intuition",
+          "presence"
+        ]
+      },
+      "effects": {
+        "hJLolFQAfc1LnHfs": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "hJLolFQAfc1LnHfs",
+          "damage": {
+            "tier1": {
+              "types": [
+                "holy"
+              ]
+            },
+            "tier2": {
+              "value": "4 + @chr",
+              "types": [
+                "holy"
+              ]
+            },
+            "tier3": {
+              "value": "7 + @chr",
+              "types": [
+                "holy"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": "<p>Until the end of the target’s next turn, they have damage weakness equal to the characteristic score used for this ability’s power roll.</p>"
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754448837387,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!UxnX9shM9QMWvfpw"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Weakening_Brand_UxnX9shM9QMWvfpw.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Weakening_Brand_UxnX9shM9QMWvfpw.json
@@ -6,9 +6,9 @@
   "img": "icons/magic/light/projectile-bolts-salvo-white.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "224",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "weakening-brand",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Where_I_Want_You_B2ETWXdsU4mVFQFj.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Where_I_Want_You_B2ETWXdsU4mVFQFj.json
@@ -1,0 +1,116 @@
+{
+  "folder": "9MmUCFDVEUEgDY04",
+  "name": "Where I Want You",
+  "type": "ability",
+  "_id": "B2ETWXdsU4mVFQFj",
+  "img": "icons/skills/melee/hand-grip-staff-blue.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "where-i-want-you",
+    "story": "When your stick speaks, your enemy moves",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility"
+        ]
+      },
+      "effects": {
+        "PxwKGnzuksIepy2Q": {
+          "name": "Damage",
+          "img": null,
+          "type": "damage",
+          "_id": "PxwKGnzuksIepy2Q",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "9 + @chr"
+            }
+          }
+        },
+        "oi2TIspf4TtGMD2I": {
+          "name": "Slide",
+          "img": null,
+          "type": "forced",
+          "_id": "oi2TIspf4TtGMD2I",
+          "forced": {
+            "tier1": {
+              "movement": [
+                "push",
+                "slide"
+              ],
+              "display": ""
+            },
+            "tier2": {
+              "movement": [
+                "slide"
+              ]
+            },
+            "tier3": {
+              "movement": [
+                "slide"
+              ],
+              "distance": "3"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754449851888,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!B2ETWXdsU4mVFQFj"
+}

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Where_I_Want_You_B2ETWXdsU4mVFQFj.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Where_I_Want_You_B2ETWXdsU4mVFQFj.json
@@ -6,9 +6,9 @@
   "img": "icons/skills/melee/hand-grip-staff-blue.webp",
   "system": {
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "where-i-want-you",

--- a/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Where_I_Want_You_B2ETWXdsU4mVFQFj.json
+++ b/src/packs/abilities/Kits_9MmUCFDVEUEgDY04/ability_Where_I_Want_You_B2ETWXdsU4mVFQFj.json
@@ -64,16 +64,14 @@
           "_id": "oi2TIspf4TtGMD2I",
           "forced": {
             "tier1": {
-              "movement": [
-                "push",
-                "slide"
-              ],
+              "movement": [],
               "display": ""
             },
             "tier2": {
               "movement": [
                 "slide"
-              ]
+              ],
+              "distance": "1"
             },
             "tier3": {
               "movement": [

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Arcane_Archer_DfUznZyAwRkgQ7Cq.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Arcane_Archer_DfUznZyAwRkgQ7Cq.json
@@ -8,9 +8,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "219",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shining-armor",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Battlemind_dFKiwPs0hVo7uWei.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Battlemind_dFKiwPs0hVo7uWei.json
@@ -8,9 +8,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "219",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shining-armor",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Cloak_and_Dagger_eQsxbl59pEjHEyB7.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Cloak_and_Dagger_eQsxbl59pEjHEyB7.json
@@ -8,9 +8,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "219",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shining-armor",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Dual_Wielder_26dSN2U5BPYxURBl.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Dual_Wielder_26dSN2U5BPYxURBl.json
@@ -8,9 +8,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shining-armor",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Guisarmier_ZQVco8CZprfeqPp6.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Guisarmier_ZQVco8CZprfeqPp6.json
@@ -1,0 +1,84 @@
+{
+  "name": "Guisarmier",
+  "type": "kit",
+  "_id": "ZQVco8CZprfeqPp6",
+  "img": "icons/weapons/polearms/glaive-hooked-steel.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Guisarmier kit is for those who want to use a polearm for extended reach while remaining protected by sturdy armor. This is the kit that allows you to become the ultimate halberd, longspear, or glaive fighter</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "guisarmier",
+    "advancements": {
+      "aHhGfXEKyJmxXQIL": {
+        "name": "Forward Thrust, Backward Smash",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "aHhGfXEKyJmxXQIL",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.W7dUzE5qItPz4iuR"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "medium",
+      "weapon": [
+        "polearm"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": 1
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 6,
+      "speed": null,
+      "stability": 1,
+      "disengage": null
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754359241535,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!ZQVco8CZprfeqPp6"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Guisarmier_ZQVco8CZprfeqPp6.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Guisarmier_ZQVco8CZprfeqPp6.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "guisarmier",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Martial_Artist_49hPWhEliTnRbuxT.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Martial_Artist_49hPWhEliTnRbuxT.json
@@ -1,0 +1,84 @@
+{
+  "name": "Martial Artist",
+  "type": "kit",
+  "_id": "49hPWhEliTnRbuxT",
+  "img": "icons/weapons/fist/fist-knuckles-brass.webp",
+  "system": {
+    "description": {
+      "value": "<p>If you want to be fast in a fight, then Martial Artist is the kit for you. Unencumbered by weapons or armor, this fighting style rewards quick, focused unarmed strikes against opponents, and allows you to be the ultimate skirmisher</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "martial-artist",
+    "advancements": {
+      "ogb8TY2zm3XIeZax": {
+        "name": "Battle Grace",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "ogb8TY2zm3XIeZax",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.aj6ZWyqY9cqpdpyV"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "none",
+      "weapon": [
+        "unarmed"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 3,
+      "speed": 3,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754361896620,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!49hPWhEliTnRbuxT"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Martial_Artist_49hPWhEliTnRbuxT.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Martial_Artist_49hPWhEliTnRbuxT.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "martial-artist",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Mountain_x41mBdtcCGTj8Quy.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Mountain_x41mBdtcCGTj8Quy.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "220",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "mountain",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Mountain_x41mBdtcCGTj8Quy.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Mountain_x41mBdtcCGTj8Quy.json
@@ -1,0 +1,84 @@
+{
+  "name": "Mountain",
+  "type": "kit",
+  "_id": "x41mBdtcCGTj8Quy",
+  "img": "icons/equipment/chest/breastplate-layered-steel-blue-gold.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Mountain kit does exactly what it says on the tin. You don heavy armor and raise a heavy weapon to stand strong against your foes, quickly demolishing them when it’s your turn to strike.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "mountain",
+    "advancements": {
+      "Os5pFYJG6bJ6umB8": {
+        "name": "Pain for Pain",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "Os5pFYJG6bJ6umB8",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.5f12S6WJGYTV3oK5"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "heavy",
+      "weapon": [
+        "heavy"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 4
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 9,
+      "speed": null,
+      "stability": 2,
+      "disengage": null
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362081556,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!x41mBdtcCGTj8Quy"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Panther_jHJnlHyRRNf9V5hm.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Panther_jHJnlHyRRNf9V5hm.json
@@ -1,0 +1,84 @@
+{
+  "name": "Panther",
+  "type": "kit",
+  "_id": "jHJnlHyRRNf9V5hm",
+  "img": "icons/weapons/hammers/hammer-double-engraved-ruby.webp",
+  "system": {
+    "description": {
+      "value": "<p>If you want a good balance of protection, speed, and damage, the Panther kit is for you. This kit increases your Stamina not by wearing armor, but through the focused battle preparation of body and mind, letting you be fast and mobile while swinging a heavy weapon at your foes</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "panther",
+    "advancements": {
+      "iCOS98pyguCqGwty": {
+        "name": "Devastating Rush",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "iCOS98pyguCqGwty",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.qenjWplO46ZaPjdb"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "none",
+      "weapon": [
+        "heavy"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 4
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 6,
+      "speed": 1,
+      "stability": 1,
+      "disengage": null
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362179505,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!jHJnlHyRRNf9V5hm"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Panther_jHJnlHyRRNf9V5hm.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Panther_jHJnlHyRRNf9V5hm.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "panther",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Pugilist_uEExxUnkmJ1whpCz.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Pugilist_uEExxUnkmJ1whpCz.json
@@ -1,0 +1,84 @@
+{
+  "name": "Pugilist",
+  "type": "kit",
+  "_id": "uEExxUnkmJ1whpCz",
+  "img": "icons/weapons/fist/fist-knuckles-stone.webp",
+  "system": {
+    "description": {
+      "value": "<p>Meant for brawlers and boxers, the Pugilist kit gives you access to a melee fighting style that grants a boost to Stamina and damage while allowing you to float like a butterfly. If you want to be a tough, strong hero who doles out punishment with your fists, then this kit is for you.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "pugilist",
+    "advancements": {
+      "z1CMvkZlfCyEOh1Y": {
+        "name": "Let's Dance",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "z1CMvkZlfCyEOh1Y",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.ivplHkJEvRq8fr4U"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "none",
+      "weapon": [
+        "unarmed"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 6,
+      "speed": 2,
+      "stability": 1,
+      "disengage": null
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362608255,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!uEExxUnkmJ1whpCz"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Pugilist_uEExxUnkmJ1whpCz.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Pugilist_uEExxUnkmJ1whpCz.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "pugilist",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Raider_jBAKshrCTStqX7yI.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Raider_jBAKshrCTStqX7yI.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "raider",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Raider_jBAKshrCTStqX7yI.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Raider_jBAKshrCTStqX7yI.json
@@ -1,0 +1,84 @@
+{
+  "name": "Raider",
+  "type": "kit",
+  "_id": "jBAKshrCTStqX7yI",
+  "img": "icons/weapons/swords/shortsword-guard-steel-worn.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Raider kit keeps you protected while granting you full mobility, providing a boost to speed and distance that lets you run around the battlefield like a Viking warrior.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "raider",
+    "advancements": {
+      "MnyFftZXJ6tA47bc": {
+        "name": "Shock and Awe",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "MnyFftZXJ6tA47bc",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.9qEPqlWu8YaKeYl7"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "light",
+      "weapon": [
+        "light"
+      ],
+      "shield": true
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": 5
+      },
+      "stamina": 6,
+      "speed": 1,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362714511,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!jBAKshrCTStqX7yI"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Ranger_IWcztYRBrAMdRQyf.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Ranger_IWcztYRBrAMdRQyf.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "221",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "ranger",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Ranger_IWcztYRBrAMdRQyf.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Ranger_IWcztYRBrAMdRQyf.json
@@ -1,0 +1,85 @@
+{
+  "name": "Ranger",
+  "type": "kit",
+  "_id": "IWcztYRBrAMdRQyf",
+  "img": "icons/weapons/bows/bow-ornamental-silver-black.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Ranger kit outfits you with light armor and weapons for every challenge, letting you easily switch between melee and ranged combat. This kit provides a good balance of bonuses to defense and offense to create a hero who is a jack-of-all-trades.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "ranger",
+    "advancements": {
+      "1gjFknWi9Pf8rjv1": {
+        "name": "Hamstring Shot",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "1gjFknWi9Pf8rjv1",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.gnF2ThmDpSNTnjhE"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "medium",
+      "weapon": [
+        "bow",
+        "medium"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": 5
+      },
+      "stamina": 6,
+      "speed": 1,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362822405,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!IWcztYRBrAMdRQyf"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Rapid_Fire_tfBbJyfk0ARRiPJU.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Rapid_Fire_tfBbJyfk0ARRiPJU.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "222",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "rapid-fire",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Rapid_Fire_tfBbJyfk0ARRiPJU.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Rapid_Fire_tfBbJyfk0ARRiPJU.json
@@ -1,0 +1,84 @@
+{
+  "name": "Rapid-Fire",
+  "type": "kit",
+  "_id": "tfBbJyfk0ARRiPJU",
+  "img": "icons/weapons/ammunition/arrows-fletching.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Rapid-Fire kit is for archers who want to deal maximum damage by shooting as many arrows as possible into nearby enemies. With this kit, your fighting technique focuses on peppering foes before they can get close enough to counterattack.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "rapid-fire",
+    "advancements": {
+      "aVAXarbjjp2f688V": {
+        "name": "Two Shot",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "aVAXarbjjp2f688V",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.Sl7RrvSQ3idV8Dok"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "light",
+      "weapon": [
+        "bow"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": 7
+      },
+      "stamina": 3,
+      "speed": 1,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362911798,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!tfBbJyfk0ARRiPJU"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Retiarius_RhaBwqKzijzbJcCQ.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Retiarius_RhaBwqKzijzbJcCQ.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "222",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "retiarius",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Retiarius_RhaBwqKzijzbJcCQ.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Retiarius_RhaBwqKzijzbJcCQ.json
@@ -1,0 +1,85 @@
+{
+  "name": "Retiarius",
+  "type": "kit",
+  "_id": "RhaBwqKzijzbJcCQ",
+  "img": "icons/weapons/polearms/trident-silver-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>The retiarius is often depicted as a lightly armored warrior with a net in one hand and a trident in the other, and this kit gives you the equipment and fighting technique to make that happen. Tie up your foe with a net and then poke them to death!</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "retiarius",
+    "advancements": {
+      "nKuPGMbSoCrHmJFI": {
+        "name": "Net and Stab",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "nKuPGMbSoCrHmJFI",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.wTEHcR8iEyJfvQZO"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "light",
+      "weapon": [
+        "ensnaring",
+        "polearm"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": 1
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 3,
+      "speed": 1,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754362989413,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!RhaBwqKzijzbJcCQ"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Shining_Armor_JE0Q1L35MuOGLVVJ.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Shining_Armor_JE0Q1L35MuOGLVVJ.json
@@ -8,9 +8,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "222",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "shining-armor",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sniper_B07q1yyc5HSCnAf7.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sniper_B07q1yyc5HSCnAf7.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "sniper",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sniper_B07q1yyc5HSCnAf7.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sniper_B07q1yyc5HSCnAf7.json
@@ -1,0 +1,84 @@
+{
+  "name": "Sniper",
+  "type": "kit",
+  "_id": "B07q1yyc5HSCnAf7",
+  "img": "icons/weapons/bows/longbow-gold-pink.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Sniper kit gives you the tools and techniques to take down enemies from afar. This kit can help you become the archer who lurks behind trees or down tunnels, picking off enemies with a bow or crossbow as they approach.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "sniper",
+    "advancements": {
+      "KVkT9bIQMKrRC4Dz": {
+        "name": "Patient Shot",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "KVkT9bIQMKrRC4Dz",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.0GI2L1gzkcXTPogJ"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "none",
+      "weapon": [
+        "bow"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 4
+        },
+        "distance": 10
+      },
+      "stamina": null,
+      "speed": 1,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754415955479,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!B07q1yyc5HSCnAf7"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Spellsword_74X1pEcNgz1OQC2x.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Spellsword_74X1pEcNgz1OQC2x.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "spellsword",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Spellsword_74X1pEcNgz1OQC2x.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Spellsword_74X1pEcNgz1OQC2x.json
@@ -1,0 +1,84 @@
+{
+  "name": "Spellsword",
+  "type": "kit",
+  "_id": "74X1pEcNgz1OQC2x",
+  "img": "icons/weapons/swords/scimitar-guard-red.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Spellsword kit combines melee strikes and a little bit of magic, letting you create a warrior who doesn’t have to choose between the incantation and the blade.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "spellsword",
+    "advancements": {
+      "cMuMLKLvEK1jwP6h": {
+        "name": "Leaping Lightning",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "cMuMLKLvEK1jwP6h",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.itkIo48j0JRCukWY"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "light",
+      "weapon": [
+        "medium"
+      ],
+      "shield": true
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 6,
+      "speed": 1,
+      "stability": 1,
+      "disengage": 0
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754416088656,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!74X1pEcNgz1OQC2x"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Stick_and_Robe_UWjNAZn9cBAMUWB0.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Stick_and_Robe_UWjNAZn9cBAMUWB0.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "stick-and-robe",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Stick_and_Robe_UWjNAZn9cBAMUWB0.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Stick_and_Robe_UWjNAZn9cBAMUWB0.json
@@ -1,0 +1,84 @@
+{
+  "name": "Stick and Robe",
+  "type": "kit",
+  "_id": "UWjNAZn9cBAMUWB0",
+  "img": "icons/weapons/staves/staff-simple.webp",
+  "system": {
+    "description": {
+      "value": "<p>Armed with a simple reach weapon, often a quarterstaff, a character using the Stick and Robe kit is highly mobile thanks to their light armor. This allows your hero to make maximum use of their weapon’s length.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "stick-and-robe",
+    "advancements": {
+      "XqKqV15yGEOepHDC": {
+        "name": "Where I Want You",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "XqKqV15yGEOepHDC",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.B2ETWXdsU4mVFQFj"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "light",
+      "weapon": [
+        "polearm"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": 1
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 3,
+      "speed": 2,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754416234829,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!UWjNAZn9cBAMUWB0"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Swashbuckler_ZoWDIjHoCJjr1uo1.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Swashbuckler_ZoWDIjHoCJjr1uo1.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "223",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "swashbuckler",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Swashbuckler_ZoWDIjHoCJjr1uo1.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Swashbuckler_ZoWDIjHoCJjr1uo1.json
@@ -1,0 +1,84 @@
+{
+  "name": "Swashbuckler",
+  "type": "kit",
+  "_id": "ZoWDIjHoCJjr1uo1",
+  "img": "icons/weapons/swords/scimitar-broad.webp",
+  "system": {
+    "description": {
+      "value": "<p>If you want to be mobile and deal a lot of damage with melee strikes, then you should reach for the Swashbuckler kit. This is a great kit for heroes who want to be master duelists.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "swashbuckler",
+    "advancements": {
+      "izsuQtqb34q33hrk": {
+        "name": "Fancy Footwork",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "izsuQtqb34q33hrk",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.71TsqYgxWvTBBTZt"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "light",
+      "weapon": [
+        "medium"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 3,
+      "speed": 3,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754416349240,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!ZoWDIjHoCJjr1uo1"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sword_and_Board_NkzAlCFgDeGuTnzr.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sword_and_Board_NkzAlCFgDeGuTnzr.json
@@ -1,0 +1,84 @@
+{
+  "name": "Sword and Board",
+  "type": "kit",
+  "_id": "NkzAlCFgDeGuTnzr",
+  "img": "icons/equipment/shield/buckler-wooden-boss-steel.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Sword and Board kit doesn’t just give you a shield—it makes the shield part of your offensive arsenal. With a medium weapon in one hand and a block of steel or solid oak in the other, you protect yourself while you control the battlefield.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "sword-and-board",
+    "advancements": {
+      "awk6CThKdV6JXyau": {
+        "name": "Shield Bash",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "awk6CThKdV6JXyau",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.qmoH5kdmy0Quwirq"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "medium",
+      "weapon": [
+        "medium"
+      ],
+      "shield": true
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 2,
+          "tier2": 2,
+          "tier3": 2
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 9,
+      "speed": null,
+      "stability": 1,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754416458430,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!NkzAlCFgDeGuTnzr"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sword_and_Board_NkzAlCFgDeGuTnzr.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Sword_and_Board_NkzAlCFgDeGuTnzr.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "224",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "sword-and-board",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Warrior_Priest_AOCz8Nufy6kbg85v.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Warrior_Priest_AOCz8Nufy6kbg85v.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "224",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "warrior-priest",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Warrior_Priest_AOCz8Nufy6kbg85v.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Warrior_Priest_AOCz8Nufy6kbg85v.json
@@ -1,0 +1,84 @@
+{
+  "name": "Warrior Priest",
+  "type": "kit",
+  "_id": "AOCz8Nufy6kbg85v",
+  "img": "icons/equipment/back/mantle-collared-white.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Warrior Priest kit imbues the power of the gods into your weapon, making it a smiting instrument. You wade into the fray without fear, thanks to the power of the divine … and the heavy armor you wear</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "warrior-priest",
+    "advancements": {
+      "5e0dJP5RORgzcLVG": {
+        "name": "Weakening Brand",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "5e0dJP5RORgzcLVG",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.UxnX9shM9QMWvfpw"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "heavy",
+      "weapon": [
+        "light"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": null
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": 9,
+      "speed": 1,
+      "stability": 1,
+      "disengage": null
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754416584400,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!AOCz8Nufy6kbg85v"
+}

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Whirlwind_zW9eM46rG8tUhTaA.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Whirlwind_zW9eM46rG8tUhTaA.json
@@ -9,9 +9,9 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
-      "license": "",
+      "book": "Heroes",
+      "page": "224",
+      "license": "Draw Steel Creator License",
       "revision": 1
     },
     "_dsid": "whirlwind",

--- a/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Whirlwind_zW9eM46rG8tUhTaA.json
+++ b/src/packs/character-options/Kits_IHZh1CqtnYYID2QA/kit_Whirlwind_zW9eM46rG8tUhTaA.json
@@ -1,0 +1,84 @@
+{
+  "name": "Whirlwind",
+  "type": "kit",
+  "_id": "zW9eM46rG8tUhTaA",
+  "img": "icons/equipment/hand/gauntlet-tooled-leather-brown.webp",
+  "system": {
+    "description": {
+      "value": "<p>The Whirlwind kit makes effective use of whips, granting you mobility, damage, and reach. If you want to be a fast-moving warrior who lashes foes with a chain or whip, then this is the kit for you</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "",
+      "revision": 1
+    },
+    "_dsid": "whirlwind",
+    "advancements": {
+      "yObEvruqSgXSwAnW": {
+        "name": "Extension of My Arm",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": null
+        },
+        "_id": "yObEvruqSgXSwAnW",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.CFbMg5w74VW3nvGM"
+          }
+        ]
+      }
+    },
+    "equipment": {
+      "armor": "none",
+      "weapon": [
+        "whip"
+      ],
+      "shield": false
+    },
+    "bonuses": {
+      "melee": {
+        "damage": {
+          "tier1": 1,
+          "tier2": 1,
+          "tier3": 1
+        },
+        "distance": 1
+      },
+      "ranged": {
+        "damage": {
+          "tier1": 0,
+          "tier2": 0,
+          "tier3": 0
+        },
+        "distance": null
+      },
+      "stamina": null,
+      "speed": 3,
+      "stability": null,
+      "disengage": 1
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kZoV8xj0DBrnj5EN": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754416695047,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!zW9eM46rG8tUhTaA"
+}


### PR DESCRIPTION
Kits and kit abilities added for the following:
- Guisarmier
- Martial Artist
- Mountain
- Panther
- Pugilist
- Raider
- Ranger
- Rapid-Fire
- Retiarius
- Sniper
- Spellsword
- Stick and Robe
- Swashbuckler
- Sword and Board
- Warrior Priest
- Whirlwind
