### PR TITLE
Implemented docs on updating CONFIG.DRAW_STEEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Removed the limitation on one non-minion creature in Squad combat groups. (#1040)
   - Added controls to the combatants' context menu to toggle whether that monster is the captain or not.
+- Non-default skills and languages added to an actor or advancement will stick around even if the code that added them to ds.CONFIG is no longer active.
 
 ## 0.8.1
 

--- a/src/docs/CONFIG-Modifications.md
+++ b/src/docs/CONFIG-Modifications.md
@@ -1,0 +1,41 @@
+The Draw Steel system can be modified by users with edits to the CONFIG.DRAW_STEEL object. The full object can be viewed in [the repository](https://github.com/MetaMorphic-Digital/draw-steel/blob/main/src/module/config.mjs); this is a list of the most commonly requested adjustments. These edits should be performed by a module script; you can make a personal module by using the built-in [Module Maker from the setup screen](https://foundryvtt.com/article/module-maker/).
+
+## Languages
+
+The default list of languages for Draw Steel comes from the core books; if you're not playing in Orden, you probably want to adjust this list.
+
+```js
+Hooks.once("init", () => {
+  // Add a language
+  CONFIG.DRAW_STEEL.languages.foo = { label: "Foo" };
+  // Remove a language
+  delete CONFIG.DRAW_STEEL.languages.anjali
+  // Remove all default languages
+  for (const key in CONFIG.DRAW_STEEL.languages) delete CONFIG.DRAW_STEEL.languages[key];
+  // Add many languages
+  Object.assign(CONFIG.DRAW_STEEL.languages, {
+    foo: { label: "Foo" },
+    bar: { label: "Bar" }
+  })
+});
+```
+
+## Skills
+
+The official rules suggest Directors customize the skill list for their own purposes. The default skill groups are "crafting", "exploration", "interpersonal", "intrigue", and "lore".
+
+```js
+Hooks.once("init", () => {
+  // Add a new skill
+  CONFIG.DRAW_STEEL.skills.list.painting = {
+    label: "Painting",
+    group: "crafting"
+  }
+  // Remove a skill
+  delete CONFIG.DRAW_STEEL.skills.list.flirt
+  // Add a skill group
+  CONFIG.DRAW_STEEL.skills.groups.technology = {
+    label: "Technology"
+  }
+})
+```

--- a/src/docs/CONFIG-Modifications.md
+++ b/src/docs/CONFIG-Modifications.md
@@ -9,14 +9,14 @@ Hooks.once("init", () => {
   // Add a language
   CONFIG.DRAW_STEEL.languages.foo = { label: "Foo" };
   // Remove a language
-  delete CONFIG.DRAW_STEEL.languages.anjali
+  delete CONFIG.DRAW_STEEL.languages.anjali;
   // Remove all default languages
   for (const key in CONFIG.DRAW_STEEL.languages) delete CONFIG.DRAW_STEEL.languages[key];
   // Add many languages
   Object.assign(CONFIG.DRAW_STEEL.languages, {
     foo: { label: "Foo" },
-    bar: { label: "Bar" }
-  })
+    bar: { label: "Bar" },
+  });
 });
 ```
 
@@ -29,13 +29,13 @@ Hooks.once("init", () => {
   // Add a new skill
   CONFIG.DRAW_STEEL.skills.list.painting = {
     label: "Painting",
-    group: "crafting"
-  }
+    group: "crafting",
+  };
   // Remove a skill
-  delete CONFIG.DRAW_STEEL.skills.list.flirt
+  delete CONFIG.DRAW_STEEL.skills.list.flirt;
   // Add a skill group
   CONFIG.DRAW_STEEL.skills.groups.technology = {
-    label: "Technology"
-  }
-})
+    label: "Technology",
+  };
+});
 ```

--- a/src/docs/Home.md
+++ b/src/docs/Home.md
@@ -12,3 +12,6 @@ Start by checking out the [[Frequently Asked Questions]]; more information can b
 ## Helpers
 * [[Enrichers]]
 * [[Roll Data]]
+
+## Development
+[[CONFIG Modifications]]

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -233,7 +233,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
     const formatter = game.i18n.getListFormatter();
     const languageList = Array.from(this.actor.system.biography.languages).map(l => ds.CONFIG.languages[l]?.label ?? l);
     const languageOptions = Object.entries(ds.CONFIG.languages).map(([value, { label }]) => ({ value, label }));
-    for (const language of this.actor.system.biography.languages) {
+    for (const language of this.actor.system._source.biography.languages) {
       if (!(language in ds.CONFIG.languages)) languageOptions.push({ value: language });
     }
     return {

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -232,9 +232,13 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
     if (!this.actor.system.schema.getField("biography.languages")) return { list: "", options: [] };
     const formatter = game.i18n.getListFormatter();
     const languageList = Array.from(this.actor.system.biography.languages).map(l => ds.CONFIG.languages[l]?.label ?? l);
+    const languageOptions = Object.entries(ds.CONFIG.languages).map(([value, { label }]) => ({ value, label }));
+    for (const language of this.actor.system.biography.languages) {
+      if (!(language in ds.CONFIG.languages)) languageOptions.push({ value: language });
+    }
     return {
       list: formatter.format(languageList),
-      options: Object.entries(ds.CONFIG.languages).map(([value, { label }]) => ({ value, label })),
+      options: languageOptions,
     };
   }
 

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -83,7 +83,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
     switch (partId) {
       case "stats":
         context.unfilledSkill = !!this.actor.system._unfilledTraits.skill?.size;
-        context.skills = this._getSkillList();
+        context.skills = this._getSkills();
         break;
       case "features":
         context.complications = await this._prepareComplicationsContext();
@@ -112,14 +112,24 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * Constructs a string listing the actor's skills.
    * @returns {string}
    */
-  _getSkillList() {
+  _getSkills() {
     const list = this.actor.system.hero.skills.reduce((skills, skill) => {
       skill = ds.CONFIG.skills.list[skill]?.label;
       if (skill) skills.push(skill);
       return skills;
     }, []).sort((a, b) => a.localeCompare(b, game.i18n.lang));
     const formatter = game.i18n.getListFormatter();
-    return formatter.format(list);
+
+    const skillOptions = ds.CONFIG.skills.optgroups;
+
+    for (const skill of this.actor.system.hero.skills) {
+      if (!(skill in ds.CONFIG.skills.list)) skillOptions.push({ value: skill });
+    }
+
+    return {
+      list: formatter.format(list),
+      options: skillOptions,
+    };
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
@@ -90,11 +90,21 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
 
     else if (context.document.type === "skill") {
       ctx.skillGroups = Object.entries(ds.CONFIG.skills.groups).map(([value, { label }]) => ({ value, label }));
+      for (const group of this.pseudoDocument.skills.groups) {
+        if (!(skill in ds.CONFIG.skills.groups)) ctx.skillGroups.push({ value: group });
+      }
+
       ctx.skillChoices = ds.CONFIG.skills.optgroups;
+      for (const skill of this.pseudoDocument.skills.choices) {
+        if (!(skill in ds.CONFIG.skills.list)) ctx.skillChoices.push({ value: skill });
+      }
     }
 
     else if (context.document.type === "language") {
       ctx.languageChoices = Object.entries(ds.CONFIG.languages).map(([value, { label }]) => ({ value, label }));
+      for (const language of this.pseudoDocument.languages) {
+        if (!(language in ds.CONFIG.languages)) ctx.languageChoices.push({ value: language });
+      }
     }
 
     return context;

--- a/templates/sheets/actor/hero-sheet/stats.hbs
+++ b/templates/sheets/actor/hero-sheet/stats.hbs
@@ -145,9 +145,9 @@
       {{/if}}
     </legend>
     {{#if isPlay}}
-    {{skills}}
+    {{skills.list}}
     {{else}}
-    {{formInput systemFields.hero.fields.skills value=systemSource.hero.skills options=config.skills.optgroups dataset=datasets.isSource}}
+    {{formInput systemFields.hero.fields.skills value=systemSource.hero.skills options=skills.options dataset=datasets.isSource}}
     {{/if}}
   </fieldset>
 </section>


### PR DESCRIPTION
- Addresses frequent question
- Improves our `options` construction to account for currently unregistered additions. Can easily be tested in world by using the additional skills/languages provided in the docs examples and then refreshing to get rid of them.