### PR TITLE
[#996] Fix level up button not showing unless XP is more than next level XP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   - Various monster role and level fixes. (#981)
   - Corrected Talent "Distance Augmentation" filters & bonus.
 - Fixed combatant groups turns not resetting on new round. (#991)
+- Fixed level up button not showing unless XP exceeded the next level XP. (#996)
 
 ## 0.8.0
 

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -448,7 +448,7 @@ export default class HeroModel extends BaseActorModel {
    * @type {boolean}
    */
   get advancementReady() {
-    return this.hero.xp > (this.nextLevelXP ?? Infinity);
+    return this.hero.xp >= (this.nextLevelXP ?? Infinity);
   }
 
   /* -------------------------------------------------- */


### PR DESCRIPTION
Closes #996 