### PR TITLE
#780 - Quick Fixes for two E1 Titles

### DIFF
--- a/src/packs/rewards/Titles_NPrextZBfLXyWrwH/1st_Echelon_M0xNtYu0IzR83TAL/Grants_boCFMPsgL0Py8wzo/feature_Deep_Sea_Diver_pBygpYvbzBFDs263.json
+++ b/src/packs/rewards/Titles_NPrextZBfLXyWrwH/1st_Echelon_M0xNtYu0IzR83TAL/Grants_boCFMPsgL0Py8wzo/feature_Deep_Sea_Diver_pBygpYvbzBFDs263.json
@@ -49,7 +49,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "<p>While adjacent to two or more allies, you gain a +2 bonus to stability</p>",
+      "description": "<p>You can automatically swim at full speed while moving.</p>",
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],

--- a/src/packs/rewards/Titles_NPrextZBfLXyWrwH/1st_Echelon_M0xNtYu0IzR83TAL/title_Doomed_5k9wFhlhSZ8UsAs2.json
+++ b/src/packs/rewards/Titles_NPrextZBfLXyWrwH/1st_Echelon_M0xNtYu0IzR83TAL/title_Doomed_5k9wFhlhSZ8UsAs2.json
@@ -20,7 +20,7 @@
     "echelon": 1,
     "story": "I don’t know what it meant, but when I watched her die, I saw a vision. I watched her die and saw my own death. Am I losing my mind?",
     "prerequisites": {
-      "value": "ou aren’t a hakaan but have witnessed the death of a hakaan."
+      "value": "You aren’t a hakaan but have witnessed the death of a hakaan."
     }
   },
   "effects": [


### PR DESCRIPTION
Deep-Sea Diver and Doomed had some incorrect text, part of #1073 for E1 titles.