### PR TITLE
Level related advancement fixes

### DIFF
--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -478,7 +478,17 @@ export default class HeroModel extends BaseActorModel {
 
     cls = cls ? cls : item;
 
-    await cls.system.applyAdvancements({ actor: this.parent, levels: { start: this.level + 1, end: this.level + levels } });
+    const levelRange = { start: this.level + 1, end: this.level + levels };
+
+    await cls.system.applyAdvancements({ actor: this.parent, levels: levelRange });
+
+    // Quick hack; fix for 0.8.1
+    if (!item) {
+      for (const item of this.parent.items) {
+        if (item !== cls)
+          if (item.supportsAdvancements) await item.system.applyAdvancements({ actor: this.parent, levels: levelRange });
+      }
+    }
 
     return this.class;
   }

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -2,6 +2,10 @@ import BaseAdvancement from "./base-advancement.mjs";
 import DSDialog from "../../../applications/api/dialog.mjs";
 import { systemID } from "../../../constants.mjs";
 
+/**
+ * @import DrawSteelActor from "../../../documents/actor.mjs";
+ */
+
 const { ArrayField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
@@ -176,6 +180,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
   async reconfigure() {
     await super.reconfigure();
 
+    /** @type {DrawSteelActor} */
     const actor = this.document.parent;
 
     const allowed = await ds.applications.api.DSDialog.confirm({
@@ -186,7 +191,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
       content: `<p>${game.i18n.localize("DRAW_STEEL.ADVANCEMENT.Reconfigure.ConfirmItemGrant.Content")}</p>`,
     });
     if (!allowed) return;
-    const chains = [await ds.utils.AdvancementChain.create(this)];
+    const chains = [await ds.utils.AdvancementChain.create(this, null, { end: actor.system.level })];
     const configuration = await ds.applications.apps.advancement.ChainConfigurationDialog.create({
       chains, actor, window: { title: "DRAW_STEEL.ADVANCEMENT.ChainConfiguration.reconfigureTitle" },
     });

--- a/src/module/utils/advancement-chain.mjs
+++ b/src/module/utils/advancement-chain.mjs
@@ -72,21 +72,16 @@ export default class AdvancementChain {
 
   /**
    * Create a new instance of instances of a chain.
-   * @param {BaseAdvancement|foundry.documents.Item} root       An advancement or item with advancements.
+   * @param {BaseAdvancement} root       An advancement or item with advancements.
    * @param {AdvancementChain} [parent]                         Parent chain link.
-   * @param {number} [_depth]                                   Current tree depth.
+   * @param {object} [options={}]                               Additional information about this advancement chain.
+   * @param {number} [options._depth=0]                         Current tree depth.
+   * @param {number} [options.start=null]                       Starting level for advancements.
+   * @param {number} [options.end=1]                            Final level for advancements.
    * @returns {Promise<AdvancementChain|AdvancementChain[]>}    A promise that resolves to the chain or chain link.
    */
-  static async create(root, parent = null, _depth = 0) {
-    if (root instanceof foundry.documents.Item) {
-
-      const chains = [];
-      for (const adv of root.getEmbeddedPseudoDocumentCollection("Advancement")) {
-        const chain = await this.create(adv);
-        chains.push(chain);
-      }
-      return chains;
-    }
+  static async create(root, parent = null, options = {}) {
+    const { _depth: _depth = 0, start: levelStart = null, end: levelEnd = 1 } = options;
 
     const advancement = root;
     const nodeData = {
@@ -122,8 +117,18 @@ export default class AdvancementChain {
 
         // Find any "child" advancements.
         for (const advancement of item.getEmbeddedPseudoDocumentCollection("Advancement")) {
-          choice.children[advancement.uuid] = await AdvancementChain.create(advancement, node, _depth + 1);
-          choice.children[advancement.uuid].parentChoice = choice; // Helps detect if chosen.
+          const validRange = advancement.levels.some(level => {
+            if (Number.isNumeric(level)) return level.between(levelStart ?? 0, levelEnd);
+            else return levelStart === null;
+          });
+          if (validRange) {
+            choice.children[advancement.uuid] = await AdvancementChain.create(advancement, node, {
+              _depth: _depth + 1,
+              start: levelStart,
+              end: levelEnd,
+            });
+            choice.children[advancement.uuid].parentChoice = choice; // Helps detect if chosen.
+          }
         }
       }
     } else if (advancement instanceof TraitAdvancement) {


### PR DESCRIPTION
1. Subsidiary advancements were not being correctly level-gated (e.g. subclass features & abilities)
2. Leveling up did not prompt the subclass advancements