### PR TITLE
New classes start with null instead of 1

### DIFF
--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -486,10 +486,9 @@ export default class HeroModel extends BaseActorModel {
       throw new Error(`A hero cannot advance beyond level ${ds.CONFIG.hero.xp_track.length}.`);
     }
 
-    const levelRange = { start: this.level + 1, end: this.level + levels };
-
-    if (!cls) item.system.applyAdvancements({ actor: this.parent, levels: levelRange });
+    if (!cls) item.system.applyAdvancements({ actor: this.parent });
     else {
+      const levelRange = { start: this.level + 1, end: this.level + levels };
       const chains = (await Promise.all(this.parent.items.map(i => {
         if (i.supportsAdvancements) return i.system.createChains(levelRange.start, levelRange.end);
         return [];

--- a/src/module/data/item/class.mjs
+++ b/src/module/data/item/class.mjs
@@ -88,7 +88,7 @@ export default class ClassModel extends AdvancementModel {
   }
 
   /** @inheritdoc */
-  async applyAdvancements({ actor, levels = { start: 1, end: 1 }, toCreate = {}, toUpdate = {}, ...options } = {}) {
+  async applyAdvancements({ actor, levels = { start: null, end: 1 }, toCreate = {}, toUpdate = {}, ...options } = {}) {
     const { end: levelEnd = 1 } = levels;
 
     const _idMap = new Map();

--- a/src/module/utils/advancement-chain.mjs
+++ b/src/module/utils/advancement-chain.mjs
@@ -119,7 +119,7 @@ export default class AdvancementChain {
         // Find any "child" advancements.
         for (const advancement of item.getEmbeddedPseudoDocumentCollection("Advancement")) {
           const validRange = advancement.levels.some(level => {
-            if (Number.isNumeric(level)) return level.between(levelStart ?? 0, levelEnd);
+            if (Number.isNumeric(level)) return level.between(levelStart, levelEnd);
             else return levelStart === null;
           });
           if (validRange) {


### PR DESCRIPTION
Kit abilities are granted at `level: null`, and rather than adjust all that data I believe starting a new class with `null` instead of `1` was more effective.

Closes #934 