### PR TITLE
Adjusted Item metadata

### DIFF
--- a/src/module/data/item/ancestryTrait.mjs
+++ b/src/module/data/item/ancestryTrait.mjs
@@ -10,6 +10,8 @@ export default class AncestryTraitModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "ancestryTrait",
+      invalidActorTypes: ["npc"],
+      packOnly: true,
       detailsPartial: [systemPath("templates/sheets/item/partials/ancestryTrait.hbs")],
     };
   }

--- a/src/module/data/item/complication.mjs
+++ b/src/module/data/item/complication.mjs
@@ -1,15 +1,14 @@
-import AdvancementModel from "./advancement.mjs";
+import FeatureModel from "./feature.mjs";
 
 /**
  * A complication is an optional feature that provides both a positive benefit and a negative drawback.
  */
-export default class ComplicationModel extends AdvancementModel {
+export default class ComplicationModel extends FeatureModel {
   /** @inheritdoc */
   static get metadata() {
     return {
       ...super.metadata,
       type: "complication",
-      packOnly: false,
       invalidActorTypes: ["npc"],
     };
   }

--- a/src/module/data/item/feature.mjs
+++ b/src/module/data/item/feature.mjs
@@ -1,4 +1,3 @@
-import { systemPath } from "../../constants.mjs";
 import AdvancementModel from "./advancement.mjs";
 
 /**
@@ -10,6 +9,7 @@ export default class FeatureModel extends AdvancementModel {
     return {
       ...super.metadata,
       type: "feature",
+      packOnly: false,
       // Not currently in use
       // detailsPartial: [systemPath("templates/sheets/item/partials/feature.hbs")],
     };

--- a/src/module/data/item/perk.mjs
+++ b/src/module/data/item/perk.mjs
@@ -11,7 +11,6 @@ export default class PerkModel extends FeatureModel {
       ...super.metadata,
       type: "perk",
       invalidActorTypes: ["npc"],
-      packOnly: true,
       detailsPartial: [systemPath("templates/sheets/item/partials/perk.hbs")],
     };
   }

--- a/src/module/data/item/perk.mjs
+++ b/src/module/data/item/perk.mjs
@@ -10,6 +10,8 @@ export default class PerkModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "perk",
+      invalidActorTypes: ["npc"],
+      packOnly: true,
       detailsPartial: [systemPath("templates/sheets/item/partials/perk.hbs")],
     };
   }

--- a/src/module/data/item/title.mjs
+++ b/src/module/data/item/title.mjs
@@ -16,7 +16,7 @@ export default class TitleModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "title",
-      packOnly: false,
+      invalidActorTypes: ["npc"],
       detailsPartial: [systemPath("templates/sheets/item/partials/title.hbs")],
     };
   }


### PR DESCRIPTION
- Added `invalidActorTypes` to perks, title, and ancestry traits to prevent them from being added to NPC actors.
- Made ancestry traits pack only
- Adjusted Complications to now also inherit from FeatureModel. That doesn't do much of anything at the moment but will be relevant when features get some usage tracking for #839 which Complications will also want that