### PR TITLE
Ogre Goon fixes

### DIFF
--- a/src/packs/monsters/Giant_mKoQH5eH9bOQmkFl/npc_Ogre_Goon_c9ltn5pwCDDrXdaa.json
+++ b/src/packs/monsters/Giant_mKoQH5eH9bOQmkFl/npc_Ogre_Goon_c9ltn5pwCDDrXdaa.json
@@ -40,7 +40,7 @@
       "turns": 1
     },
     "biography": {
-      "value": "<p></p>",
+      "value": "",
       "director": "",
       "languages": []
     },
@@ -478,7 +478,7 @@
       "name": "Grabby Hand",
       "type": "ability",
       "system": {
-        "type": "main",
+        "type": "maneuver",
         "source": {
           "book": "Monsters",
           "page": "210",
@@ -616,9 +616,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.348",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.0",
+        "systemVersion": "0.8.1",
         "lastModifiedBy": null,
         "modifiedTime": null
       },
@@ -643,7 +643,7 @@
           "weapon"
         ],
         "category": "heroic",
-        "resource": 1,
+        "resource": 3,
         "trigger": "",
         "distance": {
           "type": "line",
@@ -762,9 +762,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.348",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.0",
+        "systemVersion": "0.8.1",
         "lastModifiedBy": null,
         "modifiedTime": null
       },
@@ -1149,9 +1149,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.348",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.8.1",
     "createdTime": 1755922148660,
     "modifiedTime": null,
     "lastModifiedBy": null


### PR DESCRIPTION
noticed that the Ogre goon had a few mistakes while running it today which I have fixed.

- Grabby Hand is a Maneuver, not Main Action
- People Bowling is 3 Malice, not 1