### PR TITLE
[#1081] Blank tier display improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 - Fixed combatant groups turns not resetting on new round. (#991)
 - Fixed level up button not showing unless XP exceeded the next level XP. (#996)
 - Addressed ProseMirror deprecation warning. (#1080)
+- Improved the display of an ability's tier effects to filter out blank effects. (#1081)
+   - Removed zero damage effect rolls and buttons from the ability use message.
 - Fixed ability bonuses to strikes that don't specify melee or ranged not giving damage bonuses. (#1086)
 - Fixed some broken labels & css from the equipment => treasure rename.
 - Removed invalid roles from leaders and solo monsters. (#1087)

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -283,7 +283,7 @@ export default class AbilityModel extends BaseItemModel {
 
     context.powerRollEffects = Object.fromEntries([1, 2, 3].map(tier => [
       `tier${tier}`,
-      { text: this.power.effects.contents.map(effect => effect.toText(tier)).join("; ") },
+      { text: this.power.effects.contents.map(effect => effect.toText(tier)).filter(_ => _).join("; ") },
     ]));
     context.powerRolls = this.power.effects.size > 0;
 
@@ -471,7 +471,12 @@ export default class AbilityModel extends BaseItemModel {
           messageDataCopy.rolls.push(powerRoll);
         }
 
-        const damageEffects = this.power.effects.getByType("damage").map(effect => effect.damage[`tier${tierNumber}`]);
+        // Filter to the non-zero damage tiers and map them to the tier damage in one loop.
+        const damageEffects = this.power.effects.getByType("damage").reduce((effects, currentEffect) => {
+          const damage = currentEffect.damage[`tier${tierNumber}`];
+          if (Number(damage.value) !== 0) effects.push(damage);
+          return effects;
+        }, []);
 
         for (const damageEffect of damageEffects) {
           // If the damage types size is only 1, get the only value. If there are multiple, set the type to the returned value from the dialog.

--- a/src/module/data/message/ability-use.mjs
+++ b/src/module/data/message/ability-use.mjs
@@ -89,7 +89,7 @@ export default class AbilityUseModel extends BaseMessageModel {
     } else if (item && tierKey) {
       content.insertAdjacentHTML("afterbegin", `<p class="powerResult"><strong>${
         game.i18n.localize(`DRAW_STEEL.ROLL.Power.Results.Tier${this.tier}`)
-      }: </strong>${item.system.power.effects.contents.map(effect => effect.toText(this.tier)).join("; ")}</p>`,
+      }: </strong>${item.system.power.effects.contents.map(effect => effect.toText(this.tier)).filter(_ => _).join("; ")}</p>`,
       );
     } else console.warn("Invalid configuration");
   }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -99,6 +99,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
    */
   toText(tier) {
     const { value, types, potency } = this.damage[`tier${tier}`];
+    if (Number(value) === 0) return "";
 
     let damageTypes;
     let i18nString = "DRAW_STEEL.POWER_ROLL_EFFECT.DAMAGE.formatted";


### PR DESCRIPTION
Closes #1081

Also fixes the chat cards from showing the 0 damage rolls and damage buttons.

Do you think we should add a method to the `AbilityModel` for generating a specific tiers text instead of having to map, filter, and join in multiple places? Or since its only in two spots, it's not worth it for now?