### PR TITLE
[#973] Add combat group visibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -638,7 +638,8 @@
         "SquadOneCaptain": "A squad can only have one captain.",
         "MinionNoSquad": "Applying damage directly to a minion because it's not in a squad.",
         "TooManySquad": "Applying damage directly to a minion because it's in multiple squads."
-      }
+      },
+      "ToggleVisibility": "Toggle Visibility"
     },
     "Item": {
       "Tabs": {

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -121,6 +121,8 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
     const invertedDisposition = foundry.utils.invertObject(CONST.TOKEN_DISPOSITIONS);
 
     context.groupTurns = combat?.groups.reduce((acc, cg) => {
+      if (!cg.visible) return acc;
+
       const { _expanded, id, name, isOwner, defeated: isDefeated, hidden, disposition, initiative, img } = cg;
       const turns = groups[id] ?? [];
       const active = turns.some(t => t.id === currentTurn?.id);

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -424,6 +424,16 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
           },
         }).render({ force: true }),
       },
+      {
+        name: "DRAW_STEEL.CombatantGroup.ToggleVisibility",
+        icon: "<i class=\"fa-solid fa-eye-slash\"></i>",
+        condition: li => game.user.isGM && getCombatantGroup(li).members.size,
+        callback: li => {
+          const combatantGroup = getCombatantGroup(li);
+          const updates = Array.from(combatantGroup.members).map(member => ({ _id: member.id, hidden: !combatantGroup.hidden }));
+          combatantGroup.parent.updateEmbeddedDocuments("Combatant", updates);
+        },
+      },
     ];
   }
 

--- a/src/module/documents/combatant-group.mjs
+++ b/src/module/documents/combatant-group.mjs
@@ -145,4 +145,14 @@ export default class DrawSteelCombatantGroup extends foundry.documents.Combatant
     // Provide a default image
     if (!data.img) this.updateSource(this.constructor.getDefaultArtwork(data));
   }
+
+  /** @inheritdoc */
+  get hidden () {
+    return !this.members?.size || this.members.every(member => member.hidden);
+  }
+
+  /** @inheritdoc */
+  get visible () {
+    return this.isOwner || !this.hidden;
+  }
 }

--- a/src/styles/system/applications/sidebar/tabs/combat.css
+++ b/src/styles/system/applications/sidebar/tabs/combat.css
@@ -57,7 +57,12 @@
       &:not(.expanded) .group-turns {
         display: none;
       }
+      &.hide .group-header {
+        color: var(--color-text-subtle);
+        img {
+          opacity: 0.3;
+        }
+      }
     }
   }
-
 }


### PR DESCRIPTION
Closes #973 

- `foundry.documents.CombatantGroup` sets `hidden` as a property on the class and then sets it during data prep. I've overridden `hidden` as a getter instead. I'm not sure if that's acceptable practice or not.
- Copied the CSS for hidden combatant.