### PR TITLE
861 - Censor Feature update for Domain

### DIFF
--- a/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/class_Censor_YuuUbBMSvzN5IPLv.json
+++ b/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/class_Censor_YuuUbBMSvzN5IPLv.json
@@ -91,6 +91,21 @@
           }
         ]
       },
+      "hVDXNXUF3DWZZmR4": {
+        "name": "Deity and Domains",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "hVDXNXUF3DWZZmR4",
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.vwqIB4UTc6ow6mXt"
+          }
+        ],
+        "description": "<p>Your choice of domain determines many of the features you’ll gain from this class. (<em>Quick Build:</em> Cavall as deity and War as domain.)</p>"
+      },
       "kCHtrnGzgDaebhCC": {
         "name": "Features",
         "img": null,
@@ -101,9 +116,6 @@
         "_id": "kCHtrnGzgDaebhCC",
         "description": "<p>You gain the following features.</p>",
         "pool": [
-          {
-            "uuid": "Compendium.draw-steel.classes.Item.vwqIB4UTc6ow6mXt"
-          },
           {
             "uuid": "Compendium.draw-steel.classes.Item.qkj3iQg7Ga2OzXXY"
           },


### PR DESCRIPTION
Updated advancement structure to pull Domain and Deities from Features. Moved to mainline option selection so that quick build text was visible for hero creation.