### PR TITLE
[#1087] Remove invalid roles from leader and solo monsters and harden template against missing roles/organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 - Addressed ProseMirror deprecation warning. (#1080)
 - Fixed ability bonuses to strikes that don't specify melee or ranged not giving damage bonuses. (#1086)
 - Fixed some broken labels & css from the equipment => treasure rename.
+- Removed invalid roles from leaders and solo monsters. (#1087)
+  - Improved monster tag templates to filter out invalid roles and organizations to prevent blank tags.
 
 ## 0.8.0
 

--- a/src/packs/monsters/Ashen_Hoarder_GXX2DnZcth3KWFfL/npc_Ashen_Hoarder_EwN0CLt7UmEzQA0J.json
+++ b/src/packs/monsters/Ashen_Hoarder_GXX2DnZcth3KWFfL/npc_Ashen_Hoarder_EwN0CLt7UmEzQA0J.json
@@ -98,7 +98,7 @@
       ],
       "level": 4,
       "ev": 72,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Bredbeddle_O7zizfGvMA07rRKX/npc_Bredbeddle_wzvNh7FYggjoU6Hv.json
+++ b/src/packs/monsters/Bredbeddle_O7zizfGvMA07rRKX/npc_Bredbeddle_wzvNh7FYggjoU6Hv.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 60,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Bredbeddle_O7zizfGvMA07rRKX/npc_Phantom_Bredbeddle_gYUnLS5eDPZZtcGA.json
+++ b/src/packs/monsters/Bredbeddle_O7zizfGvMA07rRKX/npc_Phantom_Bredbeddle_gYUnLS5eDPZZtcGA.json
@@ -97,7 +97,7 @@
       ],
       "level": 3,
       "ev": 60,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Chimera_kgEKDnLbyyQ3RtLK/npc_Chimera_yMkWRu1AYXU4ukn1.json
+++ b/src/packs/monsters/Chimera_kgEKDnLbyyQ3RtLK/npc_Chimera_yMkWRu1AYXU4ukn1.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 60,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___1st_Echelon_6DKl8v5ROTdmTFsZ/npc_Chorogaunt_GqufFfTfLOy6sHxx.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___1st_Echelon_6DKl8v5ROTdmTFsZ/npc_Chorogaunt_GqufFfTfLOy6sHxx.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 20,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Dragons_1xAB7dzxBYqdc7qX/npc_Thorn_Dragon_s8Dvj26hssemdUrw.json
+++ b/src/packs/monsters/Dragons_1xAB7dzxBYqdc7qX/npc_Thorn_Dragon_s8Dvj26hssemdUrw.json
@@ -98,7 +98,7 @@
       ],
       "level": 2,
       "ev": 48,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Marauder_STHK2rkTd1XJ0og0.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Marauder_STHK2rkTd1XJ0og0.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 20,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Warleader_yPvu9Qwb9zl29eFZ.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Warleader_yPvu9Qwb9zl29eFZ.json
@@ -97,7 +97,7 @@
       ],
       "level": 3,
       "ev": 20,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Fossil_Cryptic_1HvjuVmZEBELv9LR/npc_Fossil_Cryptic_GrwkywAeRHqyGAiu.json
+++ b/src/packs/monsters/Fossil_Cryptic_1HvjuVmZEBELv9LR/npc_Fossil_Cryptic_GrwkywAeRHqyGAiu.json
@@ -97,7 +97,7 @@
       ],
       "level": 2,
       "ev": 48,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Gloom_Dragon_gsy78qjGN57mu5so/npc_Gloom_Dragon_awNlSowdCYs0igx0.json
+++ b/src/packs/monsters/Gloom_Dragon_gsy78qjGN57mu5so/npc_Gloom_Dragon_awNlSowdCYs0igx0.json
@@ -97,7 +97,7 @@
       ],
       "level": 4,
       "ev": 72,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Gnoll_6ZOnXQw3kIUDhVuS/npc_Gnoll_Carnage_zbLiA7cPHhdpkhYx.json
+++ b/src/packs/monsters/Gnoll_6ZOnXQw3kIUDhVuS/npc_Gnoll_Carnage_zbLiA7cPHhdpkhYx.json
@@ -96,7 +96,7 @@
       ],
       "level": 2,
       "ev": 16,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Hag_Xlv2aLypC87MCZAS/npc_Wode_Hag_FTLYZPKo0ZIJ0n5q.json
+++ b/src/packs/monsters/Hag_Xlv2aLypC87MCZAS/npc_Wode_Hag_FTLYZPKo0ZIJ0n5q.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 60,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Deathrex_Shedded_Skin_zkHAnfXdQmEJ7sXQ.json
+++ b/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Deathrex_Shedded_Skin_zkHAnfXdQmEJ7sXQ.json
@@ -98,7 +98,7 @@
       ],
       "level": 1,
       "ev": 12,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Deathrex_cmB79a1nLuwimt3P.json
+++ b/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Deathrex_cmB79a1nLuwimt3P.json
@@ -98,7 +98,7 @@
       ],
       "level": 1,
       "ev": 12,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Manticore_GjGhUOD7nBaOg0ca/npc_Manticore_8DT1J2OmO380DsYt.json
+++ b/src/packs/monsters/Manticore_GjGhUOD7nBaOg0ca/npc_Manticore_8DT1J2OmO380DsYt.json
@@ -97,7 +97,7 @@
       ],
       "level": 4,
       "ev": 72,
-      "role": "solo",
+      "role": "",
       "organization": "solo"
     }
   },

--- a/src/packs/monsters/Time_Raider_9g4m05r5B3CZpEms/npc_Time_Raider_Tyrannis_mTkZYmsNyoV0ihlR.json
+++ b/src/packs/monsters/Time_Raider_9g4m05r5B3CZpEms/npc_Time_Raider_Tyrannis_mTkZYmsNyoV0ihlR.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 20,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Ground_Commander_Y2m150vDEZJprWgF.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Ground_Commander_Y2m150vDEZJprWgF.json
@@ -96,7 +96,7 @@
       ],
       "level": 3,
       "ev": 20,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/templates/sheets/actor/npc/header.hbs
+++ b/templates/sheets/actor/npc/header.hbs
@@ -22,10 +22,10 @@
       <div class="tag">{{keyword}}</div>
       {{/each}}
       {{!-- Organization/Role Tags --}}
-      {{#if system.monster.organization}}
+      {{#if organizationLabel}}
       <div class="tag">{{organizationLabel}}</div>
       {{/if}}
-      {{#if system.monster.role}}
+      {{#if roleLabel}}
       <div class="tag">{{roleLabel}}</div>
       {{/if}}
       {{#unless isPlay}}


### PR DESCRIPTION
Closes #1087 

Looks like the issue is largely because some monsters had a solo or leader role somehow despite that not being a valid role from the list. I've removed those instances. 

I also updated the template to filter out anything without a role/organization label. Will prevent against cases like this or ones where a module adds custom roles/organizations and is later removed.