### PR TITLE
[#1147] Add move action type and default move actions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -813,6 +813,7 @@
           "FreeManeuver": "Free Maneuver",
           "Triggered": "Triggered Action",
           "FreeTriggered": "Free Triggered Action",
+          "Move": "Move Action",
           "None": "No Action",
           "Villain": "Villain Action"
         },

--- a/lang/en.json
+++ b/lang/en.json
@@ -813,7 +813,7 @@
           "FreeManeuver": "Free Maneuver",
           "Triggered": "Triggered Action",
           "FreeTriggered": "Free Triggered Action",
-          "Move": "Move Action",
+          "Move": "Move",
           "None": "No Action",
           "Villain": "Villain Action"
         },

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -813,6 +813,12 @@ export const hero = {
     "Compendium.draw-steel.abilities.Item.eqUobBcm81mqZVgJ",
     // Stand Up
     "Compendium.draw-steel.abilities.Item.XeUU0Blvi0fy0b2G",
+    // Advance
+    "Compendium.draw-steel.abilities.Item.ucR2C7lMvXrKIMZ7",
+    // Disengage
+    "Compendium.draw-steel.abilities.Item.vBlTvHRZ5JBXWYt6",
+    // Ride
+    "Compendium.draw-steel.abilities.Item.QXOkflcYF6DITJE3",
   ]),
   /**
    * XP progression for heroes.
@@ -1097,6 +1103,9 @@ const abilityTypes = {
   freeTriggered: {
     label: "DRAW_STEEL.Item.ability.Type.FreeTriggered",
     triggered: true,
+  },
+  move: {
+    label: "DRAW_STEEL.Item.ability.Type.Move",
   },
   none: {
     label: "DRAW_STEEL.Item.ability.Type.None",

--- a/src/packs/abilities/Basic_Abilities_YKzQ5cCX8knW8fAc/ability_Advance_ucR2C7lMvXrKIMZ7.json
+++ b/src/packs/abilities/Basic_Abilities_YKzQ5cCX8knW8fAc/ability_Advance_ucR2C7lMvXrKIMZ7.json
@@ -1,0 +1,62 @@
+{
+  "folder": "YKzQ5cCX8knW8fAc",
+  "name": "Advance",
+  "type": "ability",
+  "_id": "ucR2C7lMvXrKIMZ7",
+  "img": "icons/skills/movement/feet-bladed-boots-fire.webp",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "272",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "advance",
+    "story": "",
+    "keywords": [],
+    "type": "move",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self",
+      "custom": ""
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>When a creature takes the Advance move action, they move a number of squares up to their speed. They can break up this movement with their maneuver and main action however they wish.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.348",
+    "systemId": "draw-steel",
+    "systemVersion": "0.9.0",
+    "createdTime": 1758665540843,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!ucR2C7lMvXrKIMZ7"
+}

--- a/src/packs/abilities/Basic_Abilities_YKzQ5cCX8knW8fAc/ability_Disengage_vBlTvHRZ5JBXWYt6.json
+++ b/src/packs/abilities/Basic_Abilities_YKzQ5cCX8knW8fAc/ability_Disengage_vBlTvHRZ5JBXWYt6.json
@@ -1,0 +1,62 @@
+{
+  "folder": "YKzQ5cCX8knW8fAc",
+  "name": "Disengage",
+  "type": "ability",
+  "_id": "vBlTvHRZ5JBXWYt6",
+  "img": "icons/skills/movement/feet-spurred-boots-brown.webp",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "272",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "disengage",
+    "story": "",
+    "keywords": [],
+    "type": "move",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self",
+      "custom": ""
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>When a creature takes the Disengage move action, they can shift 1 square. Certain class features, kits, and other rules allow a creature to shift more than 1 square when they disengage. A creature who does so can break up their shift with their maneuver and main action however they wish.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.348",
+    "systemId": "draw-steel",
+    "systemVersion": "0.9.0",
+    "createdTime": 1758665655715,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!vBlTvHRZ5JBXWYt6"
+}

--- a/src/packs/abilities/Basic_Abilities_YKzQ5cCX8knW8fAc/ability_Ride_QXOkflcYF6DITJE3.json
+++ b/src/packs/abilities/Basic_Abilities_YKzQ5cCX8knW8fAc/ability_Ride_QXOkflcYF6DITJE3.json
@@ -1,0 +1,62 @@
+{
+  "folder": "YKzQ5cCX8knW8fAc",
+  "name": "Ride",
+  "type": "ability",
+  "_id": "QXOkflcYF6DITJE3",
+  "img": "icons/environment/people/cavalry.webp",
+  "system": {
+    "source": {
+      "book": "Heroes",
+      "page": "272",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "ride",
+    "story": "",
+    "keywords": [],
+    "type": "move",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "self"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self",
+      "custom": ""
+    },
+    "power": {
+      "roll": {
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effect": {
+      "before": "<p>A creature can take the Ride move action only while mounted on another creature. When a creature takes the Ride move action, they cause their mount to move up to the mount’s speed, taking the rider with them. Alternatively, a creature can use the Ride move action to have their mount use the Disengage move action as a free triggered action. A creature can use the Ride move action only once per round. A mounted creature can only have this move action applied to them once per round. This movement can be broken up with the rider’s maneuver and main action however they wish.</p>",
+      "after": ""
+    },
+    "spend": {
+      "text": "",
+      "value": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.348",
+    "systemId": "draw-steel",
+    "systemVersion": "0.9.0",
+    "createdTime": 1758665687967,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  },
+  "_key": "!items!QXOkflcYF6DITJE3"
+}


### PR DESCRIPTION
Closes #1147 
Closes #530 

Added the move action type to the config. Since we're adding this action type, I went ahead and added default core moves (advance, disengage, and ride) as new basic abilities to be auto populated on heroes.