### PR TITLE
Updated Targeting label handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 ### Changed
 
+- Added "custom" target property to abilities, which will override the target label. (#886)
+  - Also added "Enemy or Object" as a new type
+  - Revised i18n strings for many of the "All" types, e.g. "All creatures" => "Each creature"
 - Removed the limitation on one non-minion creature in Squad combat groups. (#1040)
   - Added controls to the combatants' context menu to toggle whether that monster is the captain or not.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@
 
 ### Changed
 
-- Added "custom" target property to abilities, which will override the target label. (#886)
-  - Also added "Enemy or Object" as a new type
-  - Revised i18n strings for many of the "All" types, e.g. "All creatures" => "Each creature"
+- Added a "Custom Label" property for ability targets, which will override the default label. (#886)
+  - Also added "Enemy or Object" as a new target type.
+  - Revised i18n strings for many of the "All" types, e.g. "All creatures" => "Each creature".
 - Removed the limitation on one non-minion creature in Squad combat groups. (#1040)
   - Added controls to the combatants' context menu to toggle whether that monster is the captain or not.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -712,6 +712,9 @@
             "type": {
               "label": "Type"
             },
+            "custom": {
+              "label": "Custom Label"
+            },
             "value": {
               "label": "Value"
             }
@@ -835,19 +838,22 @@
           "All": "All",
           "Creature": "Creature",
           "CreatureEmbed": "{value} creature(s)",
-          "AllCreatures": "All creatures",
+          "AllCreatures": "Each creature",
           "Object": "Object",
           "ObjectEmbed": "{value} object(s)",
-          "AllObjects": "All objects",
+          "AllObjects": "Each object",
           "CreatureObject": "Creature or Object",
           "CreatureObjectEmbed": "{value} creature(s) or object(s)",
-          "AllCreatureObject": "All creatures and objects",
+          "AllCreatureObject": "Each creature and object",
           "Enemy": "Enemy",
           "EnemyEmbed": "{value} enemies",
-          "AllEnemies": "All enemies",
+          "EnemyObject": "Enemy or Object",
+          "AllEnemyObject": "Each enemy or object",
+          "EnemyObjectEmbed": "{value} enemies or object(s)",
+          "AllEnemies": "Each enemy",
           "Ally": "Ally",
           "AllyEmbed": "{value} allies",
-          "AllAllies": "All allies",
+          "AllAllies": "Each ally",
           "Self": "Self",
           "SelfOrAlly": "Self or one ally",
           "SelfOrCreature": "Self or one creature",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1226,6 +1226,11 @@ const abilityTargets = {
     all: "DRAW_STEEL.Item.ability.Target.AllEnemies",
     embedLabel: "DRAW_STEEL.Item.ability.Target.EnemyEmbed",
   },
+  enemyObject: {
+    label: "DRAW_STEEL.Item.ability.Target.EnemyObject",
+    all: "DRAW_STEEL.Item.ability.Target.AllEnemyObject",
+    embedLabel: "DRAW_STEEL.Item.ability.Target.EnemyObjectEmbed",
+  },
   ally: {
     label: "DRAW_STEEL.Item.ability.Target.Ally",
     all: "DRAW_STEEL.Item.ability.Target.AllAllies",

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -48,6 +48,7 @@ declare module "./ability.mjs" {
     trigger: string;
     target: {
       type: string;
+      custom: string;
       /** Null value indicates "all". */
       value: number | null;
     }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -63,6 +63,7 @@ export default class AbilityModel extends BaseItemModel {
     }, initial: "melee", required: true, blank: false });
     schema.target = new fields.SchemaField({
       type: new fields.StringField({ required: true, blank: false, initial: "self" }),
+      custom: new fields.StringField(),
       value: new fields.NumberField({ integer: true }),
     });
 
@@ -239,9 +240,9 @@ export default class AbilityModel extends BaseItemModel {
     labels.distance = game.i18n.format(ds.CONFIG.abilities.distances[this.distance.type]?.embedLabel, { ...this.distance });
 
     const targetConfig = ds.CONFIG.abilities.targets[this.target.type] ?? { embedLabel: "Unknown" };
-    labels.target = this.target.value === null ?
+    labels.target = this.target.custom || (this.target.value === null ?
       targetConfig.all ?? game.i18n.localize(targetConfig.embedLabel) :
-      game.i18n.format(targetConfig.embedLabel, { value: this.target.value });
+      game.i18n.format(targetConfig.embedLabel, { value: this.target.value }));
 
     return labels;
   }

--- a/templates/sheets/item/partials/ability.hbs
+++ b/templates/sheets/item/partials/ability.hbs
@@ -28,6 +28,7 @@
 <fieldset>
   <legend>{{systemFields.target.label}}</legend>
   {{formGroup systemFields.target.fields.type value=system.target.type options=targetTypes}}
+  {{formGroup systemFields.target.fields.custom value=system.target.custom}}
   {{#if (and (ne system.target.type "self") (ne system.target.type "selfOrAlly") (ne system.target.type "special"))}}
   {{formGroup systemFields.target.fields.value value=system.target.value placeholder=(localize "DRAW_STEEL.Item.ability.Target.All")}}
   {{/if}}


### PR DESCRIPTION

- Added a "Custom Label" property for ability targets, which will override the default label.
  - Also added "Enemy or Object" as a new target type.
  - Revised i18n strings for many of the "All" types, e.g. "All creatures" => "Each creature".

Closes #886 