### PR TITLE
[#1173] Corrected roles for Grulqin, Orliq, and Wobalas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
     - Corrected Hrraaaaaagh! ability to be a free triggered action. (#1145)
     - Added 1 malice cost to the Hrraaaaaagh! ability per errata.
     - Corrected the description of the Destructive Path feature per errata.
+  - Corrected monster roles to the Grulqin, Orliq, and Wobalas. (#1173)
 
 ## 0.8.1
 

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
@@ -1,7 +1,7 @@
 {
   "name": "Grulqin",
   "type": "npc",
-  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "img": "systems/draw-steel/assets/roles/brute.webp",
   "system": {
     "stamina": {
       "value": 9,
@@ -373,7 +373,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "src": "systems/draw-steel/assets/roles/brute.webp",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
@@ -95,7 +95,7 @@
       ],
       "level": 4,
       "ev": 6,
-      "role": "minion",
+      "role": "brute",
       "organization": "minion"
     }
   },

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Lumbering_Egress_PgfTJjJwE66nvFkA.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Lumbering_Egress_PgfTJjJwE66nvFkA.json
@@ -95,7 +95,7 @@
       ],
       "level": 6,
       "ev": 32,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
@@ -1,7 +1,7 @@
 {
   "name": "Orliq",
   "type": "npc",
-  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "img": "systems/draw-steel/assets/roles/brute.webp",
   "system": {
     "stamina": {
       "value": 8,
@@ -465,7 +465,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "src": "systems/draw-steel/assets/roles/brute.webp",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
@@ -96,7 +96,7 @@
       ],
       "level": 4,
       "ev": 6,
-      "role": "minion",
+      "role": "harrier",
       "organization": "minion"
     }
   },

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
@@ -1,7 +1,7 @@
 {
   "name": "Wobalas",
   "type": "npc",
-  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "img": "systems/draw-steel/assets/roles/brute.webp",
   "system": {
     "stamina": {
       "value": 7,
@@ -342,7 +342,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "src": "systems/draw-steel/assets/roles/brute.webp",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
@@ -95,7 +95,7 @@
       ],
       "level": 4,
       "ev": 6,
-      "role": "minion",
+      "role": "artillery",
       "organization": "minion"
     }
   },

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Ordinator_GMlN5QMe8ETbrF7p.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Ordinator_GMlN5QMe8ETbrF7p.json
@@ -97,7 +97,7 @@
       ],
       "level": 3,
       "ev": 20,
-      "role": "leader",
+      "role": "",
       "organization": "leader"
     }
   },
@@ -1202,7 +1202,7 @@
     "exportSource": null,
     "coreVersion": "13.348",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.1",
+    "systemVersion": "0.9.0",
     "createdTime": 1757118122491,
     "modifiedTime": null,
     "lastModifiedBy": null


### PR DESCRIPTION
Closes #1173 

They had invalid roles of "minion". Added their correct roles. 

Since we had this issue with monsters having the solo role too, I did a search in the packs folder for invalid roles. Found two more that had a "leader" role which wasn't correct. Updated those as well.