### PR TITLE
Add initial Polyglot support

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -195,3 +195,4 @@ Hooks.on("renderTokenApplication", applications.hooks.renderTokenApplication);
  */
 Hooks.on("diceSoNiceRollStart", helpers.diceSoNiceRollStart);
 Hooks.on("hotReload", helpers.hotReload);
+Hooks.once("polyglot.init", helpers.polyglotInit);

--- a/lang/en.json
+++ b/lang/en.json
@@ -1586,7 +1586,7 @@
       "Uvalic": "Uvalic",
       "Vaniric": "Vaniric",
       "Variac": "Variac",
-      "Vasloria": "Vasloria",
+      "Vasloria": "Vaslorian",
       "Vastariax": "Vastariax",
       "Vhoric": "Vhoric",
       "Voll": "Voll",

--- a/src/module/helpers/_module.mjs
+++ b/src/module/helpers/_module.mjs
@@ -1,4 +1,5 @@
 export * from "./dsn.mjs";
+export * from "./polyglot.mjs";
 export * from "./hotReload.mjs";
 export * from "./handlebars.mjs";
 export * as macros from "./macros.mjs";

--- a/src/module/helpers/polyglot.mjs
+++ b/src/module/helpers/polyglot.mjs
@@ -164,20 +164,18 @@ export function polyglotInit(LanguageProvider) {
      *         If this is something we want, and are able to do without breaking other setups, then this is probably the place to do it.
      */
     async getLanguages() {
-      const outputLangs = {};
-
       if (this.replaceLanguages) { // if module setting to only use custom-set languages is enabled
         this.languages = {}; // remove the rpg system's own list of languages from Polyglot. (No impact to PC feature selection options.)
       }
       const languagesSetting = game.settings.get("polyglot", "Languages"); // User-set fonts and scrambling overrides for system langs
-      for (let lang in this.languages) {
+      this.languages = Object.keys(this.languages).reduce((outputLangs, lang) => {
         outputLangs[lang] = {
           label: ds.CONFIG.languages[lang].label,
           font: languagesSetting[lang]?.font || this.languages[lang]?.font || this.defaultFont,
           rng: languagesSetting[lang]?.rng ?? "default",
         };
-      }
-      this.languages = outputLangs;
+        return outputLangs;
+      }, {});
     }
 
     /**
@@ -185,7 +183,7 @@ export function polyglotInit(LanguageProvider) {
      * Called during init on user's designated character, before lang list is fully loaded, to establish user's chat language options. 
      * Called also by Director during regular play, whenever selecting an actor on the canvas.
      * @param {DrawSteelActor} actor
-     * @returns [known_languages, literate_languages] Array of Set objects for spoken, written language keys for the actor.
+     * @returns {[Set<string>, Set<string>]} Tuple of Set objects for an actor's [spoken, written] language keys.
      */
     getUserLanguages(actor) {
       let known_languages = new Set(); // set of language keys; fluency with spoken language

--- a/src/module/helpers/polyglot.mjs
+++ b/src/module/helpers/polyglot.mjs
@@ -1,0 +1,221 @@
+import DrawSteelActor from "../documents/actor.mjs";
+
+/**
+ * Provide external add-on Polyglot with default settings for all of Draw Steel's in-game languages. Polyglot LINK: https://foundryvtt.com/packages/polyglot/
+ * The DrawSteelLanguageProvider class can be later accessed at `game.polyglot.api.providers[`system.${ds.CONST.systemID}`]`, after "polyglot.ready" Hook has fired.
+ * 
+ * This provider must be handed over to Polyglot during its initialization, or the module will fallback to the Generic language provider.
+ * Most of the class is built around providing the `languages` field as soon as possible (for chat message masking?) during world load, and
+ * then later fleshing that field out with localized labels and module config states.
+ * @param {LanguageProvider} LanguageProvider - Base languages configuration class provided by the Polyglot init event.
+ */
+export function polyglotInit(LanguageProvider) {
+  class DrawSteelLanguageProvider extends LanguageProvider {
+
+    requiresReady = true; // Ask Polyglot to wait to load until "ready" has fired/babele is done loading.
+
+    /**
+     * Polyglot-compatible list of all languages in Draw Steel, with their default configurations.
+     * Called during init, before localization is ready. Polyglot unconditionally requires the language-to-font relationship be available at this stage, though,
+     * or it will fallback to Generic language provider. `rng` and `label` are fully fleshed out as part of setup later.
+     * @typedef {Object}
+     * @property {string} label - The displayed name for the language, used in the UI.
+     * @property {string} font - The typeface name used to render language'd text in the UI. This is the full, well-formatted text of the Polyglot font selection dropdown list, spaces and all.
+     * Don't assume access to core Foundry fonts! Polyglot module setting to allow Foundry fonts is off by default.
+     * @property {string} rng - Enum-like. The text scrambling logic of the language'd text.
+     * "default" (consistent scrambling algo based on input string) / "unique" (identical text will not be identically scrambled) / "none" (use actual text with the wingding-like font; readable if a "real" font is used).
+     */
+    languages = {
+      // ancestry languages
+      caelian: { // Polyglot would like the first language provided to be the system's "Common" language
+        font: "Meroitic Demotic",
+      },
+      anjali: {
+        font: "High Drowic",
+      },
+      axiomatic: {
+        font: "Miroslav Normal",
+      },
+      filliaric: {
+        font: "Kargi",
+      },
+      highKuric: {
+        font: "Maras Eye",
+      },
+      hyrallic: {
+        font: "Ar Ciela",
+      },
+      illyvric: {
+        font: "Ar Ciela",
+      },
+      kalliak: {
+        font: "Kargi",
+      },
+      kethaic: {
+        font: "Semphari",
+      },
+      khelt: {
+        font: "Barazhad",
+      },
+      khoursirian: {
+        font: "Meroitic Demotic",
+      },
+      lowKuric: {
+        font: "Ork Glyphs",
+      },
+      mindspeech: {
+        font: "Saurian",
+      },
+      protoCtholl: {
+        font: "Tengwar",
+      },
+      szetch: {
+        font: "Kargi",
+      },
+      theFirstLanguage: {
+        font: "Mage Script",
+      },
+      tholl: {
+        font: "Tengwar",
+      },
+      urollialic: {
+        font: "Skaven",
+      },
+      variac: {
+        font: "Skaven",
+      },
+      vastariax: {
+        font: "Rellanic",
+      },
+      vhoric: {
+        font: "Maras Eye",
+      },
+      voll: {
+        font: "Celestial",
+      },
+      yllyric: {
+        font: "Ar Ciela",
+      },
+      zahariax: {
+        font: "Dark Eldar",
+      },
+      zaliac: {
+        font: "Floki",
+      },
+      // Human languages. Khoursirian already covered
+      higaran: {
+        font: "Meroitic Demotic",
+      },
+      khemharic: {
+        font: "Meroitic Demotic",
+      },
+      oaxuatl: {
+        font: "Meroitic Demotic",
+      },
+      phaedran: {
+        font: "Meroitic Demotic",
+      },
+      riojan: {
+        font: "Meroitic Demotic",
+      },
+      uvalic: {
+        font: "Meroitic Demotic",
+      },
+      vaniric: {
+        font: "Meroitic Demotic",
+      },
+      vasloria: {
+        font: "Meroitic Demotic",
+      },
+      // Dead languages
+      highRhyvian: {
+        font: "Ar Ciela",
+      },
+      khamish: {
+        font: "Jungle Slang",
+      },
+      kheltivari: {
+        font: "Barazhad",
+      },
+      lowRhivian: {
+        font: "Ar Ciela",
+      },
+      oldVariac: {
+        font: "Skaven",
+      },
+      phorialtic: {
+        font: "Ork Glyphs",
+      },
+      rallarian: {
+        font: "Floki",
+      },
+      ullorvic: {
+        font: "Ar Ciela",
+      },
+    };
+
+    /**
+     * Fleshes out the `languages` property on this class to Polyglot for use.
+     * It must be fully fleshed out at this stage, with the necessary `label` and `rng` properties.
+     * Called by base class as part of super.setup().
+     * 
+     * REVIEW: Polyglot allows Directors to add and configure homebrew, custom languages.
+     *         We could allow Polyglot to insert those custom languages to ds.CONFIG.languages, so that custom languages appear as advancement options.
+     *         If this is something we want, and are able to do without breaking other setups, then this is probably the place to do it.
+     */
+    async getLanguages() {
+      const outputLangs = {};
+
+      if (this.replaceLanguages) { // if module setting to only use custom-set languages is enabled
+        this.languages = {}; // remove the rpg system's own list of languages from Polyglot. (No impact to PC feature selection options.)
+      }
+      const languagesSetting = game.settings.get("polyglot", "Languages"); // User-set fonts and scrambling overrides for system langs
+      for (let lang in this.languages) {
+        outputLangs[lang] = {
+          label: ds.CONFIG.languages[lang].label,
+          font: languagesSetting[lang]?.font || this.languages[lang]?.font || this.defaultFont,
+          rng: languagesSetting[lang]?.rng ?? "default",
+        };
+      }
+      this.languages = outputLangs;
+    }
+
+    /**
+     * Returns Draw Steel language keys for a specific actor document, as translated into a Polyglot-compatible object.
+     * Called during init on user's designated character, before lang list is fully loaded, to establish user's chat language options. 
+     * Called also by Director during regular play, whenever selecting an actor on the canvas.
+     * @param {DrawSteelActor} actor
+     * @returns [known_languages, literate_languages] Array of Set objects for spoken, written language keys for the actor.
+     */
+    getUserLanguages(actor) {
+      let known_languages = new Set(); // set of language keys; fluency with spoken language
+      let literate_languages = new Set(); // set of language keys; fluency with written language.
+
+      const actorLangs = Array.from(actor.system.biography?.languages);
+
+      if (actorLangs) {
+        known_languages = new Set(actorLangs);
+      }
+      
+      return [known_languages, literate_languages];
+      // REVIEW: We could mark Dead Languages as written-only with `literate_languages` here. Polyglot would limit these languages to Journals.
+      //         But Heroes p57 immediately gives an exception to Dead Langauges being written-only, with Khamish described as still having a spoken niche.
+      //         Is it desirable behavior to limit some/all Dead Languages to Journals?
+    }
+
+  } // end DrawSteelLanguageProvider
+
+  // Final handover of system's language provider to Polyglot.
+  game.polyglot.api.registerSystem(DrawSteelLanguageProvider); 
+
+  // Force the language list to be prepped. This is for when, on world startup, Draw Steel is not currently the default language provider.
+  // Only necessary to prevent Polyglot settings from going unresponsive when switching _to_ Draw Steel language provider.
+  // FIXME: This manual invoking of language setup doesn't seem to appear in other systems' language providers...
+  //        There's probably a better approach to preventing this unresponsiveness.
+  Hooks.once("ds.ready", async () => {
+    const providerId = `system.${ds.CONST.systemID}`;
+    if (game.polyglot.api.languageProvider.id != providerId) {
+      game.polyglot.api.providers[providerId].getLanguages();
+    }
+  });
+} // end polyglotInit()


### PR DESCRIPTION
Closes #640. Adds Polyglot support for Draw Steel's base languages in chat messages and journals.

Also fixes the English localization string for one language's name: `Vasloria` > `Vaslorian`, per Heroes p56.

Sorry for the low priority surprise! :bow: It wasn't until my "just to get familiar" experiments had made real progress that I noticed my faux pas. I'm aware of the current milestone now; I'll start getting familiar shortly with how to make compendium contributions and find some work to stake a claim on.

This is my first time making a public code contribution-- to a Foundry project, and in general. If you spot a(nother) faux pas or have a word of advice, I'd be grateful to hear it. I usually work with C#, so I'm sure I've missed something obvious with list manipulation or JSDoc here.

A few notes on Polyglot support, here and in general:
* This implementation uses the Polyglot API to register a game system's default languages during the module's initialization. Another option would have been to commit a LanguageProvider class like this to the module's own repo.
* Regarding languages' default fonts-- I've made an effort to preserve language relationships with these font choices (such as elvish languages sharing the same cursive-like wingding, all dwarvish languages using nordic rune-like wingdings, humans all get chicken scratch, etc.). But my only exposure to this lore is from the core rulebooks; I'm expecting I've made an oversight or two.
* There should be no impact to the broader system. This is a new method, called on a Polyglot hook to translate existing Draw Steel language entities into objects that Polyglot expects. There's no overriding or alteration to the system.
* :exclamation: It looks like the system isn't currently awarding PCs with the common tongue? I don't see Draw Steel currently awarding player characters Caelian, not unless they explicitly select it as part of advancements. Am I missing a character creation step, or a system config setting? If not, this might be a new issue.
  * Heroes p56, quote: "All player characters know Caelian!".
  * This might be related to #720. Discussion there floats the idea of changes to the language selection form element.
  * A quick and hacky fix would be to manually include Caelian in `getUserLanguages(actor)`, in this PR.
  * A more maintainable solution might be to always include Caelian in any language advancement, perhaps with a new system setting like "All PCs know Caelian?".
* Polyglot allows Directors to add custom languages. I haven't brought these custom languages into the base Draw Steel system here-- I haven't overridden  `ds.CONFIG.languages` to include custom languages, to allow actors to gain proficiency with them. That struck me as something to open a new issue on, for discussion.
  * Directors can still add custom languages right now via Polyglot, and can use their global language selector to speak/write in these languages. Players and actors can't currently gain proficiency in these custom languages, though.
* Polyglot allows systems to distinguish between "spoken" (chat messages & journals) and "written" (journals only) languages. Heroes p57 describes Dead Languages as only written... but then talks about how Khamish is still (with limits) spoken today. Rather than preventing Directors from having NPCs who speak these dead languages, I've marked all languages as "spoken" here.