### PR TITLE
Update Current Stamina based on Max HP Update

### DIFF
--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -283,8 +283,13 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    */
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
-
-    if ((game.userId === userId) && changed.system?.stamina) this.updateStaminaEffects();
+    if (game.userId === userId && changed.system?.stamina) {
+      this.updateStaminaEffects();
+      // Has our maximum stamina been updated? Is our current stamina equal to our max stamina?
+      if (changed.system?.stamina?.max && options.ds?.previousStamina?.max && options.ds.previousStamina.max !== this.stamina.max && this.stamina.value === options.ds.previousStamina.max) {
+        this.parent.update({ "system.stamina.value": this.stamina.max });
+      }
+    }
 
     if (options.ds?.previousStamina && changed.system?.stamina) {
       const stamDiff = options.ds.previousStamina.value - (changed.system.stamina.value || options.ds.previousStamina.value);

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -283,10 +283,10 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    */
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
-    if (game.userId === userId && changed.system?.stamina) {
+    if ((game.userId === userId) && changed.system?.stamina) {
       this.updateStaminaEffects();
       // Has our maximum stamina been updated? Is our current stamina equal to our max stamina?
-      if (changed.system?.stamina?.max && options.ds?.previousStamina?.max && options.ds.previousStamina.max !== this.stamina.max && this.stamina.value === options.ds.previousStamina.max) {
+      if ((changed.system?.stamina?.max && options.ds?.previousStamina?.max) && ((options.ds.previousStamina.max !== this.stamina.max) && (this.stamina.value === options.ds.previousStamina.max))) {
         this.parent.update({ "system.stamina.value": this.stamina.max });
       }
     }


### PR DESCRIPTION
In `0.7.3`, I kept experiencing issues with an actor's current stamina always being set to 20 regardless of how the max stamina was set. This adds some code to adjust the current stamina if the maximum has been changed (and the current stamina has been set to the max).

In my experimenting, also setting temporary stamina didn't update the actor's counter either. I'm happy to address that as well (or make that a separate PR).