### PR TITLE
#761 - Dwarf Ancestry Update

### DIFF
--- a/src/packs/origins/Ancestries_g8kLlrl0nzciXfRF/Dwarf_Dc3tgD6gCZDA5Ysd/Features_dMTmeM8PrGfzX0Ur/ancestryTrait_Grounded_SRXimbhqaB29laQU.json
+++ b/src/packs/origins/Ancestries_g8kLlrl0nzciXfRF/Dwarf_Dc3tgD6gCZDA5Ysd/Features_dMTmeM8PrGfzX0Ur/ancestryTrait_Grounded_SRXimbhqaB29laQU.json
@@ -50,7 +50,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your hearty stone body and connection to the earth make it difficult for others to move you. You have a +1 bonus to stability.</p>",
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],
@@ -60,7 +60,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.348",
         "systemId": "draw-steel",
         "systemVersion": "0.8.0",
         "createdTime": 1754528969395,

--- a/src/packs/origins/Ancestries_g8kLlrl0nzciXfRF/Dwarf_Dc3tgD6gCZDA5Ysd/Features_dMTmeM8PrGfzX0Ur/ancestryTrait_Spark_Off_Your_Skin_cUb18dpzvSq6VCyL.json
+++ b/src/packs/origins/Ancestries_g8kLlrl0nzciXfRF/Dwarf_Dc3tgD6gCZDA5Ysd/Features_dMTmeM8PrGfzX0Ur/ancestryTrait_Spark_Off_Your_Skin_cUb18dpzvSq6VCyL.json
@@ -40,7 +40,7 @@
           "priority": null
         }
       ],
-      "disabled": true,
+      "disabled": false,
       "duration": {
         "startTime": null,
         "combat": null,
@@ -50,7 +50,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your stone skin affords you potent protection. You have a +6 bonus to Stamina, and that bonus increases by 6 at 4th, 7th, and 10th levels.</p>",
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],
@@ -60,7 +60,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.348",
         "systemId": "draw-steel",
         "systemVersion": "0.8.0",
         "createdTime": 1754529415256,


### PR DESCRIPTION
Updated two Dwarven Ancestries:

Grounded
Added effect description so players will know what the effect is doing.

Spark Off Your Skin
Added effect description so players will know what the effect is doing. Disabled effect suspension and toggled the effect on, so it will be active when applied to the character instead of needing to be toggled. This should hopefully help prevent confusion with other effects that are on by default with other races.