### PR TITLE
[#1054] Add damage/heal modification dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added Combatant Group tracker visibility controls. (#973)
   - If all combatants in a group are hidden, the group is hidden.
   - Added context menu option to quickly hide/unhide each combatant in the group.
+- Added an Alt-Click option on the Apply Damage/Heal buttons to allow modifying damage/heal amount and damage type before applying. (#1054)
 
 ### Changed
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1442,6 +1442,21 @@
             "Label": "Success Threshold"
           }
         }
+      },
+      "Damage": {
+        "ModificationDialog": {
+          "DamageFormula": {
+            "Label": "Damage Formula"
+          },
+          "DamageType": {
+            "Label": "Damage Type"
+          },
+          "Title": {
+            "Damage": "Damage Modification Dialog",
+            "Heal": "Healing Modification Dialog"
+          },
+          "Apply": "Apply Modification"
+        }
       }
     },
     "Setting": {
@@ -1637,12 +1652,12 @@
         "Buttons": {
           "ApplyHeal": {
             "Label": "Regain {amount} {type}",
-            "Tooltip": "Shift+Click: Halve Heal",
+            "Tooltip": "Shift+Click: Halve Heal<br>Alt+Click: Modify Heal",
             "TempCapped": "{name} already has more temporary Stamina"
           },
           "ApplyDamage": {
             "Label": "Apply {amount}{type} Damage",
-            "Tooltip": "Shift+Click: Halve Damage"
+            "Tooltip": "Shift+Click: Halve Damage<br>Alt+Click: Modify Damage"
           }
         }
       },


### PR DESCRIPTION
Closes #1054 

I'm not sure if how I'm grabbing the old roll data is the best way to do it. Core doesn't save the roll data when the chat message is created, so I'm having to grab it from the ability or the message. One way to easily solve this would be to override `DamageRoll#toJSON` to include the the roll data, but I wasn't sure if that was desirable or not.

I'm creating the new damage roll as a message just so that it's clear what new damage/heal total will be post modification.