### PR TITLE
[#1119] Use token name in PR dialog and add target token hovering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - New Compendium Content:
   - Demon Echelons 2-4
 - Added suggested books and licenses in the source input form. (#841)
+- In the Power Roll Dialog, when hovering a target's name and modifiers, the target's token will be highlighted as well.
 
 ### Changed
 
@@ -34,6 +35,7 @@
   - Revised i18n strings for many of the "All" types, e.g. "All creatures" => "Each creature".
 - Removed the limitation on one non-minion creature in Squad combat groups. (#1040)
   - Added controls to the combatants' context menu to toggle whether that monster is the captain or not.
+- In the Power Roll Dialog, changed the target's name from the actor name to the token name. (#1119)
 - Non-default skills and languages added to an actor or advancement will stick around even if the code that added them to ds.CONFIG is no longer active.
 - Renamed the "AbilityBonus" class to "AbilityModifier", the `type` is still `"abilityModifier"`.
 

--- a/src/module/applications/apps/power-roll-dialog.mjs
+++ b/src/module/applications/apps/power-roll-dialog.mjs
@@ -2,6 +2,8 @@ import { systemPath } from "../../constants.mjs";
 import PowerRoll from "../../rolls/power.mjs";
 import RollDialog from "../api/roll-dialog.mjs";
 
+/** @import DrawSteelToken  from "../../canvas/placeables/token.mjs" */
+
 const { FormDataExtended } = foundry.applications.ux;
 
 /**
@@ -29,6 +31,14 @@ export default class PowerRollDialog extends RollDialog {
 
   /* -------------------------------------------------- */
 
+  /**
+   * The currently highlighted token.
+   * @type {DrawSteelToken | null}
+   */
+  #highlightedToken = null;
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   async _preparePartContext(partId, context, options) {
     context = await super._preparePartContext(partId, context, options);
@@ -47,6 +57,28 @@ export default class PowerRollDialog extends RollDialog {
     }
 
     return context;
+  }
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+
+    if (context.targets) {
+      // Add event listeners to trigger target token hovering.
+      this.element.addEventListener("pointermove", event => {
+        if (!canvas.ready) return;
+
+        const tokenUuid = event.target.closest(".target.group[data-token-uuid]")?.dataset.tokenUuid;
+        const token = this.options.context.targets.find(target => target.tokenUuid === tokenUuid)?.token.object;
+        if (token && token._canHover(game.user, event) && token.visible) {
+          token._onHoverIn(event, { hoverOutOthers: true });
+          this.#highlightedToken = token;
+        } else {
+          this.#highlightedToken?._onHoverOut(event);
+          this.#highlightedToken = null;
+        }
+      });
+    }
   }
 
   /* -------------------------------------------------- */
@@ -82,6 +114,7 @@ export default class PowerRollDialog extends RollDialog {
   async _prepareTargets(context) {
     for (const target of context.targets) {
       if (!target.actor) target.actor = await fromUuid(target.uuid);
+      if (!target.token) target.token = await fromUuid(target.tokenUuid);
 
       target.combinedModifiers = {
         edges: Math.clamp(target.modifiers.edges + context.modifiers.edges, 0, PowerRoll.MAX_EDGE),

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -443,6 +443,7 @@ export default class AbilityModel extends BaseItemModel {
         modifiers: options.modifiers,
         targets: [...game.user.targets].reduce((accumulator, target) => {
           accumulator.push({
+            tokenUuid: target.document.uuid,
             uuid: target.actor?.uuid ?? "",
             modifiers: this.getTargetModifiers(target),
           });

--- a/templates/apps/power-roll-dialog.hbs
+++ b/templates/apps/power-roll-dialog.hbs
@@ -21,8 +21,8 @@
     </div>
   </div>
   {{#each targets as |target|}}
-  <div class="target group">
-    <div class="header">{{target.actor.name}}</div>
+  <div class="target group" data-token-uuid="{{target.token.uuid}}">
+    <div class="header">{{target.token.name}}</div>
     <div class="modifiers">
       <label>
         <span>{{localize "DRAW_STEEL.ROLL.Power.Modifier.Edges"}}</span>


### PR DESCRIPTION
Closes #1119 

The issue only requests to use token name instead of actor name to more easily separate the targets. I figured a good improvement would be token hovering similar to the combat tracker, since a player may not always know which name goes with which token.