### PR TITLE
Typo fix: "Vaslorian" EN label

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1586,7 +1586,7 @@
       "Uvalic": "Uvalic",
       "Vaniric": "Vaniric",
       "Variac": "Variac",
-      "Vasloria": "Vasloria",
+      "Vasloria": "Vaslorian",
       "Vastariax": "Vastariax",
       "Vhoric": "Vhoric",
       "Voll": "Voll",


### PR DESCRIPTION
Vasloria is the nation, Vaslorian is the language! Heroes, p56 at the absolute bottom.