### PR TITLE
Sudoku touchups

### DIFF
--- a/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
@@ -101,6 +101,7 @@ export default class PowerRollEffectSheet extends PseudoDocumentSheet {
       const effect = await ActiveEffect.implementation.create({
         name: ActiveEffect.implementation.defaultName({ parent: item }),
         img: item.img,
+        origin: item.uuid,
         transfer: false,
       }, { parent: item });
 

--- a/src/module/data/item/class.mjs
+++ b/src/module/data/item/class.mjs
@@ -83,6 +83,7 @@ export default class ClassModel extends AdvancementModel {
 
   /** @inheritdoc */
   prepareDerivedData() {
+    super.prepareDerivedData();
     if (this.actor) {
       this.actor.system.recoveries.max = this.recoveries;
       this.actor.system.stamina.max += this.stamina.starting + (this.level - 1) * this.stamina.level;

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -56,6 +56,20 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+    // Item grants that are only granting a single item should have a matching icon
+    const hasDefaultImage = (this.img === ds.CONFIG.Advancement.itemGrant.defaultImage);
+    const hasOneGrant = (this.pool.length === 1);
+    if (hasDefaultImage & hasOneGrant) {
+      const indexEntry = fromUuidSync(this.pool[0].uuid);
+      this.img = indexEntry.img;
+    }
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Recursive method to find all items that were added to an actor by this advancement.
    * If the item is unowned, this returns `null`.

--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -49,6 +49,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
 
   /** @inheritdoc */
   prepareBaseData() {
+    super.prepareBaseData();
     this.img ||= ds.CONFIG[this.constructor.metadata.documentName][this.type].defaultImage;
   }
 

--- a/templates/sheets/item/effects.hbs
+++ b/templates/sheets/item/effects.hbs
@@ -16,7 +16,7 @@
             class="effect-control"
             data-action="createDoc"
             data-origin="{{@root.document.uuid}}"
-            data-img="icons/svg/aura.svg"
+            data-img="{{@root.document.img}}"
             {{#if (eq section.type "inactive")}}
             data-disabled="true"
             {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}


### PR DESCRIPTION
Some small touch ups to sudokus that came to my mind
- Item grants with a single item should default to that item's icon. `fromUuidSync` is guaranteed to provide an index with `img` because we prevent dropping items with parents.
- Made sure applied effects have all the right attributes lined up