### PR TITLE
Fix typo in "Acolyte of Fire" effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,9 @@
 ### Fixed
 
 - Player-Facing Compendium data fixes:
-  - Dragon Knight Wyrmplate and Prismatic Scales referred to wrong attribute key. (#1108)
+  - Corrected attribute key for Dragon Knight Wyrmplate and Prismatic Scales. (#1108)
   - Various ancestry immunities and weaknesses switched to Upgrade from Add to prevent stacking. (#1134)
+  - Corrected attribute key for Acolyte of Fire. (#1151)
   - Talent Choke ability didn't have the characteristic selected for the potency and had an unnecessary Active Effect.
 - GM-Facing Compendium Data fixes:
   - Bendrak "Warp Perception" now uses a customized Weakened. (#1104)

--- a/src/packs/classes/Elementalist_SVgKuVoWB0FrXkal/Features_JwIyKm3943QCjSQQ/Fire_gWcqrI8cFJGHNpit/feature_Acolyte_of_Fire_M6BXDQml9cHpYFgP.json
+++ b/src/packs/classes/Elementalist_SVgKuVoWB0FrXkal/Features_JwIyKm3943QCjSQQ/Fire_gWcqrI8cFJGHNpit/feature_Acolyte_of_Fire_M6BXDQml9cHpYFgP.json
@@ -44,7 +44,7 @@
           "priority": null
         },
         {
-          "key": "damage.tier2value",
+          "key": "damage.tier2.value",
           "mode": 2,
           "value": "1",
           "priority": null


### PR DESCRIPTION
Fixes #1151 - tl;dr: A typo in "Acolyte of Fire" caused an exception when applying bonuses.