### PR TITLE
[#890] Swap `stamina.value` for `stamina.spent`

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -1033,6 +1033,17 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
   }
 
   /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _processFormData(event, form, formData) {
+    formData = super._processFormData(event, form, formData);
+    if ("value" in (formData.system?.stamina ?? {})) {
+      formData.system.stamina.spent = this.document.system.stamina.max - Number(formData.system.stamina.value);
+    }
+    return formData;
+  }
+
+  /* -------------------------------------------------- */
   /*   Actor Override Handling                          */
   /* -------------------------------------------------- */
 

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -25,7 +25,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     const schema = {};
 
     schema.stamina = new fields.SchemaField({
-      value: new fields.NumberField({ initial: 20, nullable: false, integer: true }),
+      spent: new fields.NumberField({ initial: 0, nullable: false, integer: true, min: 0 }),
       max: new fields.NumberField({ initial: 20, nullable: false, integer: true }),
       temporary: new fields.NumberField({ initial: 0, nullable: false, integer: true }),
     });
@@ -138,8 +138,8 @@ export default class BaseActorModel extends DrawSteelSystemModel {
 
     // Apply all stamina bonuses before calculating winded
     this.stamina.max += this.echelon * this.stamina.bonuses.echelon;
-
     this.stamina.winded = Math.floor(this.stamina.max / 2);
+    this.stamina.value = this.stamina.max - this.stamina.spent;
 
     // Presents better if there's a 0 instead of blank
     this.combat.save.bonus ||= "0";
@@ -475,7 +475,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     staminaUpdates.temporary = Math.max(0, this.stamina.temporary - damageToTempStamina);
 
     const remainingDamage = Math.max(0, damage - damageToTempStamina);
-    if (remainingDamage > 0) staminaUpdates.value = this.stamina.value - remainingDamage;
+    if (remainingDamage > 0) staminaUpdates.spent = this.stamina.spent + remainingDamage;
 
     return this.parent.update({ "system.stamina": staminaUpdates }, damageTypeOption);
   }

--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -287,7 +287,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     if ((game.userId === userId) && changed.system?.stamina) this.updateStaminaEffects();
 
     if (options.ds?.previousStamina && changed.system?.stamina) {
-      const stamDiff = options.ds.previousStamina.value - (changed.system.stamina.value || options.ds.previousStamina.value);
+      const stamDiff = (changed.system.stamina.spent || options.ds.previousStamina.spent) - options.ds.previousStamina.spent;
       const tempDiff = options.ds.previousStamina.temporary - (changed.system.stamina.temporary || options.ds.previousStamina.temporary);
       const diff = stamDiff + tempDiff;
       this.displayStaminaChange(diff, options.ds.damageType);

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -36,7 +36,7 @@ export default class HeroModel extends BaseActorModel {
     const schema = super.defineSchema();
 
     schema.stamina = new fields.SchemaField({
-      value: new fields.NumberField({ initial: 20, nullable: false, integer: true }),
+      spent: new fields.NumberField({ initial: 0, nullable: false, integer: true, min: 0 }),
       temporary: new fields.NumberField({ initial: 0, nullable: false, integer: true }),
     }, { trackedAttribute: true });
 
@@ -265,7 +265,7 @@ export default class HeroModel extends BaseActorModel {
           xp: this.hero.xp + this.hero.victories,
         },
         stamina: {
-          value: this.stamina.max,
+          spent: 0,
         },
       },
     });

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -94,7 +94,8 @@ export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.
     if (update === current) return this;
 
     // Determine the updates to make to the actor data
-    const updates = { "system.stamina.value": Math.clamp(update, this.system.stamina.min, this.system.stamina.max) };
+    const spent = this.system.stamina.max - Math.clamp(update, this.system.stamina.min, this.system.stamina.max);
+    const updates = { "system.stamina.spent": spent };
 
     // Allow a hook to override these changes
     const allowed = Hooks.call("modifyTokenAttribute", { attribute, value, isDelta, isBar }, updates, this);

--- a/templates/sheets/actor/hero-sheet/stats.hbs
+++ b/templates/sheets/actor/hero-sheet/stats.hbs
@@ -29,12 +29,12 @@
           }}
         </div>
         <div class="resource-current">
-          {{formGroup
-          systemFields.stamina.fields.value
-          value=system.stamina.value
-          dataset=datasets.notSource
-          classes="stacked"
-          }}
+          <div class="form-group stacked">
+            <label>{{localize "DRAW_STEEL.Actor.base.FIELDS.stamina.value.label"}}</label>
+            <div class="form-fields">
+              <input type="number" name="system.stamina.value" value="{{system.stamina.value}}">
+            </div>
+          </div>
         </div>
         <span class="resource-max">
           <div class="form-group stacked">

--- a/templates/sheets/actor/npc/stats.hbs
+++ b/templates/sheets/actor/npc/stats.hbs
@@ -27,12 +27,12 @@
             label=(localize "TYPES.CombatantGroup.squad")
             }}
             {{else}}
-            {{formGroup
-            systemFields.stamina.fields.value
-            value=system.stamina.value
-            dataset=datasets.notSource
-            classes="paired"
-            }}
+            <div class="form-group paired">
+              <label>{{localize "DRAW_STEEL.Actor.base.FIELDS.stamina.value.label"}}</label>
+              <div class="form-fields">
+                <input type="number" name="system.stamina.value" value="{{system.stamina.value}}">
+              </div>
+            </div>
             {{/if}}
           </div>
           {{/if}}


### PR DESCRIPTION
Removes `stamina.value` in favor of `stamina.spent`, which has a minimum and initial value of `0`, and no maximum value.

The `spent` property is not capped by `stamina.max`, allowing for damage to overflow as before.

Token attribute bars were tested and should already work.

The base actor sheet processes `system.stamina.value` in the form data to map to `system.stamina.spent`.

The result is that if you have lost X stamina, and your maximum changes, the difference between the maximum and your current stamina is still X. This is easy to verify on an npc actor.

Closes #890.