### PR TITLE
[#790] Resolved logic blocking players from using NPC abilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Fixed display of multi-result abilities
 - Fixed unrequited prompting for end of turn events (#673)
 - Fixed project and save rolls not respecting roll mode settings. (#734)
+- Players can now use NPC abilities that don't have malice costs. (#790)
 - Secret blocks will now display in enriched descriptions for owned documents.
 
 ### Removed

--- a/lang/en.json
+++ b/lang/en.json
@@ -1459,7 +1459,8 @@
           "label": "Adjust Malice",
           "hint": "Positive numbers will increase the value and negative numbers will decrease the value."
         },
-        "ResetMalice": "Reset Malice"
+        "ResetMalice": "Reset Malice",
+        "PlayerError": "Malice can only be updated by a GM."
       },
       "ShowPlayerMalice": {
         "Label": "Show Malice Value To Players",

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -154,7 +154,10 @@ export default class NPCModel extends BaseActorModel {
 
   /** @inheritdoc */
   async updateResource(delta) {
-    if (!game.user.isGM) throw new Error("Malice can only be updated by a GM");
+    if (!game.user.isGM) {
+      ui.notifications.error("DRAW_STEEL.Setting.Malice.PlayerError", { localize: true, console: false });
+      throw new Error("Malice can only be updated by a GM");
+    }
     /** @type {MaliceModel} */
     const malice = game.actors.malice;
     await game.settings.set(systemID, "malice", { value: malice.value + delta });

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -421,7 +421,7 @@ export default class AbilityModel extends BaseItemModel {
     }
 
     // TODO: Figure out how to better handle invocations when this.actor is null
-    await this.actor?.system.updateResource(resourceSpend * -1);
+    if (resourceSpend) await this.actor?.system.updateResource(resourceSpend * -1);
 
     if (this.power.roll.enabled) {
       const formula = this.power.roll.formula ? `2d10 + ${this.power.roll.formula}` : "2d10";


### PR DESCRIPTION
Fairly simple logic fix. Continuing to use `console: false` for when we want to both have a ui error *and* throw an error.

Closes #790