### PR TITLE
Set `stamina.value` to be derived from `stamina.max` while it is undefined

### DIFF
--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -26,7 +26,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     const schema = {};
 
     schema.stamina = new fields.SchemaField({
-      value: new fields.NumberField({ initial: 20, nullable: false, integer: true }),
+      value: new fields.NumberField({ initial: null, nullable: true, integer: true }),
       max: new fields.NumberField({ initial: 20, nullable: false, integer: true }),
       temporary: new fields.NumberField({ initial: 0, nullable: false, integer: true }),
     });
@@ -154,6 +154,10 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     // Apply all stamina bonuses before calculating winded
     this.stamina.max += this.echelon * this.stamina.bonuses.echelon;
     this.stamina.max += this.level * this.stamina.bonuses.level;
+
+    // If our current stamina has not been set, match it to max:
+    this.stamina.value ??= this.stamina.max;
+
     this.stamina.winded = Math.floor(this.stamina.max / 2);
 
     // Presents better if there's a 0 instead of blank


### PR DESCRIPTION
Possible fix for #890.

Currently this sets `stamina.value` to `undefined` initially, and matches it to `stamina.max` if it is still set to `undefined`.