### PR TITLE
Implemented "Self or one creature" targeting option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
   - If set to "Roll for Event", a roll button will appear in the chat message.
   - If set to "Event Milestones", if an event milestone is reached, text will indicate the number of milestones reached.
 - Added name and image inputs to Power Roll Effect creation. (#718)
-- Added "Self or Ally" and "Self and Allies" targeting options.
+- Added "Self or ally", "Self and allies", and "Self or one creature" targeting options. (#872)
 - When a project roll is a breakthrough, a button will appear to roll the project again.
 - The Source Information popout will show the Compendium Source of an item if it is available.
 - Added a generic "spend hero token" option available to all users.

--- a/lang/en.json
+++ b/lang/en.json
@@ -770,8 +770,9 @@
           "AllyEmbed": "{value} allies",
           "AllAllies": "All allies",
           "Self": "Self",
-          "SelfOrAlly": "Self or one Ally",
-          "SelfAlly": "Self and Allies",
+          "SelfOrAlly": "Self or one ally",
+          "SelfOrCreature": "Self or one creature",
+          "SelfAlly": "Self and allies",
           "AllSelfAllies": "Self and each ally",
           "SelfAllyEmbed": "Self and {value} allies",
           "Special": "Special"

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1235,6 +1235,10 @@ const abilityTargets = {
     label: "DRAW_STEEL.Item.ability.Target.SelfOrAlly",
     embedLabel: "DRAW_STEEL.Item.ability.Target.SelfOrAlly",
   },
+  selfOrCreature: {
+    label: "DRAW_STEEL.Item.ability.Target.SelfOrCreature",
+    embedLabel: "DRAW_STEEL.Item.ability.Target.SelfOrCreature",
+  },
   selfAlly: {
     label: "DRAW_STEEL.Item.ability.Target.SelfAlly",
     all: "DRAW_STEEL.Item.ability.Target.AllSelfAllies",

--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Core_roGg2qsPifapFQEN/ability_Lines_of_Force_6JirKNIULN4f4Ii0.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Core_roGg2qsPifapFQEN/ability_Lines_of_Force_6JirKNIULN4f4Ii0.json
@@ -27,7 +27,7 @@
     },
     "damageDisplay": "melee",
     "target": {
-      "type": "selfOrAlly"
+      "type": "selfOrCreature"
     },
     "power": {
       "roll": {
@@ -37,7 +37,7 @@
       "effects": {}
     },
     "effect": {
-      "before": "<p>Note: This ability should be listed as <strong>'Self or One Creature'</strong></p><p>You can select a new target of the same size or smaller within distance to be force moved instead. You become the source of the forced movement, determine the new target’s destination, and can push the target instead of using the original forced movement type. Additionally, the forced movement distance gains a bonus equal to your Might score.</p>",
+      "before": "<p>You can select a new target of the same size or smaller within distance to be force moved instead. You become the source of the forced movement, determine the new target’s destination, and can push the target instead of using the original forced movement type. Additionally, the forced movement distance gains a bonus equal to your Might score.</p>",
       "after": ""
     },
     "spend": {

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Core_iexBQBs46QdCPaeD/Chronopathy_6FyJBW2D9ZCcMO4l/ability_Accelerate_dmk0jCUh8JaKmQas.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Core_iexBQBs46QdCPaeD/Chronopathy_6FyJBW2D9ZCcMO4l/ability_Accelerate_dmk0jCUh8JaKmQas.json
@@ -27,7 +27,7 @@
     },
     "damageDisplay": "melee",
     "target": {
-      "type": "selfOrAlly"
+      "type": "selfOrCreature"
     },
     "power": {
       "roll": {
@@ -37,7 +37,7 @@
       "effects": {}
     },
     "effect": {
-      "before": "<p>Note: Self and One Creature.</p><p>The target shifts up to a number of squares equal to your Reason score.</p>",
+      "before": "<p>The target shifts up to a number of squares equal to your Reason score.</p>",
       "after": ""
     },
     "spend": {

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Core_iexBQBs46QdCPaeD/Chronopathy_6FyJBW2D9ZCcMO4l/ability_Again_zy367OiF8Di2eiQx.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Core_iexBQBs46QdCPaeD/Chronopathy_6FyJBW2D9ZCcMO4l/ability_Again_zy367OiF8Di2eiQx.json
@@ -27,7 +27,7 @@
     },
     "damageDisplay": "melee",
     "target": {
-      "type": "creature",
+      "type": "selfOrCreature",
       "value": 1
     },
     "power": {
@@ -38,7 +38,7 @@
       "effects": {}
     },
     "effect": {
-      "before": "<p>Note: Self or one creature</p><p>You can use this ability after seeing the result of the triggering roll. The target must reroll the power roll and use the new roll.</p>",
+      "before": "<p>You can use this ability after seeing the result of the triggering roll. The target must reroll the power roll and use the new roll.</p>",
       "after": ""
     },
     "spend": {


### PR DESCRIPTION
While I recognize that we may want to refactor in the future, that's an 0.9 problem. This PR addresses the three abilities that actually have this targeting structure.

Closes #872