### PR TITLE
fix: disable sheet interactions for non-owners using {{disabled}} helper (fixes #744)

### DIFF
--- a/templates/sheets/actor/shared/abilities.hbs
+++ b/templates/sheets/actor/shared/abilities.hbs
@@ -13,7 +13,7 @@
       <div class="item-column item-distance">{{@root.abilityFields.distance.label}}</div>
       <div class="item-column item-target">{{@root.abilityFields.target.label}}</div>
       <div class="item-column item-controls">
-        {{#if abilityType.showAdd}}
+        {{#if (and abilityType.showAdd @root.isOwner)}}
         {{#with (localize "DRAW_STEEL.SHEET.Add" itemName=(localize "TYPES.Item.ability")) as |addItemTooltip|}}
         <a class="createDoc" data-action="createDoc" data-document-class="Item" data-type="ability" data-render-sheet="true" data-system.type="{{@key}}" data-tooltip-text="{{addItemTooltip}}">
           <i class="fa-solid fa-plus"></i>
@@ -26,7 +26,7 @@
       {{#each abilityType.abilities as |abilityContext|}}
       <li class="item ability draggable" data-item-id="{{abilityContext.item.id}}" data-document-class="Item">
         <div class="item-row">
-          <div class="item-column item-name rollable" data-action="useAbility">
+          <div class="item-column item-name rollable" data-action="useAbility" {{disabled (not @root.isOwner)}}>
             <img class="item-image" src="{{abilityContext.item.img}}" alt="{{abilityContext.item.name}}">
             {{#if abilityContext.item.system.restricted}}
             <div class="restricted-warning" data-tooltip="DRAW_STEEL.Item.ability.Restricted">


### PR DESCRIPTION
Disables ability tab interactions (rolling, using abilities) for non-owners by applying the {{disabled}} Handlebars helper to relevant elements. This ensures that restricted actions are only available to sheet owners, aligning with system permissions. Left the Resources section untouched due to ongoing work in another PR.