### PR TITLE
Various Documentation Fixes

### DIFF
--- a/src/module/applications/api/pseudo-document-sheet.mjs
+++ b/src/module/applications/api/pseudo-document-sheet.mjs
@@ -73,7 +73,7 @@ export default class PseudoDocumentSheet extends HandlebarsApplicationMixin(Appl
 
   /**
    * Retrieve or register a new instance of a pseudo-document sheet.
-   * @param {ds.data.pseudoDocuments.PseudoDocument} pseudoDocument   The pseudo-document.
+   * @param {PseudoDocument} pseudoDocument   The pseudo-document.
    * @returns {PseudoDocumentSheet|null}    An existing or new instance of a sheet, or null if the pseudo-
    *                                        document does not have a sheet class.
    */

--- a/src/module/applications/hooks/combatantConfig.mjs
+++ b/src/module/applications/hooks/combatantConfig.mjs
@@ -1,6 +1,8 @@
-/** @import DrawSteelCombatant from "../../documents/combatant.mjs" */
-/** @import { ApplicationRenderOptions } from "@client/applications/_types.mjs" */
-/** @import CombatantConfig from "@client/applications/sheets/combatant-config.mjs" */
+/**
+ * @import DrawSteelCombatant from "../../documents/combatant.mjs";
+ * @import { ApplicationRenderOptions } from "@client/applications/_types.mjs";
+ * @import CombatantConfig from "@client/applications/sheets/combatant-config.mjs";
+ */
 
 /**
  * A hook event that fires when the CombatantConfig application is rendered.

--- a/src/module/applications/sheets/npc.mjs
+++ b/src/module/applications/sheets/npc.mjs
@@ -2,8 +2,10 @@ import { systemID, systemPath } from "../../constants.mjs";
 import DrawSteelActorSheet from "./actor-sheet.mjs";
 import { DocumentSourceInput, MonsterMetadataInput } from "../apps/_module.mjs";
 
-/** @import { FormSelectOption } from "@client/applications/forms/fields.mjs" */
-/** @import DrawSteelActor from "../../documents/actor.mjs"; */
+/**
+ * @import { FormSelectOption } from "@client/applications/forms/fields.mjs";
+ * @import DrawSteelActor from "../../documents/actor.mjs";
+ */
 
 export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
   /** @inheritdoc */

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -1,8 +1,10 @@
 import { systemID, systemPath } from "../../../constants.mjs";
 import { DrawSteelCombatant, DrawSteelCombatantGroup } from "../../../documents/_module.mjs";
 
-/** @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs" */
-/** @import DrawSteelActor from "../../../documents/actor.mjs" */
+/**
+ * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs";
+ * @import DrawSteelActor from "../../../documents/actor.mjs";
+ */
 
 const { ux, sidebar } = foundry.applications;
 

--- a/src/module/applications/ui/players.mjs
+++ b/src/module/applications/ui/players.mjs
@@ -1,8 +1,10 @@
 import { systemID, systemPath } from "../../constants.mjs";
 
-/** @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs" */
-/** @import { HeroTokenModel } from "../../data/settings/hero-tokens.mjs"; */
-/** @import { MaliceModel } from "../../data/settings/malice.mjs"; */
+/**
+ * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs";
+ * @import { HeroTokenModel } from "../../data/settings/hero-tokens.mjs";
+ * @import { MaliceModel } from "../../data/settings/malice.mjs";
+ */
 
 /**
  * An extension of the core Players display that adds controls for hero tokens and malice.

--- a/src/module/applications/ux/enrichers/roll.mjs
+++ b/src/module/applications/ux/enrichers/roll.mjs
@@ -1,9 +1,11 @@
-/** @import { TextEditorEnricher, TextEditorEnricherConfig } from "@client/config.mjs" */
-/** @import HTMLEnrichedContentElement from "@client/applications/elements/enriched-content.mjs" */
-
 import DrawSteelChatMessage from "../../../documents/chat-message.mjs";
 import { DSRoll, DamageRoll } from "../../../rolls/_module.mjs";
 import DSDialog from "../../api/dialog.mjs";
+
+/**
+ * @import { TextEditorEnricher, TextEditorEnricherConfig } from "@client/config.mjs";
+ * @import HTMLEnrichedContentElement from "@client/applications/elements/enriched-content.mjs";
+ */
 
 /**
  * Implementation logic for all roll-style enrichers.

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -1,5 +1,7 @@
-/** @import DrawSteelTokenDocument from "../../documents/token.mjs" */
-/** @import { Point } from "@common/_types.mjs" */
+/**
+ * @import DrawSteelTokenDocument from "../../documents/token.mjs";
+ * @import { Point } from "@common/_types.mjs";
+ */
 
 /**
  * A Placeable Object subclass adding system-specific behavior and registered in CONFIG.Token.objectClass.

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -1,8 +1,10 @@
 import { systemPath } from "../../../constants.mjs";
 
-/** @import { TokenMovementActionConfig, TokenRulerWaypoint } from "@client/_types.mjs" */
-/** @import { DeepReadonly } from "@common/_types.mjs" */
-/** @import DrawSteelTokenDocument from "../../../documents/token.mjs"; */
+/**
+ * @import { TokenMovementActionConfig, TokenRulerWaypoint } from "@client/_types.mjs";
+ * @import { DeepReadonly } from "@common/_types.mjs";
+ * @import DrawSteelTokenDocument from "../../../documents/token.mjs";
+ */
 
 /**
  * Draw Steel implementation of the core token ruler.

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -3,10 +3,12 @@ import { requiredInteger, setOptions } from "../helpers.mjs";
 import BaseActorModel from "./base.mjs";
 import SourceModel from "../models/source.mjs";
 
-/** @import DrawSteelItem from "../../documents/item.mjs"; */
-/** @import AbilityModel from "../item/ability.mjs"; */
-/** @import { MaliceModel } from "../settings/_module.mjs"; */
-/** @import DamagePowerRollEffect from "../pseudo-documents/power-roll-effects/damage-effect.mjs"; */
+/**
+ * @import DrawSteelItem from "../../documents/item.mjs";
+ * @import AbilityModel from "../item/ability.mjs";
+ * @import { MaliceModel } from "../settings/_module.mjs";
+ * @import DamagePowerRollEffect from "../pseudo-documents/power-roll-effects/damage-effect.mjs";
+ */
 
 /**
  * NPCs are created and controlled by the director.

--- a/src/module/data/message/saving-throw.mjs
+++ b/src/module/data/message/saving-throw.mjs
@@ -1,7 +1,9 @@
 import BaseMessageModel from "./base.mjs";
 
-/** @import { SavingThrowRoll } from "../../rolls/saving-throw.mjs" */
-/** @import DrawSteelActiveEffect from "../../documents/active-effect.mjs"; */
+/**
+ * @import { SavingThrowRoll } from "../../rolls/saving-throw.mjs";
+ * @import DrawSteelActiveEffect from "../../documents/active-effect.mjs";
+ */
 
 const fields = foundry.data.fields;
 

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -1,8 +1,10 @@
 import FormulaField from "../../fields/formula-field.mjs";
 import TypedPseudoDocument from "../typed-pseudo-document.mjs";
 
-/** @import { DataSchema } from "@common/abstract/_types.mjs" */
-/** @import { DrawSteelActor, DrawSteelItem } from "../../../documents/_module.mjs"; */
+/**
+ * @import { DataSchema } from "@common/abstract/_types.mjs";
+ * @import { DrawSteelActor, DrawSteelItem } from "../../../documents/_module.mjs";
+ */
 
 const { SchemaField, StringField } = foundry.data.fields;
 

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -1,7 +1,10 @@
 import TargetedConditionPrompt from "../applications/apps/targeted-condition-prompt.mjs";
 
-/** @import { StatusEffectConfig } from "@client/config.mjs" */
-/** @import DrawSteelActor from "./actor.mjs"; */
+/**
+ * @import { StatusEffectConfig } from "@client/config.mjs";
+ * @import { ActiveEffectDuration, EffectDurationData } from "../data/effect/_types";
+ * @import DrawSteelActor from "./actor.mjs";
+ */
 
 /**
  * A document subclass adding system-specific behavior and registered in CONFIG.ActiveEffect.documentClass.
@@ -89,8 +92,6 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
   }
 
   /* -------------------------------------------------- */
-
-  /** @import { ActiveEffectDuration, EffectDurationData } from "../data/effect/_types" */
 
   /**
    * Compute derived data related to active effect duration.

--- a/src/module/documents/combatant-group.mjs
+++ b/src/module/documents/combatant-group.mjs
@@ -1,4 +1,4 @@
-/** @import { CombatantGroupData } from "@common/types.mjs"; */
+/** @import { CombatantGroupData } from "@common/documents/_types.mjs"; */
 
 /**
  * A document subclass adding system-specific behavior and registered in CONFIG.CombatantGroup.documentClass.

--- a/src/module/helpers/_module.mjs
+++ b/src/module/helpers/_module.mjs
@@ -1,5 +1,5 @@
 export * from "./dsn.mjs";
-export * from "./hotReload.mjs";
+export * from "./hot-reload.mjs";
 export * from "./handlebars.mjs";
 export * as macros from "./macros.mjs";
 export * as localization from "./localization.mjs";

--- a/src/module/helpers/dsn.mjs
+++ b/src/module/helpers/dsn.mjs
@@ -1,5 +1,7 @@
-/** @import DrawSteelUser from "../documents/user.mjs"; */
-/** @import DSRoll from "../rolls/base.mjs"; */
+/**
+ * @import DrawSteelUser from "../documents/user.mjs";
+ * @import DSRoll from "../rolls/base.mjs";
+ */
 
 /**
  * Called when a 3D roll starts from the hook of the Chat message or when showForRoll is called directly from the API.

--- a/src/module/helpers/hot-reload.mjs
+++ b/src/module/helpers/hot-reload.mjs
@@ -1,6 +1,6 @@
 import { systemPath } from "../constants.mjs";
 
-/** @import {HotReloadData} from "@client/types.mjs" */
+/** @import {HotReloadData} from "@client/_types.mjs" */
 
 /**
  * A hook event that fires when a package that is being watched by the hot reload system has a file changed.
@@ -14,7 +14,7 @@ export function hotReload(data) {
   // Possible need to update this if we add other languages into the base system
   if (data.path === systemPath("lang/en.json")) {
     // Hook is called *before* i18n is updated so need to wait for that to resolve
-    // Can be removed if https://github.com/foundryvtt/foundryvtt/issues/11762 is implemented
+    // Revisit in v14 vis a vis https://github.com/foundryvtt/foundryvtt/issues/13285
     queueMicrotask(() => {
       // Repeat the i18n process from Localization.#localizeDataModels
       for (const documentName of CONST.ALL_DOCUMENT_TYPES) {

--- a/src/module/helpers/settings.mjs
+++ b/src/module/helpers/settings.mjs
@@ -1,7 +1,7 @@
 import { systemID } from "../constants.mjs";
 import { HeroTokenModel, MaliceModel } from "../data/settings/_module.mjs";
 
-/** @import { SettingConfig } from "@common/types.mjs" */
+/** @import { SettingConfig } from "@client/_types.mjs" */
 
 const fields = foundry.data.fields;
 

--- a/system.json
+++ b/system.json
@@ -232,7 +232,7 @@
   ],
   "socket": true,
   "manifest": "https://raw.githubusercontent.com/MetaMorphic-Digital/draw-steel/refs/heads/main/system.json",
-  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.8.0/draw-steel-release-0.8.0.zip",
+  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.8.1/draw-steel-release-0.8.1.zip",
   "background": "systems/draw-steel/assets/anvil-impact.png",
   "grid": {
     "type": 1,


### PR DESCRIPTION
- multiple lines of type imports are now using block imports
- fixed various type imports broken by v13 adjustments
- renamed hotReload.mjs to hot-reload.mjs to fit overall file naming conventions