### PR TITLE
Renamed "AbilityBonus" class to "AbilityModifier"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Removed the limitation on one non-minion creature in Squad combat groups. (#1040)
   - Added controls to the combatants' context menu to toggle whether that monster is the captain or not.
+- Renamed the "AbilityBonus" class to "AbilityModifier", the `type` is still `"abilityModifier"`.
 
 ## 0.8.1
 

--- a/src/module/data/effect/_module.mjs
+++ b/src/module/data/effect/_module.mjs
@@ -1,2 +1,2 @@
-export { default as AbilityBonus } from "./ability-bonus.mjs";
+export { default as AbilityModifier } from "./ability-modifier.mjs";
 export { default as BaseEffectModel } from "./base.mjs";

--- a/src/module/data/effect/ability-modifier.mjs
+++ b/src/module/data/effect/ability-modifier.mjs
@@ -6,9 +6,9 @@ import { setOptions } from "../helpers.mjs";
  */
 
 /**
- * An Active Effect subtype that represents bonuses to an actor's abilities.
+ * An Active Effect subtype that represents adjustments to an actor's abilities.
  */
-export default class AbilityBonus extends BaseEffectModel {
+export default class AbilityModifier extends BaseEffectModel {
   /** @inheritdoc */
   static get metadata() {
     return {


### PR DESCRIPTION
I didn't fix the class & file name after adjusting the `type` during the original review process. Only breaking if someone specifically was extending or referencing that class, which I doubt.