### PR TITLE
[#626] Refactor embed toggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Changed
 
 - Changed available keywords on treasures to be more accurate. (#270)
+- Refactor the toggling of item and effect description dropdowns to use a CSS transition instead of re-rendering the application. (#626)
 - Added a "Custom Label" property for ability targets, which will override the default label. (#886)
   - Also added "Enemy or Object" as a new target type.
   - Revised i18n strings for many of the "All" types, e.g. "All creatures" => "Each creature".

--- a/src/module/applications/api/document-sheet-mixin.mjs
+++ b/src/module/applications/api/document-sheet-mixin.mjs
@@ -1,7 +1,9 @@
 import constructHTMLButton from "../../utils/construct-html-button.mjs";
 
-/** @import { Constructor } from "@common/_types.mjs" */
-/** @import { Document } from "@common/abstract/_module.mjs" */
+/**
+ * @import { Constructor } from "@common/_types.mjs"
+ * @import { Document } from "@common/abstract/_module.mjs"
+ */
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -451,6 +451,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
     for (const e of this.actor.allApplicableEffects()) {
       const effectContext = {
         id: e.id,
+        uuid: e.uuid,
         name: e.name,
         img: e.img,
         parent: e.parent,

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -462,7 +462,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
 
       if (this._expandedDocumentEmbeds.has(e.id)) {
         effectContext.expanded = true;
-        effectContext.enrichedDescription = await enrichHTML(e.description, { relativeTo: e });
+        effectContext.enrichedDescription = await e.system.toEmbed({});
       }
 
       if (!e.active) categories.inactive.effects.push(effectContext);

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -275,7 +275,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
   async _prepareItemContext(item) {
     const context = {
       item,
-      expanded: this._expandedDocumentEmbeds.has(item.id),
+      expanded: this._expandedDocumentDescriptions.has(item.id),
     };
 
     // only generate the item embed when it's expanded
@@ -460,7 +460,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
         expanded: false,
       };
 
-      if (this._expandedDocumentEmbeds.has(e.id)) {
+      if (this._expandedDocumentDescriptions.has(e.id)) {
         effectContext.expanded = true;
         effectContext.enrichedDescription = await e.system.toEmbed({});
       }

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -271,7 +271,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
 
       if (this._expandedDocumentEmbeds.has(e.id)) {
         effectContext.expanded = true;
-        effectContext.enrichedDescription = await enrichHTML(e.description, { relativeTo: e });
+        effectContext.enrichedDescription = await e.system.toEmbed({});
       }
 
       if (!e.transfer) categories.applied.effects.push(effectContext);

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -261,6 +261,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     for (const e of this.item.effects) {
       const effectContext = {
         id: e.id,
+        uuid: e.uuid,
         name: e.name,
         img: e.img,
         sourceName: e.sourceName,

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -269,7 +269,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
         expanded: false,
       };
 
-      if (this._expandedDocumentEmbeds.has(e.id)) {
+      if (this._expandedDocumentDescriptions.has(e.id)) {
         effectContext.expanded = true;
         effectContext.enrichedDescription = await e.system.toEmbed({});
       }

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -84,7 +84,7 @@
         .document-embed {
           display: grid;
           grid-template-rows: 0fr;
-          transition: grid-template-rows .25s linear;
+          transition: grid-template-rows .15s linear;
 
           &.expanded {
             grid-template-rows: 1fr;

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -86,7 +86,6 @@
           grid-template-rows: 0fr;
           transition: grid-template-rows .25s linear;
 
-
           &.expanded {
             grid-template-rows: 1fr;
           }

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -85,6 +85,7 @@
           display: grid;
           grid-template-rows: 0fr;
           transition: grid-template-rows .15s linear;
+          padding: 0px 5px 0px 5px;
 
           &.expanded {
             grid-template-rows: 1fr;

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -81,7 +81,7 @@
           }
         }
 
-        .document-embed {
+        .document-description {
           display: grid;
           grid-template-rows: 0fr;
           transition: grid-template-rows .15s linear;

--- a/src/styles/system/applications/components/effects.css
+++ b/src/styles/system/applications/components/effects.css
@@ -80,6 +80,21 @@
             }
           }
         }
+
+        .document-embed {
+          display: grid;
+          grid-template-rows: 0fr;
+          transition: grid-template-rows .25s linear;
+
+
+          &.expanded {
+            grid-template-rows: 1fr;
+          }
+
+          & > div {
+            overflow: hidden;
+          }
+        }
       }
     }
   }

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -71,6 +71,21 @@
             }
           }
         }
+
+        .document-embed {
+          display: grid;
+          grid-template-rows: 0fr;
+          transition: grid-template-rows .25s linear;
+
+
+          &.expanded {
+            grid-template-rows: 1fr;
+          }
+
+          & > div {
+            overflow: hidden;
+          }
+        }
       }
     }
   }

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -72,7 +72,7 @@
           }
         }
 
-        .document-embed {
+        .document-description {
           display: grid;
           grid-template-rows: 0fr;
           transition: grid-template-rows .15s linear;

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -76,6 +76,7 @@
           display: grid;
           grid-template-rows: 0fr;
           transition: grid-template-rows .15s linear;
+          padding: 0px 5px 0px 5px;
 
           &.expanded {
             grid-template-rows: 1fr;

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -75,7 +75,7 @@
         .document-embed {
           display: grid;
           grid-template-rows: 0fr;
-          transition: grid-template-rows .25s linear;
+          transition: grid-template-rows .15s linear;
 
           &.expanded {
             grid-template-rows: 1fr;

--- a/src/styles/system/applications/components/items.css
+++ b/src/styles/system/applications/components/items.css
@@ -77,7 +77,6 @@
           grid-template-rows: 0fr;
           transition: grid-template-rows .25s linear;
 
-
           &.expanded {
             grid-template-rows: 1fr;
           }

--- a/templates/sheets/actor/hero-sheet/equipment.hbs
+++ b/templates/sheets/actor/hero-sheet/equipment.hbs
@@ -25,7 +25,7 @@
     </div>
     <ol class="item-list kit-list">
       {{#each kits as |kitContext|}}
-      <li class="item feature draggable expandable-document" data-document-id="{{kitContext.item.id}}" data-item-id="{{kitContext.item.id}}" data-document-class="Item" data-parent-uuid="{{kitContext.item.parent.uuid}}">
+      <li class="item feature draggable expandable-document" data-document-uuid="{{kitContext.item.uuid}}" data-document-id="{{kitContext.item.id}}" data-item-id="{{kitContext.item.id}}" data-document-class="Item" data-parent-uuid="{{kitContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{kitContext.item.img}}" alt="{{kitContext.item.name}}">
@@ -39,7 +39,7 @@
           <div class="item-column item-melee-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.melee.damage}}</div>
           <div class="item-column item-ranged-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.ranged.damage}}</div>
           <div class="item-column item-controls">
-            <a class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
+            <a class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if kitContext.expanded}}expanded{{/if}}">
@@ -72,7 +72,7 @@
     </div>
     <ol class="item-list treasure-list">
       {{#each treasureType.treasure as |treasureContext|}}
-      <li class="item treasure draggable expandable-document" data-document-id="{{treasureContext.item.id}}" data-item-id="{{treasureContext.item.id}}" data-document-class="Item" data-parent-uuid="{{treasureContext.item.parent.uuid}}">
+      <li class="item treasure draggable expandable-document" data-document-uuid="{{treasureContext.item.uuid}}" data-document-id="{{treasureContext.item.id}}" data-item-id="{{treasureContext.item.id}}" data-document-class="Item" data-parent-uuid="{{treasureContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{treasureContext.item.img}}" alt="{{treasureContext.item.name}}">
@@ -91,7 +91,7 @@
             </a>
           </div>
           <div class="item-column item-controls">
-            <a class="fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
+            <a class="fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if treasureContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/hero-sheet/equipment.hbs
+++ b/templates/sheets/actor/hero-sheet/equipment.hbs
@@ -25,7 +25,7 @@
     </div>
     <ol class="item-list kit-list">
       {{#each kits as |kitContext|}}
-      <li class="item feature draggable expandable-document" data-document-id="{{kitContext.item.id}}" data-item-id="{{kitContext.item.id}}" data-document-class="Item">
+      <li class="item feature draggable expandable-document" data-document-id="{{kitContext.item.id}}" data-item-id="{{kitContext.item.id}}" data-document-class="Item" data-parent-uuid="{{kitContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{kitContext.item.img}}" alt="{{kitContext.item.name}}">
@@ -42,7 +42,7 @@
             <a class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="document-embed item-embed {{#if kitContext.expanded}}expanded{{/if}}">
+        <div class="document-description item-embed {{#if kitContext.expanded}}expanded{{/if}}">
           {{#if kitContext.expanded}}{{{kitContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>
@@ -72,7 +72,7 @@
     </div>
     <ol class="item-list treasure-list">
       {{#each treasureType.treasure as |treasureContext|}}
-      <li class="item treasure draggable expandable-document" data-document-id="{{treasureContext.item.id}}" data-item-id="{{treasureContext.item.id}}" data-document-class="Item">
+      <li class="item treasure draggable expandable-document" data-document-id="{{treasureContext.item.id}}" data-item-id="{{treasureContext.item.id}}" data-document-class="Item" data-parent-uuid="{{treasureContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{treasureContext.item.img}}" alt="{{treasureContext.item.name}}">
@@ -94,7 +94,7 @@
             <a class="fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="document-embed item-embed {{#if treasureContext.expanded}}expanded{{/if}}">
+        <div class="document-description item-embed {{#if treasureContext.expanded}}expanded{{/if}}">
           {{#if treasureContext.expanded}}{{{treasureContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/hero-sheet/equipment.hbs
+++ b/templates/sheets/actor/hero-sheet/equipment.hbs
@@ -25,7 +25,7 @@
     </div>
     <ol class="item-list kit-list">
       {{#each kits as |kitContext|}}
-      <li class="item feature draggable" data-item-id="{{kitContext.item.id}}" data-document-class="Item">
+      <li class="item feature draggable expandable-document" data-document-id="{{kitContext.item.id}}" data-item-id="{{kitContext.item.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{kitContext.item.img}}" alt="{{kitContext.item.name}}">
@@ -39,12 +39,10 @@
           <div class="item-column item-melee-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.melee.damage}}</div>
           <div class="item-column item-ranged-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.ranged.damage}}</div>
           <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}"></i>
-            </a>
+            <a class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="item-embed">
+        <div class="document-embed item-embed {{#if kitContext.expanded}}expanded{{/if}}">
           {{#if kitContext.expanded}}{{{kitContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>
@@ -74,7 +72,7 @@
     </div>
     <ol class="item-list treasure-list">
       {{#each treasureType.treasure as |treasureContext|}}
-      <li class="item treasure draggable" data-item-id="{{treasureContext.item.id}}" data-document-class="Item">
+      <li class="item treasure draggable expandable-document" data-document-id="{{treasureContext.item.id}}" data-item-id="{{treasureContext.item.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{treasureContext.item.img}}" alt="{{treasureContext.item.name}}">
@@ -93,12 +91,10 @@
             </a>
           </div>
           <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}"></i>
-            </a>
+            <a class="fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="item-embed">
+        <div class="document-embed item-embed {{#if treasureContext.expanded}}expanded{{/if}}">
           {{#if treasureContext.expanded}}{{{treasureContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/hero-sheet/features.hbs
+++ b/templates/sheets/actor/hero-sheet/features.hbs
@@ -15,7 +15,7 @@
     </div>
     <ol class="item-list complications-list">
       {{#each complications.complications as |complicationContext|}}
-      <li class="item complication draggable expandable-document" data-document-id="{{complicationContext.item.id}}" data-item-id="{{complicationContext.item.id}}" data-document-class="Item" data-parent-uuid="{{complicationContext.item.parent.uuid}}">
+      <li class="item complication draggable expandable-document" data-document-uuid="{{complicationContext.item.uuid}}" data-document-id="{{complicationContext.item.id}}" data-item-id="{{complicationContext.item.id}}" data-document-class="Item" data-parent-uuid="{{complicationContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{complicationContext.item.img}}" alt="{{complicationContext.item.name}}">
@@ -24,7 +24,7 @@
             </div>
           </div>
           <div class="item-column item-controls">
-            <a class="fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
+            <a class="fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if complicationContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/hero-sheet/features.hbs
+++ b/templates/sheets/actor/hero-sheet/features.hbs
@@ -15,7 +15,7 @@
     </div>
     <ol class="item-list complications-list">
       {{#each complications.complications as |complicationContext|}}
-      <li class="item complication draggable" data-item-id="{{complicationContext.item.id}}" data-document-class="Item">
+      <li class="item complication draggable expandable-document" data-document-id="{{complicationContext.item.id}}" data-item-id="{{complicationContext.item.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{complicationContext.item.img}}" alt="{{complicationContext.item.name}}">
@@ -24,12 +24,10 @@
             </div>
           </div>
           <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}"></i>
-            </a>
+            <a class="fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="item-embed">
+        <div class="document-embed item-embed {{#if complicationContext.expanded}}expanded{{/if}}">
           {{#if complicationContext.expanded}}{{{complicationContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/hero-sheet/features.hbs
+++ b/templates/sheets/actor/hero-sheet/features.hbs
@@ -15,7 +15,7 @@
     </div>
     <ol class="item-list complications-list">
       {{#each complications.complications as |complicationContext|}}
-      <li class="item complication draggable expandable-document" data-document-id="{{complicationContext.item.id}}" data-item-id="{{complicationContext.item.id}}" data-document-class="Item">
+      <li class="item complication draggable expandable-document" data-document-id="{{complicationContext.item.id}}" data-item-id="{{complicationContext.item.id}}" data-document-class="Item" data-parent-uuid="{{complicationContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name">
             <img class="item-image" src="{{complicationContext.item.img}}" alt="{{complicationContext.item.name}}">
@@ -27,7 +27,7 @@
             <a class="fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="document-embed item-embed {{#if complicationContext.expanded}}expanded{{/if}}">
+        <div class="document-description item-embed {{#if complicationContext.expanded}}expanded{{/if}}">
           {{#if complicationContext.expanded}}{{{complicationContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/hero-sheet/header.hbs
+++ b/templates/sheets/actor/hero-sheet/header.hbs
@@ -1,7 +1,15 @@
 {{!-- Partial for header tags --}}
 {{#*inline "headerTag"}}
 {{#if originDoc}}
-<span data-document-class="Item" data-item-id="{{lookup originDoc "id"}}">
+
+<span
+  data-document-class="Item"
+  data-item-id="{{lookup originDoc "id"}}"
+  data-parent-uuid="{{@root.document.uuid}}"
+  {{! eslint-disable-next-line @html-eslint/no-duplicate-attrs }}
+  data-document-id="{{lookup originDoc "id"}}"
+  data-document-uuid="{{lookup originDoc "uuid"}}"
+>
   <a class="filled" data-action="viewDoc">
     {{lookup originDoc "name"}}
   </a>

--- a/templates/sheets/actor/hero-sheet/projects.hbs
+++ b/templates/sheets/actor/hero-sheet/projects.hbs
@@ -17,7 +17,7 @@
     </div>
     <ol class="item-list project-list">
       {{#each projects as |projectContext|}}
-      <li class="item project draggable" data-item-id="{{projectContext.item.id}}" data-document-class="Item">
+      <li class="item project draggable expandable-document" data-document-id="{{projectContext.item.id}}" data-item-id="{{projectContext.item.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name rollable" data-action="rollProject">
             <img class="item-image" src="{{projectContext.item.img}}" alt="{{projectContext.item.name}}">
@@ -28,12 +28,10 @@
           <div class="item-column item-points">{{ifThen projectContext.item.system.points projectContext.item.system.points "0"}} / {{projectContext.item.system.goal}}</div>
           <div class="item-column item-type">{{lookup (lookup @root.config.projects.types projectContext.item.system.type) "label"}}</div>
           <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}"></i>
-            </a>
+            <a class="fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="item-embed">
+        <div class="document-embed item-embed {{#if projectContext.expanded}}expanded{{/if}}">
           {{#if projectContext.expanded}}{{{projectContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/hero-sheet/projects.hbs
+++ b/templates/sheets/actor/hero-sheet/projects.hbs
@@ -17,7 +17,7 @@
     </div>
     <ol class="item-list project-list">
       {{#each projects as |projectContext|}}
-      <li class="item project draggable expandable-document" data-document-id="{{projectContext.item.id}}" data-item-id="{{projectContext.item.id}}" data-document-class="Item" data-parent-uuid="{{projectContext.item.parent.uuid}}">
+      <li class="item project draggable expandable-document" data-document-uuid="{{projectContext.item.uuid}}" data-document-id="{{projectContext.item.id}}" data-item-id="{{projectContext.item.id}}" data-document-class="Item" data-parent-uuid="{{projectContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name rollable" data-action="rollProject">
             <img class="item-image" src="{{projectContext.item.img}}" alt="{{projectContext.item.name}}">
@@ -28,7 +28,7 @@
           <div class="item-column item-points">{{ifThen projectContext.item.system.points projectContext.item.system.points "0"}} / {{projectContext.item.system.goal}}</div>
           <div class="item-column item-type">{{lookup (lookup @root.config.projects.types projectContext.item.system.type) "label"}}</div>
           <div class="item-column item-controls">
-            <a class="fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
+            <a class="fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if projectContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/hero-sheet/projects.hbs
+++ b/templates/sheets/actor/hero-sheet/projects.hbs
@@ -17,7 +17,7 @@
     </div>
     <ol class="item-list project-list">
       {{#each projects as |projectContext|}}
-      <li class="item project draggable expandable-document" data-document-id="{{projectContext.item.id}}" data-item-id="{{projectContext.item.id}}" data-document-class="Item">
+      <li class="item project draggable expandable-document" data-document-id="{{projectContext.item.id}}" data-item-id="{{projectContext.item.id}}" data-document-class="Item" data-parent-uuid="{{projectContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name rollable" data-action="rollProject">
             <img class="item-image" src="{{projectContext.item.img}}" alt="{{projectContext.item.name}}">
@@ -31,7 +31,7 @@
             <a class="fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="document-embed item-embed {{#if projectContext.expanded}}expanded{{/if}}">
+        <div class="document-description item-embed {{#if projectContext.expanded}}expanded{{/if}}">
           {{#if projectContext.expanded}}{{{projectContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/shared/abilities.hbs
+++ b/templates/sheets/actor/shared/abilities.hbs
@@ -24,7 +24,7 @@
     </div>
     <ol class="item-list abilities-list">
       {{#each abilityType.abilities as |abilityContext|}}
-      <li class="item ability draggable expandable-document" data-document-id="{{abilityContext.item.id}}" data-item-id="{{abilityContext.item.id}}" data-document-class="Item" data-parent-uuid="{{abilityContext.item.parent.uuid}}">
+      <li class="item ability draggable expandable-document" data-document-uuid="{{abilityContext.item.uuid}}" data-document-id="{{abilityContext.item.id}}" data-item-id="{{abilityContext.item.id}}" data-document-class="Item" data-parent-uuid="{{abilityContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name rollable" data-action="useAbility">
             <img class="item-image" src="{{abilityContext.item.img}}" alt="{{abilityContext.item.name}}">
@@ -52,7 +52,7 @@
           <div class="item-column item-distance">{{abilityContext.formattedLabels.distance}}</div>
           <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
           <div class="item-column item-controls">
-            <a class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
+            <a class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed content-embed {{#if abilityContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/shared/abilities.hbs
+++ b/templates/sheets/actor/shared/abilities.hbs
@@ -24,7 +24,7 @@
     </div>
     <ol class="item-list abilities-list">
       {{#each abilityType.abilities as |abilityContext|}}
-      <li class="item ability draggable expandable-document" data-document-id="{{abilityContext.item.id}}" data-item-id="{{abilityContext.item.id}}" data-document-class="Item">
+      <li class="item ability draggable expandable-document" data-document-id="{{abilityContext.item.id}}" data-item-id="{{abilityContext.item.id}}" data-document-class="Item" data-parent-uuid="{{abilityContext.item.parent.uuid}}">
         <div class="item-row">
           <div class="item-column item-name rollable" data-action="useAbility">
             <img class="item-image" src="{{abilityContext.item.img}}" alt="{{abilityContext.item.name}}">
@@ -55,7 +55,7 @@
             <a class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="document-embed item-embed content-embed {{#if abilityContext.expanded}}expanded{{/if}}">
+        <div class="document-description item-embed content-embed {{#if abilityContext.expanded}}expanded{{/if}}">
           {{#if abilityContext.expanded}}{{{abilityContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/shared/abilities.hbs
+++ b/templates/sheets/actor/shared/abilities.hbs
@@ -24,7 +24,7 @@
     </div>
     <ol class="item-list abilities-list">
       {{#each abilityType.abilities as |abilityContext|}}
-      <li class="item ability draggable" data-item-id="{{abilityContext.item.id}}" data-document-class="Item">
+      <li class="item ability draggable expandable-document" data-document-id="{{abilityContext.item.id}}" data-item-id="{{abilityContext.item.id}}" data-document-class="Item">
         <div class="item-row">
           <div class="item-column item-name rollable" data-action="useAbility">
             <img class="item-image" src="{{abilityContext.item.img}}" alt="{{abilityContext.item.name}}">
@@ -52,12 +52,10 @@
           <div class="item-column item-distance">{{abilityContext.formattedLabels.distance}}</div>
           <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
           <div class="item-column item-controls">
-            <a data-action="toggleItemEmbed">
-              <i class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}"></i>
-            </a>
+            <a class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
           </div>
         </div>
-        <div class="item-embed content-embed">
+        <div class="document-embed item-embed content-embed {{#if abilityContext.expanded}}expanded{{/if}}">
           {{#if abilityContext.expanded}}{{{abilityContext.embed.outerHTML}}}{{/if}}
         </div>
       </li>

--- a/templates/sheets/actor/shared/effects.hbs
+++ b/templates/sheets/actor/shared/effects.hbs
@@ -39,7 +39,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable expandable-document" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-uuid="{{effect.parent.uuid}}" data-document-class="ActiveEffect">
+        <li class="effect draggable expandable-document" data-document-uuid="{{effect.uuid}}" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-parent-uuid="{{effect.parent.uuid}}" data-document-class="ActiveEffect" data-parent-document-name="{{effect.parent.documentName}}">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -58,7 +58,7 @@
               {{#if @root.editable}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
               <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.ActiveEffect.Name")}}"></a>
-              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentEmbed"></a>
+              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentDescription"></a>
               {{/if}}
             </div>
           </div>

--- a/templates/sheets/actor/shared/effects.hbs
+++ b/templates/sheets/actor/shared/effects.hbs
@@ -39,7 +39,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable expandable-document" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+        <li class="effect draggable expandable-document" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -63,7 +63,7 @@
             </div>
           </div>
           <div class="document-embed effect-description {{#if effect.expanded}}expanded{{/if}}">
-            {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
+            {{#if effect.expanded}}{{{effect.enrichedDescription.outerHTML}}}{{/if}}
           </div>
         </li>
         {{/each}}

--- a/templates/sheets/actor/shared/effects.hbs
+++ b/templates/sheets/actor/shared/effects.hbs
@@ -39,7 +39,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+        <li class="effect draggable expandable-document" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -58,11 +58,11 @@
               {{#if @root.editable}}
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
               <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.ActiveEffect.Name")}}"></a>
-              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
+              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentEmbed"></a>
               {{/if}}
             </div>
           </div>
-          <div class="effect-description">
+          <div class="document-embed effect-description {{#if effect.expanded}}expanded{{/if}}">
             {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
           </div>
         </li>

--- a/templates/sheets/actor/shared/effects.hbs
+++ b/templates/sheets/actor/shared/effects.hbs
@@ -39,7 +39,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable expandable-document" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}" data-document-class="ActiveEffect">
+        <li class="effect draggable expandable-document" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-uuid="{{effect.parent.uuid}}" data-document-class="ActiveEffect">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -62,7 +62,7 @@
               {{/if}}
             </div>
           </div>
-          <div class="document-embed effect-description {{#if effect.expanded}}expanded{{/if}}">
+          <div class="document-description effect-description {{#if effect.expanded}}expanded{{/if}}">
             {{#if effect.expanded}}{{{effect.enrichedDescription.outerHTML}}}{{/if}}
           </div>
         </li>

--- a/templates/sheets/actor/shared/partials/features/features.hbs
+++ b/templates/sheets/actor/shared/partials/features/features.hbs
@@ -15,7 +15,7 @@
   </div>
   <ol class="item-list feature-list">
     {{#each features as |featureContext|}}
-    <li class="item feature draggable" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
+    <li class="item feature draggable expandable-document" data-document-id="{{featureContext.item.id}}" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
       <div class="item-row">
         <div class="item-column item-name">
           <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
@@ -25,12 +25,10 @@
         </div>
         <div class="item-column item-type">{{localize typeLabel}}</div>
         <div class="item-column item-controls">
-          <a data-action="toggleItemEmbed">
-            <i class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}"></i>
-          </a>
+          <a class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
         </div>
       </div>
-      <div class="item-embed">
+      <div class="document-embed item-embed {{#if featureContext.expanded}}expanded{{/if}}">
         {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
       </div>
     </li>

--- a/templates/sheets/actor/shared/partials/features/features.hbs
+++ b/templates/sheets/actor/shared/partials/features/features.hbs
@@ -15,7 +15,7 @@
   </div>
   <ol class="item-list feature-list">
     {{#each features as |featureContext|}}
-    <li class="item feature draggable expandable-document" data-document-id="{{featureContext.item.id}}" data-item-id="{{featureContext.item.id}}" data-document-class="Item">
+    <li class="item feature draggable expandable-document" data-document-id="{{featureContext.item.id}}" data-item-id="{{featureContext.item.id}}" data-document-class="Item" data-parent-uuid="{{featureContext.item.parent.uuid}}">
       <div class="item-row">
         <div class="item-column item-name">
           <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
@@ -28,7 +28,7 @@
           <a class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
         </div>
       </div>
-      <div class="document-embed item-embed {{#if featureContext.expanded}}expanded{{/if}}">
+      <div class="document-description item-embed {{#if featureContext.expanded}}expanded{{/if}}">
         {{#if featureContext.expanded}}{{{featureContext.embed.outerHTML}}}{{/if}}
       </div>
     </li>

--- a/templates/sheets/actor/shared/partials/features/features.hbs
+++ b/templates/sheets/actor/shared/partials/features/features.hbs
@@ -15,7 +15,7 @@
   </div>
   <ol class="item-list feature-list">
     {{#each features as |featureContext|}}
-    <li class="item feature draggable expandable-document" data-document-id="{{featureContext.item.id}}" data-item-id="{{featureContext.item.id}}" data-document-class="Item" data-parent-uuid="{{featureContext.item.parent.uuid}}">
+    <li class="item feature draggable expandable-document" data-document-uuid="{{featureContext.item.uuid}}" data-document-id="{{featureContext.item.id}}" data-item-id="{{featureContext.item.id}}" data-document-class="Item" data-parent-uuid="{{featureContext.item.parent.uuid}}">
       <div class="item-row">
         <div class="item-column item-name">
           <img class="item-image" src="{{featureContext.item.img}}" alt="{{featureContext.item.name}}">
@@ -25,7 +25,7 @@
         </div>
         <div class="item-column item-type">{{localize typeLabel}}</div>
         <div class="item-column item-controls">
-          <a class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}" data-action="toggleDocumentEmbed"></a>
+          <a class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
         </div>
       </div>
       <div class="document-description item-embed {{#if featureContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/item/effects.hbs
+++ b/templates/sheets/item/effects.hbs
@@ -30,7 +30,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}">
+        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-id="{{@root.document.id}}">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">

--- a/templates/sheets/item/effects.hbs
+++ b/templates/sheets/item/effects.hbs
@@ -54,7 +54,7 @@
             </div>
           </div>
           <div class="document-embed effect-description {{#if effect.expanded}}expanded{{/if}}">
-            {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
+            {{#if effect.expanded}}{{{effect.enrichedDescription.outerHTML}}}{{/if}}
           </div>
         </li>
         {{/each}}

--- a/templates/sheets/item/effects.hbs
+++ b/templates/sheets/item/effects.hbs
@@ -30,7 +30,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-id="{{@root.document.id}}">
+        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-uuid="{{@root.document.uuid}}">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -53,7 +53,7 @@
               <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentEmbed"></a>
             </div>
           </div>
-          <div class="document-embed effect-description {{#if effect.expanded}}expanded{{/if}}">
+          <div class="document-description effect-description {{#if effect.expanded}}expanded{{/if}}">
             {{#if effect.expanded}}{{{effect.enrichedDescription.outerHTML}}}{{/if}}
           </div>
         </li>

--- a/templates/sheets/item/effects.hbs
+++ b/templates/sheets/item/effects.hbs
@@ -30,7 +30,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-uuid="{{@root.document.uuid}}">
+        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-uuid="{{effect.uuid}}" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}" data-parent-id="{{@root.document.id}}" data-parent-uuid="{{@root.document.uuid}}" data-parent-document-name="{{effect.parent.documentName}}">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -50,7 +50,7 @@
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
               <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.ActiveEffect.Name")}}"></a>
               {{/if}}
-              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentEmbed"></a>
+              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentDescription"></a>
             </div>
           </div>
           <div class="document-description effect-description {{#if effect.expanded}}expanded{{/if}}">

--- a/templates/sheets/item/effects.hbs
+++ b/templates/sheets/item/effects.hbs
@@ -30,7 +30,7 @@
       </li>
       <ol class="effect-list">
         {{#each section.effects as |effect|}}
-        <li class="effect draggable" data-effect-id="{{effect.id}}">
+        <li class="effect draggable expandable-document" data-document-class="ActiveEffect" data-document-id="{{effect.id}}" data-effect-id="{{effect.id}}">
           <div class="effect-row">
             <div class="effect-name">
               <img class="effect-image" src="{{effect.img}}" alt="{{effect.name}}">
@@ -50,10 +50,10 @@
               {{!-- <!-- eslint-disable-next-line @html-eslint/quotes --> --}}
               <a class="effect-control fa-fw fa-solid fa-trash" data-action="deleteDoc" data-tooltip-text="{{localize "DOCUMENT.Delete" type=(localize "DRAW_STEEL.ActiveEffect.Name")}}"></a>
               {{/if}}
-              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleEffectDescription"></a>
+              <a class="fa-fw fa-solid fa-angle-{{ifThen effect.expanded 'down' 'right'}}" data-action="toggleDocumentEmbed"></a>
             </div>
           </div>
-          <div class="effect-description">
+          <div class="document-embed effect-description {{#if effect.expanded}}expanded{{/if}}">
             {{#if effect.expanded}}{{{effect.enrichedDescription}}}{{/if}}
           </div>
         </li>


### PR DESCRIPTION
Closes #626 

Moved the `_getEmbeddedDocument` function to the mixin. Kept it the same basically, with accounting for unowned AE's.

I think I've test different scenarios to make sure it all functions the way it did previously.

I noticed that the CSS for item-lists and effect-lists is largely similar. It might be good to add like `document-list` to the classes and then move most of the CSS to that.

In a future PR, we could probably also move the view/create/deleteDoc actions from the actor and item sheets to the mixin.