### PR TITLE
Bugfix: Talent's Distance Augmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@
 
 ### Changed
 
+- The skill list on the character sheet is now sorted alphabetically.
+
 ### Fixed
 
 - Fixed an issue where the migration would error when migrating personal compendiums.
+- Compendium data fixes
+  - Corrected Talent "Distance Augmentation" filters & bonus
 
 ## 0.8.0
 

--- a/src/packs/classes/Talent_Q4pvMWEIONrsqHp0/Features_oBlC3EZdWggPWyRn/Psionic_Augmentations_1b95uSyyQlEuFh6G/feature_Distance_Augmentation_mwwEAQ5s5j8sBr1s.json
+++ b/src/packs/classes/Talent_Q4pvMWEIONrsqHp0/Features_oBlC3EZdWggPWyRn/Psionic_Augmentations_1b95uSyyQlEuFh6G/feature_Distance_Augmentation_mwwEAQ5s5j8sBr1s.json
@@ -41,7 +41,7 @@
         {
           "key": "distance",
           "mode": 2,
-          "value": "1",
+          "value": "2",
           "priority": null
         }
       ],

--- a/src/packs/classes/Talent_Q4pvMWEIONrsqHp0/Features_oBlC3EZdWggPWyRn/Psionic_Augmentations_1b95uSyyQlEuFh6G/feature_Distance_Augmentation_mwwEAQ5s5j8sBr1s.json
+++ b/src/packs/classes/Talent_Q4pvMWEIONrsqHp0/Features_oBlC3EZdWggPWyRn/Psionic_Augmentations_1b95uSyyQlEuFh6G/feature_Distance_Augmentation_mwwEAQ5s5j8sBr1s.json
@@ -32,7 +32,7 @@
         },
         "filters": {
           "keywords": [
-            "magic",
+            "psionic",
             "ranged"
           ]
         }


### PR DESCRIPTION
According to the text:

> Your ranged psionic abilities gain a +2 bonus to distance.

Changed the "Magic" Tag to "Psionic", and the bonus to +2