### PR TITLE
[#775] Add level 1 Shadow features

### DIFF
--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Black_Ash_mVrcIPkC67dLxgpu/ability_Black_Ash_Teleport_IdkIEstbEaLfpYis.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Black_Ash_mVrcIPkC67dLxgpu/ability_Black_Ash_Teleport_IdkIEstbEaLfpYis.json
@@ -1,0 +1,65 @@
+{
+  "folder": "mVrcIPkC67dLxgpu",
+  "name": "Black Ash Teleport",
+  "type": "ability",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "162",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "black-ash-teleport",
+    "story": "In a swirl of black ash, you step from one place to another.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "maneuver",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You teleport up to 5 squares. If you have concealment or cover at your destination, you can use the Hide maneuver even if you are observed. If you successfully hide using this maneuver, you gain 1 surge.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "You teleport 1 additional square for each insight spent.",
+      "value": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652242640,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_id": "IdkIEstbEaLfpYis",
+  "sort": 100000,
+  "_key": "!items!IdkIEstbEaLfpYis"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Black_Ash_mVrcIPkC67dLxgpu/ability_In_All_This_Confusion_mN8875dhoHknYI3w.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Black_Ash_mVrcIPkC67dLxgpu/ability_In_All_This_Confusion_mN8875dhoHknYI3w.json
@@ -1,0 +1,65 @@
+{
+  "folder": "mVrcIPkC67dLxgpu",
+  "name": "In All This Confusion",
+  "type": "ability",
+  "_id": "mN8875dhoHknYI3w",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "in-all-this-confusion",
+    "story": "You vanish in a plume of black smoke to avoid danger.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "triggered",
+    "category": "",
+    "resource": null,
+    "trigger": "You take damage.",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You take half the damage, then can teleport up to 4 squares after the triggering effect resolves.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "You teleport 1 additional square for each insight spent.",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754653018018,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!mN8875dhoHknYI3w"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Caustic_Alchemy_RcnGdtclSI28JdXI/ability_Coat_the_Blade_ihPfHnfcJFw3Ujx8.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Caustic_Alchemy_RcnGdtclSI28JdXI/ability_Coat_the_Blade_ihPfHnfcJFw3Ujx8.json
@@ -1,0 +1,63 @@
+{
+  "folder": "RcnGdtclSI28JdXI",
+  "name": "Coat the Blade",
+  "type": "ability",
+  "_id": "ihPfHnfcJFw3Ujx8",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "162",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "coat-the-blade",
+    "story": "A little poison goes a long way.",
+    "keywords": [],
+    "type": "maneuver",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You gain 2 surges. Additionally, whenever you use a surge before the end of the encounter, you can choose to have it deal poison damage.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "For each insight you spend, you gain 1 additional surge.",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652265514,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!ihPfHnfcJFw3Ujx8"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Caustic_Alchemy_RcnGdtclSI28JdXI/ability_Defensive_Roll_YZE0KvfPqDrFGKy9.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_Caustic_Alchemy_RcnGdtclSI28JdXI/ability_Defensive_Roll_YZE0KvfPqDrFGKy9.json
@@ -1,0 +1,63 @@
+{
+  "folder": "RcnGdtclSI28JdXI",
+  "name": "Defensive Roll",
+  "type": "ability",
+  "_id": "YZE0KvfPqDrFGKy9",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "defensive-roll",
+    "story": "",
+    "keywords": [],
+    "type": "triggered",
+    "category": "signature",
+    "resource": null,
+    "trigger": "Another creature damages you.",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You take half the triggering damage, then can shift up to 2 squares after the triggering effect resolves. If you end this shift with concealment or cover, you can use the Hide maneuver even if you are observed.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "The potency of any effects associated with the damage are reduced by 1 for you.",
+      "value": 1
+    }
+  },
+  "effects": [],
+  "sort": 100000,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652935644,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!YZE0KvfPqDrFGKy9"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_the_Harlequin_Mask_D711GmZWkqwMzrof/ability_Clever_Trick_rtFwtr8oYTBhjCn8.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_the_Harlequin_Mask_D711GmZWkqwMzrof/ability_Clever_Trick_rtFwtr8oYTBhjCn8.json
@@ -1,0 +1,65 @@
+{
+  "folder": "D711GmZWkqwMzrof",
+  "name": "Clever Trick",
+  "type": "ability",
+  "_id": "rtFwtr8oYTBhjCn8",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "162",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "clever-trick",
+    "story": "You sow a moment of confusion in combat, to your enemy’s peril.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "triggered",
+    "category": "heroic",
+    "resource": 1,
+    "trigger": "An enemy targets you with a strike.",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>Choose an enemy within distance of the triggering strike, including the enemy who targeted you. The strike targets that enemy instead.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 100000,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652824296,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!rtFwtr8oYTBhjCn8"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_the_Harlequin_Mask_D711GmZWkqwMzrof/ability_I_m_No_Threat_ZZbgNnWUKXD14C1r.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/College_of_the_Harlequin_Mask_D711GmZWkqwMzrof/ability_I_m_No_Threat_ZZbgNnWUKXD14C1r.json
@@ -1,0 +1,65 @@
+{
+  "folder": "D711GmZWkqwMzrof",
+  "name": "I'm No Threat",
+  "type": "ability",
+  "_id": "ZZbgNnWUKXD14C1r",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "162",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "im-no-threat",
+    "story": "Taking on an illusory countenance gives you an advantage on subterfuge.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "maneuver",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You envelop yourself in an illusion that makes you appear nonthreatening and harmless to your enemies. You might take on the appearance of a harmless animal of your size, such as a sheep or capybara, or you might appear as a less heroic and unarmed version of yourself. While this illusion lasts, your strikes gain an edge, and when you take the Disengage move action, you gain a +1 bonus to the distance you can shift.</p><p>The illusion ends when you harm another creature, when you physically interact with a creature, when you use this ability again, or when you end the illusion (no action required). If you end this illusion by harming another creature, you gain 1 surge.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "Choose a creature whose size is no more than 1 greater than yours and who is within 10 squares. This ability’s illusion makes you appear as that creature. This illusion covers your entire body, including clothing and armor, and alters your voice to sound like that of the creature. You gain an edge on tests made to convince the creature’s allies that you are the creature.",
+      "value": 1
+    }
+  },
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652491391,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!ZZbgNnWUKXD14C1r"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/ability_Hesitation_is_Weakness_weYBoNzMpzcu9qUr.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/ability_Hesitation_is_Weakness_weYBoNzMpzcu9qUr.json
@@ -1,0 +1,63 @@
+{
+  "folder": "64bJmA5AuYdQRJGq",
+  "name": "Hesitation is Weakness",
+  "type": "ability",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "hesitation-is-weakness",
+    "story": "Keep up the attack. Never give them a moment’s grace.",
+    "keywords": [],
+    "type": "freeTriggered",
+    "category": "heroic",
+    "resource": 1,
+    "trigger": "Another hero ends their turn. That hero can’t have used this ability to start their turn.",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You take your turn after the triggering hero.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652234236,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_id": "weYBoNzMpzcu9qUr",
+  "sort": 0,
+  "_key": "!items!weYBoNzMpzcu9qUr"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/folders_College_of_Black_Ash_mVrcIPkC67dLxgpu.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/folders_College_of_Black_Ash_mVrcIPkC67dLxgpu.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "64bJmA5AuYdQRJGq",
+  "name": "College of Black Ash",
+  "color": null,
+  "sorting": "a",
+  "_id": "mVrcIPkC67dLxgpu",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!mVrcIPkC67dLxgpu"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/folders_College_of_Caustic_Alchemy_RcnGdtclSI28JdXI.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/folders_College_of_Caustic_Alchemy_RcnGdtclSI28JdXI.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "64bJmA5AuYdQRJGq",
+  "name": "College of Caustic Alchemy",
+  "color": null,
+  "sorting": "a",
+  "_id": "RcnGdtclSI28JdXI",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!RcnGdtclSI28JdXI"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/folders_College_of_the_Harlequin_Mask_D711GmZWkqwMzrof.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Core_64bJmA5AuYdQRJGq/folders_College_of_the_Harlequin_Mask_D711GmZWkqwMzrof.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "64bJmA5AuYdQRJGq",
+  "name": "College of the Harlequin Mask",
+  "color": null,
+  "sorting": "a",
+  "_id": "D711GmZWkqwMzrof",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!D711GmZWkqwMzrof"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Disorienting_Strike_fxdiH1SHqvKGcMYY.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Disorienting_Strike_fxdiH1SHqvKGcMYY.json
@@ -1,0 +1,115 @@
+{
+  "folder": "vFbMXPTlF69DU7Bw",
+  "name": "Disorienting Strike",
+  "type": "ability",
+  "_id": "fxdiH1SHqvKGcMYY",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "disorienting-strike",
+    "story": "Your attack leaves them reeling, allowing you to follow up.",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 3,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "qd50FlsYfrxTVaNT": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "qd50FlsYfrxTVaNT",
+          "damage": {
+            "tier1": {
+              "value": "4 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "10 + @chr"
+            }
+          }
+        },
+        "NnAuNYuytTeAgHIE": {
+          "name": "Slide",
+          "img": null,
+          "type": "forced",
+          "_id": "NnAuNYuytTeAgHIE",
+          "forced": {
+            "tier1": {
+              "movement": [
+                "slide"
+              ],
+              "distance": "2"
+            },
+            "tier2": {
+              "movement": [
+                "slide"
+              ],
+              "distance": "3"
+            },
+            "tier3": {
+              "movement": [
+                "slide"
+              ],
+              "distance": "5"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>You can shift into any square the target leaves when you slide them.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754653203931,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!fxdiH1SHqvKGcMYY"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Eviscerate_yX2KU1Eqc24ijqcB.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Eviscerate_yX2KU1Eqc24ijqcB.json
@@ -1,0 +1,133 @@
+{
+  "folder": "vFbMXPTlF69DU7Bw",
+  "name": "Eviscerate",
+  "type": "ability",
+  "_id": "yX2KU1Eqc24ijqcB",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "eviscerate",
+    "story": "You leave your foe bleeding out after a devastating attack.",
+    "keywords": [
+      "melee",
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 3,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": 1,
+      "secondary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "usNmGX1G4kLRGect": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "usNmGX1G4kLRGect",
+          "damage": {
+            "tier1": {
+              "value": "4 + @chr"
+            },
+            "tier2": {
+              "value": "6 + @chr"
+            },
+            "tier3": {
+              "value": "10 + @chr"
+            }
+          }
+        },
+        "oJxRlmVITpM6ArAR": {
+          "name": "Bleed",
+          "img": null,
+          "type": "applied",
+          "_id": "oJxRlmVITpM6ArAR",
+          "applied": {
+            "tier1": {
+              "effects": {
+                "bleeding": {
+                  "condition": "failure",
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "characteristic": "agility"
+              },
+              "display": "{{potency}}, bleeding (save ends)"
+            },
+            "tier2": {
+              "effects": {
+                "bleeding": {
+                  "condition": "failure",
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "effects": {
+                "bleeding": {
+                  "condition": "failure",
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754653360172,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!yX2KU1Eqc24ijqcB"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Get_In_Get_Out_VwqbeNSv0ItsaaPD.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Get_In_Get_Out_VwqbeNSv0ItsaaPD.json
@@ -1,0 +1,89 @@
+{
+  "folder": "vFbMXPTlF69DU7Bw",
+  "name": "Get In Get Out",
+  "type": "ability",
+  "_id": "VwqbeNSv0ItsaaPD",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "get-in-get-out",
+    "story": "Move unexpectedly, strike fast, and be gone!",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 3,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "gdKcCGwtcYsz89kp": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "gdKcCGwtcYsz89kp",
+          "damage": {
+            "tier1": {
+              "value": "5 + @chr"
+            },
+            "tier2": {
+              "value": "8 + @chr"
+            },
+            "tier3": {
+              "value": "11 + @chr"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>You can shift up to your speed, dividing that movement before or after your strike as desired.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754653752887,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!VwqbeNSv0ItsaaPD"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Two_Throats_at_Once_PF2heedkoTuLzInM.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Two_Throats_at_Once_PF2heedkoTuLzInM.json
@@ -1,0 +1,89 @@
+{
+  "folder": "vFbMXPTlF69DU7Bw",
+  "name": "Two Throats at Once",
+  "type": "ability",
+  "_id": "PF2heedkoTuLzInM",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "two-throats-at-once",
+    "story": "A bargain.",
+    "keywords": [
+      "melee",
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 3,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": 1,
+      "secondary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 2
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {
+        "RW4KtlbI1CFcdnh1": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "RW4KtlbI1CFcdnh1",
+          "damage": {
+            "tier1": {
+              "value": "4"
+            },
+            "tier2": {
+              "value": "6"
+            },
+            "tier3": {
+              "value": "10"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754653961003,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!PF2heedkoTuLzInM"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_Coup_de_Grace_wdOVSaOWjUsPmeEM.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_Coup_de_Grace_wdOVSaOWjUsPmeEM.json
@@ -1,0 +1,89 @@
+{
+  "folder": "7ad8TbrSqCknctHP",
+  "name": "Coup de Grace",
+  "type": "ability",
+  "_id": "wdOVSaOWjUsPmeEM",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "coup-de-grace",
+    "story": "Your blade might be the last thing they see.",
+    "keywords": [
+      "melee",
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": 1,
+      "secondary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {
+        "JInSxfOtZ5PQSoNr": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "JInSxfOtZ5PQSoNr",
+          "damage": {
+            "tier1": {
+              "value": "2d6 +7 + @chr"
+            },
+            "tier2": {
+              "value": "2d6 + 11 + @chr"
+            },
+            "tier3": {
+              "value": "2d6 + 16 + @chr"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754654149704,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!wdOVSaOWjUsPmeEM"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_One_Hundred_Throats_a93xTnhOnwJSe0Zq.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_One_Hundred_Throats_a93xTnhOnwJSe0Zq.json
@@ -1,0 +1,84 @@
+{
+  "folder": "7ad8TbrSqCknctHP",
+  "name": "One Hundred Throats",
+  "type": "ability",
+  "_id": "a93xTnhOnwJSe0Zq",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "one-hundred-throats",
+    "story": "As you move across the battlefield, every foe within reach feels your wrath.",
+    "keywords": [
+      "melee",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {
+        "LlA2HlCs97T3Fo1H": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "LlA2HlCs97T3Fo1H",
+          "damage": {
+            "tier1": {
+              "value": "3"
+            },
+            "tier2": {
+              "value": "6"
+            },
+            "tier3": {
+              "value": "9"
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>You shift up to your speed and make one power roll that targets up to three enemies who came adjacent to you during the move.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754654245571,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!a93xTnhOnwJSe0Zq"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_Setup_sZDSZOUU9LgQCLcP.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_Setup_sZDSZOUU9LgQCLcP.json
@@ -1,0 +1,112 @@
+{
+  "folder": "7ad8TbrSqCknctHP",
+  "name": "Setup",
+  "type": "ability",
+  "_id": "sZDSZOUU9LgQCLcP",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "setup",
+    "story": "Your friends will thank you.",
+    "keywords": [
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "t8iRG5mpyr4cbhsy": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "t8iRG5mpyr4cbhsy",
+          "damage": {
+            "tier1": {
+              "value": "6 + @chr"
+            },
+            "tier2": {
+              "value": "9 + @chr"
+            },
+            "tier3": {
+              "value": "13 + @chr"
+            }
+          }
+        },
+        "hAxcmYNAUDBvbagb": {
+          "name": "",
+          "img": null,
+          "type": "other",
+          "_id": "hAxcmYNAUDBvbagb",
+          "other": {
+            "tier1": {
+              "potency": {
+                "characteristic": "reason"
+              },
+              "display": "{{potency}}, the target has damage weakness 5 (save ends)"
+            },
+            "tier2": {
+              "display": "{{potency}}, the target has damage weakness 5 (save ends)"
+            },
+            "tier3": {
+              "display": "{{potency}}, the target has damage weakness 5 (save ends)",
+              "potency": {
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754654362675,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!sZDSZOUU9LgQCLcP"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_Shadowstrike_mMqubTdf0bE8mCXV.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/5_Insight_7ad8TbrSqCknctHP/ability_Shadowstrike_mMqubTdf0bE8mCXV.json
@@ -1,0 +1,67 @@
+{
+  "folder": "7ad8TbrSqCknctHP",
+  "name": "Shadowstrike",
+  "type": "ability",
+  "_id": "mMqubTdf0bE8mCXV",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "164",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "shadowstrike",
+    "story": "They have no idea what the college taught you.",
+    "keywords": [
+      "magic",
+      "melee",
+      "ranged"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self"
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>You use a strike signature ability twice.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754654861160,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!mMqubTdf0bE8mCXV"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Gasping_in_Pain_avpi9kfzRK0B9YIk.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Gasping_in_Pain_avpi9kfzRK0B9YIk.json
@@ -1,0 +1,181 @@
+{
+  "name": "Gasping in Pain",
+  "type": "ability",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "gasping-in-pain",
+    "story": "Your precise strikes let your allies take advantage of a target’s agony.",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "QEp70zgOT7JvvAsj": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "QEp70zgOT7JvvAsj",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "5 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": "none"
+              }
+            },
+            "tier3": {
+              "value": "8 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": "none"
+              }
+            }
+          }
+        },
+        "ZDAkGVNcvWDeydrN": {
+          "name": "Prone",
+          "img": null,
+          "type": "applied",
+          "_id": "ZDAkGVNcvWDeydrN",
+          "applied": {
+            "tier1": {
+              "display": "",
+              "effects": {},
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "display": "",
+              "effects": {},
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": "none"
+              }
+            },
+            "tier3": {
+              "display": "{{potency}}, prone",
+              "effects": {
+                "prone": {
+                  "condition": "failure",
+                  "properties": []
+                }
+              },
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": "intuition"
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>One ally within 5 squares of the target gains 1 surge.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Active Effect",
+      "img": "icons/svg/item-bag.svg",
+      "transfer": false,
+      "_id": "ZHEKuOicVxYamG0Q",
+      "type": "base",
+      "system": {
+        "end": {
+          "type": "",
+          "roll": "1d10 + @combat.save.bonus"
+        }
+      },
+      "changes": [],
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.0",
+        "lastModifiedBy": null,
+        "modifiedTime": null
+      },
+      "_key": "!items.effects!avpi9kfzRK0B9YIk.ZHEKuOicVxYamG0Q"
+    }
+  ],
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652138162,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "folder": "vaDG7PoWBTXrSv3N",
+  "_id": "avpi9kfzRK0B9YIk",
+  "sort": 100000,
+  "_key": "!items!avpi9kfzRK0B9YIk"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_I_Work_Better_Alone_ehA3Xd2YnARQszb2.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_I_Work_Better_Alone_ehA3Xd2YnARQszb2.json
@@ -1,0 +1,109 @@
+{
+  "folder": "vaDG7PoWBTXrSv3N",
+  "name": "I Work Better Alone",
+  "type": "ability",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "i-work-better-alone",
+    "story": "“It’s better, just you and me. Isn’t it?”",
+    "keywords": [
+      "melee",
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": 1,
+      "secondary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "LSya3EucBwfM9AhF": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "LSya3EucBwfM9AhF",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "6 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "9 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>If the target has none of your allies adjacent to them, you gain 1 surge before making the power roll.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652139983,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_id": "ehA3Xd2YnARQszb2",
+  "sort": 300000,
+  "_key": "!items!ehA3Xd2YnARQszb2"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Teamwork_Has_Its_Place_7iEVcJVYLoDe49Cs.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Teamwork_Has_Its_Place_7iEVcJVYLoDe49Cs.json
@@ -1,0 +1,109 @@
+{
+  "name": "Teamwork Has Its Place",
+  "type": "ability",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "teamwork-has-its-place",
+    "story": "You attack an enemy as an ally exposes their weakness.",
+    "keywords": [
+      "melee",
+      "ranged",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": 1,
+      "secondary": 5
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "LSya3EucBwfM9AhF": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "LSya3EucBwfM9AhF",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "6 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "9 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>If any ally is adjacent to the target, you gain 1 surge before making the power roll.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652141402,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "folder": "vaDG7PoWBTXrSv3N",
+  "_id": "7iEVcJVYLoDe49Cs",
+  "sort": 200000,
+  "_key": "!items!7iEVcJVYLoDe49Cs"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_You_Were_Watching_the_Wrong_One_JsIqJ0UsUSNJemm3.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_You_Were_Watching_the_Wrong_One_JsIqJ0UsUSNJemm3.json
@@ -1,0 +1,107 @@
+{
+  "folder": "vaDG7PoWBTXrSv3N",
+  "name": "You Were Watching the Wrong One",
+  "type": "ability",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "163",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "you-were-watching-the-wrong-one",
+    "story": "They can’t watch both of you at once.",
+    "keywords": [
+      "melee",
+      "strike",
+      "weapon"
+    ],
+    "type": "main",
+    "category": "signature",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": 1
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": [
+          "agility"
+        ]
+      },
+      "effects": {
+        "Rg07lIS1mEqsl7gZ": {
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "Rg07lIS1mEqsl7gZ",
+          "damage": {
+            "tier1": {
+              "value": "3 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "5 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "8 + @chr",
+              "types": [],
+              "properties": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effect": {
+      "before": "<p>As long as you have one or more allies within 5 squares of the target, you gain 1 surge. If you are flanking the target when you use this ability, choose one ally who is flanking with you. That ally also gains 1 surge.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652142658,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_id": "JsIqJ0UsUSNJemm3",
+  "sort": 0,
+  "_key": "!items!JsIqJ0UsUSNJemm3"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/folders_3_Insight_vFbMXPTlF69DU7Bw.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/folders_3_Insight_vFbMXPTlF69DU7Bw.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "qFX1RI3AfCfQGG0r",
+  "name": "3 Insight",
+  "color": null,
+  "sorting": "a",
+  "_id": "vFbMXPTlF69DU7Bw",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!vFbMXPTlF69DU7Bw"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/folders_5_Insight_7ad8TbrSqCknctHP.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/folders_5_Insight_7ad8TbrSqCknctHP.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "qFX1RI3AfCfQGG0r",
+  "name": "5 Insight",
+  "color": null,
+  "sorting": "a",
+  "_id": "7ad8TbrSqCknctHP",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!7ad8TbrSqCknctHP"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/folders_Signature_vaDG7PoWBTXrSv3N.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/folders_Signature_vaDG7PoWBTXrSv3N.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "qFX1RI3AfCfQGG0r",
+  "name": "Signature",
+  "color": null,
+  "sorting": "a",
+  "_id": "vaDG7PoWBTXrSv3N",
+  "description": "",
+  "sort": 100000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!vaDG7PoWBTXrSv3N"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/folders_Core_64bJmA5AuYdQRJGq.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/folders_Core_64bJmA5AuYdQRJGq.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "ymzPghcR2SYV1TKr",
+  "name": "Core",
+  "color": null,
+  "sorting": "a",
+  "_id": "64bJmA5AuYdQRJGq",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!64bJmA5AuYdQRJGq"
+}

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/folders_Level_1_qFX1RI3AfCfQGG0r.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/folders_Level_1_qFX1RI3AfCfQGG0r.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "ymzPghcR2SYV1TKr",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "qFX1RI3AfCfQGG0r",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!qFX1RI3AfCfQGG0r"
+}

--- a/src/packs/abilities/folders_Shadow_ymzPghcR2SYV1TKr.json
+++ b/src/packs/abilities/folders_Shadow_ymzPghcR2SYV1TKr.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Shadow",
+  "color": null,
+  "sorting": "a",
+  "_id": "ymzPghcR2SYV1TKr",
+  "description": "",
+  "sort": 400000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652034464,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!ymzPghcR2SYV1TKr"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/College_of_Caustic_Sorcery_0Q6ixeCJx3aWWvD2/feature_Smoke_Bomb_dk98ef3XQxkZwW3Q.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/College_of_Caustic_Sorcery_0Q6ixeCJx3aWWvD2/feature_Smoke_Bomb_dk98ef3XQxkZwW3Q.json
@@ -1,0 +1,47 @@
+{
+  "folder": "0Q6ixeCJx3aWWvD2",
+  "name": "Smoke Bomb",
+  "type": "feature",
+  "_id": "dk98ef3XQxkZwW3Q",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": {
+      "value": "<p>You always carry a supply of smoke bombs to use for distractions and easy getaways. You can use the Hide maneuver even if you are observed and don’t initially have cover or concealment. When you do so, you can shift a number of squares equal to your Agility score. If you end this movement with cover or concealment, you are automatically hidden.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Heroes",
+      "page": "162",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "smoke-bomb",
+    "advancements": {},
+    "type": {
+      "value": "",
+      "subtype": ""
+    },
+    "prerequisites": {
+      "value": ""
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754652711249,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!dk98ef3XQxkZwW3Q"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/feature_Insight_8UVDKdZXiXzfFI0I.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/feature_Insight_8UVDKdZXiXzfFI0I.json
@@ -1,0 +1,47 @@
+{
+  "folder": "LvOyLhTtUGY7s6C5",
+  "name": "Insight",
+  "type": "feature",
+  "_id": "8UVDKdZXiXzfFI0I",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": {
+      "value": "<p>By observing your enemy, you learn how to use their weaknesses against them, building up a Heroic Resource called insight.</p><h4>Insight in Combat</h4><p>At the start of a combat encounter or some other stressful situation tracked in combat rounds (as determined by the Director), you gain insight equal to your Victories. At the start of each of your turns during combat, you gain 1d3 insight.</p><p>Additionally, the first time each combat round that you deal damage incorporating 1 or more surges, you gain 1 insight.</p><p>Whenever you use a heroic ability that makes use of a power roll, that ability costs 1 fewer insight if you have an edge or double edge on it. If the ability has multiple targets, the cost is reduced even if the ability gains an edge or has a double edge against only one target.</p><p>You lose any remaining insight at the end of the encounter.</p><h4>Insight Outside of Combat</h4><p>Although you can’t gain insight outside of combat, you can use your heroic abilities and effects that cost insight without spending it. Whenever you use an ability or effect outside of combat that costs insight, you can’t use that same ability or effect outside of combat again until you earn 1 or more Victories or finish a respite.</p><p>When you use an ability outside of combat that lets you spend unlimited insight on its effect, such as Black Ash Teleport, you can use it as if you had spent an amount of insight equal to your Victories.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Heroes",
+      "page": "161",
+      "license": "Draw Steel Creator License",
+      "revision": 1
+    },
+    "_dsid": "insight",
+    "advancements": {},
+    "type": {
+      "value": "",
+      "subtype": ""
+    },
+    "prerequisites": {
+      "value": ""
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754646044111,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!8UVDKdZXiXzfFI0I"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/folders_College_of_Black_Ash_Go0oE6bJuCYq7G7M.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/folders_College_of_Black_Ash_Go0oE6bJuCYq7G7M.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "LvOyLhTtUGY7s6C5",
+  "name": "College of Black Ash",
+  "color": null,
+  "sorting": "a",
+  "_id": "Go0oE6bJuCYq7G7M",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!Go0oE6bJuCYq7G7M"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/folders_College_of_Caustic_Sorcery_0Q6ixeCJx3aWWvD2.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/folders_College_of_Caustic_Sorcery_0Q6ixeCJx3aWWvD2.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "LvOyLhTtUGY7s6C5",
+  "name": "College of Caustic Sorcery",
+  "color": null,
+  "sorting": "a",
+  "_id": "0Q6ixeCJx3aWWvD2",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!0Q6ixeCJx3aWWvD2"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/folders_College_of_the_Harlequin_Mask_BNGAZfxMXH1J0xCX.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Features_LvOyLhTtUGY7s6C5/folders_College_of_the_Harlequin_Mask_BNGAZfxMXH1J0xCX.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "LvOyLhTtUGY7s6C5",
+  "name": "College of the Harlequin Mask",
+  "color": null,
+  "sorting": "a",
+  "_id": "BNGAZfxMXH1J0xCX",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!BNGAZfxMXH1J0xCX"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Subclasses_zUXKgyV6RrQD4AsM/subclass_College_of_Black_Ash_w9bPx3bsOslJ43Tj.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Subclasses_zUXKgyV6RrQD4AsM/subclass_College_of_Black_Ash_w9bPx3bsOslJ43Tj.json
@@ -1,0 +1,87 @@
+{
+  "folder": "zUXKgyV6RrQD4AsM",
+  "name": "College of Black Ash",
+  "type": "subclass",
+  "_id": "w9bPx3bsOslJ43Tj",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": {
+      "value": "<p>The College of Black Ash founded the art of being a shadow. Its graduates are unmatched in mobility, using sorcery to teleport around the battlefield, manipulate shadows, and summon darkness. You have the Magic skill.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Heroes",
+      "page": "161",
+      "license": "Draw Steek Creator License",
+      "revision": 1
+    },
+    "_dsid": "college-of-black-ash",
+    "advancements": {
+      "DS1CCC4gnDZOFbKL": {
+        "name": "Skill (Magic)",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "DS1CCC4gnDZOFbKL",
+        "skills": {
+          "choices": [
+            "magic"
+          ],
+          "groups": [
+            "lore"
+          ]
+        }
+      },
+      "mowLOvhmuO9Kk4jb": {
+        "name": "College Features",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "mowLOvhmuO9Kk4jb",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.IdkIEstbEaLfpYis"
+          }
+        ]
+      },
+      "vOxGJwtwG89f8PKr": {
+        "name": "College Triggered Action",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "vOxGJwtwG89f8PKr",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.mN8875dhoHknYI3w"
+          }
+        ]
+      }
+    },
+    "classLink": "shadow"
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754644717200,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!w9bPx3bsOslJ43Tj"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Subclasses_zUXKgyV6RrQD4AsM/subclass_College_of_Caustic_Sorcery_Hh1KF3TjXZydyOL2.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Subclasses_zUXKgyV6RrQD4AsM/subclass_College_of_Caustic_Sorcery_Hh1KF3TjXZydyOL2.json
@@ -1,0 +1,90 @@
+{
+  "folder": "zUXKgyV6RrQD4AsM",
+  "name": "College of Caustic Sorcery",
+  "type": "subclass",
+  "_id": "Hh1KF3TjXZydyOL2",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": {
+      "value": "<p>The College of Caustic Alchemy teaches its students recipes for the acids, bombs, and poisons used in their grim work. Graduates of the college are exceptional assassins. You have the Alchemy skill.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Heroes",
+      "page": "161",
+      "license": "Draw Steek Creator License",
+      "revision": 1
+    },
+    "_dsid": "college-of-caustic-sorcery",
+    "advancements": {
+      "sYZpxuQaSemR3bK7": {
+        "name": "Skill (Alchemy)",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "sYZpxuQaSemR3bK7",
+        "skills": {
+          "groups": [
+            "crafting"
+          ],
+          "choices": [
+            "alchemy"
+          ]
+        }
+      },
+      "AiYDTum2T3m69MtA": {
+        "name": "College Features",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "AiYDTum2T3m69MtA",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.ihPfHnfcJFw3Ujx8"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.dk98ef3XQxkZwW3Q"
+          }
+        ]
+      },
+      "lA6e1IozFTgIYFtt": {
+        "name": "College Triggered Action",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "lA6e1IozFTgIYFtt",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.YZE0KvfPqDrFGKy9"
+          }
+        ]
+      }
+    },
+    "classLink": "shadow"
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754644737060,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!Hh1KF3TjXZydyOL2"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Subclasses_zUXKgyV6RrQD4AsM/subclass_College_of_the_Harlequin_Mask_FVMUt54L6k3ZOO58.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/Subclasses_zUXKgyV6RrQD4AsM/subclass_College_of_the_Harlequin_Mask_FVMUt54L6k3ZOO58.json
@@ -1,0 +1,87 @@
+{
+  "folder": "zUXKgyV6RrQD4AsM",
+  "name": "College of the Harlequin Mask",
+  "type": "subclass",
+  "_id": "FVMUt54L6k3ZOO58",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": {
+      "value": "<p>Graduates of the College of the Harlequin Mask learn illusion magic, which they use to infiltrate enemy strongholds and create orchestrated chaos in combat. You have the Lie skill.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Heroes",
+      "page": "161",
+      "license": "Draw Steek Creator License",
+      "revision": 1
+    },
+    "_dsid": "college-of-the-harlequin-mask",
+    "advancements": {
+      "UoYJf2tjr0RXuMBm": {
+        "name": "Skill (Lie)",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "UoYJf2tjr0RXuMBm",
+        "skills": {
+          "groups": [
+            "interpersonal"
+          ],
+          "choices": [
+            "lie"
+          ]
+        }
+      },
+      "gCBxdwLbtULbFgSX": {
+        "name": "College Features",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "gCBxdwLbtULbFgSX",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.ZZbgNnWUKXD14C1r"
+          }
+        ]
+      },
+      "OxbNmzO132RahSg4": {
+        "name": "College Triggered Action",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "OxbNmzO132RahSg4",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.rtFwtr8oYTBhjCn8"
+          }
+        ]
+      }
+    },
+    "classLink": "shadow"
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "whGCKogBJnD2ehjg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "createdTime": 1754644755259,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!FVMUt54L6k3ZOO58"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/class_Shadow_08pJ0i8AwjMsrKO1.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/class_Shadow_08pJ0i8AwjMsrKO1.json
@@ -59,6 +59,95 @@
           "level": 1
         },
         "description": "<p>Then choose any five skills from Criminal Underworld or the skills of the exploration, interpersonal, or intrigue skill groups.</p>"
+      },
+      "xbz684UecAtQyYgk": {
+        "name": "Features",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "xbz684UecAtQyYgk",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.8UVDKdZXiXzfFI0I"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.weYBoNzMpzcu9qUr"
+          }
+        ]
+      },
+      "902QsazsIAjNioxx": {
+        "name": "Signature Ability",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "902QsazsIAjNioxx",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.avpi9kfzRK0B9YIk"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.ehA3Xd2YnARQszb2"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.7iEVcJVYLoDe49Cs"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.JsIqJ0UsUSNJemm3"
+          }
+        ],
+        "chooseN": 1
+      },
+      "6Hec0kIaaXm1ZSPf": {
+        "name": "3 Insight",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "6Hec0kIaaXm1ZSPf",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.fxdiH1SHqvKGcMYY"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.yX2KU1Eqc24ijqcB"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.VwqbeNSv0ItsaaPD"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.PF2heedkoTuLzInM"
+          }
+        ],
+        "chooseN": 1
+      },
+      "SuaZbEJYFdKVDgnS": {
+        "name": "5 Insight",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "SuaZbEJYFdKVDgnS",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.wdOVSaOWjUsPmeEM"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.a93xTnhOnwJSe0Zq"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.sZDSZOUU9LgQCLcP"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.mMqubTdf0bE8mCXV"
+          }
+        ],
+        "chooseN": 1
       }
     },
     "_dsid": "shadow",

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/folders_Features_LvOyLhTtUGY7s6C5.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/folders_Features_LvOyLhTtUGY7s6C5.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "ngcpmEclU2UUJbz4",
+  "name": "Features",
+  "color": null,
+  "sorting": "a",
+  "_id": "LvOyLhTtUGY7s6C5",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!LvOyLhTtUGY7s6C5"
+}

--- a/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/folders_Subclasses_zUXKgyV6RrQD4AsM.json
+++ b/src/packs/classes/Shadow_ngcpmEclU2UUJbz4/folders_Subclasses_zUXKgyV6RrQD4AsM.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "ngcpmEclU2UUJbz4",
+  "name": "Subclasses",
+  "color": null,
+  "sorting": "a",
+  "_id": "zUXKgyV6RrQD4AsM",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.346",
+    "systemId": "draw-steel",
+    "systemVersion": "0.8.0",
+    "lastModifiedBy": null,
+    "modifiedTime": null
+  },
+  "_key": "!folders!zUXKgyV6RrQD4AsM"
+}


### PR DESCRIPTION
Added all subclasses, features, and abilities of a level 1 Shadow to the compendium, including adding them to the class and subclass Advancement.

Still missing subclass choice in class advancement as the system doesn't support it yet.