### PR TITLE
Radenwight "Trouser Cut" ability adds custom "Pantsed" effect. (#1146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
     - Added 1 malice cost to the Hrraaaaaagh! ability per errata.
     - Corrected the description of the Destructive Path feature per errata.
   - Corrected monster roles to the Grulqin, Orliq, and Wobalas. (#1173)
+  - Radenwight "Trouser Cut" applies a custom "Pantsed" effect. (#1146)
 
 ## 0.8.1
 

--- a/src/packs/monster-features/Malice_Features_lr85fBx5XwieZOfH/Radenwight_Malice_03K0sUwNwFfBqFBD/ability_Trouser_Cut_wXnCVvnrDSeah9ks.json
+++ b/src/packs/monster-features/Malice_Features_lr85fBx5XwieZOfH/Radenwight_Malice_03K0sUwNwFfBqFBD/ability_Trouser_Cut_wXnCVvnrDSeah9ks.json
@@ -100,6 +100,38 @@
               "display": "taunted (EoT)"
             }
           }
+        },
+        "QdFMpIV605bQ2ACQ": {
+          "name": "Pantsed",
+          "img": null,
+          "type": "applied",
+          "_id": "QdFMpIV605bQ2ACQ",
+          "applied": {
+            "tier1": {
+              "effects": {
+                "iwDfJBIJlMiF4Olr": {
+                  "condition": "always",
+                  "end": ""
+                }
+              }
+            },
+            "tier2": {
+              "effects": {
+                "iwDfJBIJlMiF4Olr": {
+                  "condition": "always",
+                  "end": ""
+                }
+              }
+            },
+            "tier3": {
+              "effects": {
+                "iwDfJBIJlMiF4Olr": {
+                  "condition": "always",
+                  "end": ""
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -112,7 +144,63 @@
       "value": null
     }
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Pantsed",
+      "img": "icons/equipment/leg/cuisses-leather-red.webp",
+      "type": "base",
+      "origin": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
+      "transfer": false,
+      "_id": "iwDfJBIJlMiF4Olr",
+      "system": {
+        "end": {
+          "type": "",
+          "roll": "1d10 + @combat.save.bonus"
+        }
+      },
+      "changes": [
+        {
+          "key": "system.movement.value",
+          "mode": 3,
+          "value": "0",
+          "priority": null
+        },
+        {
+          "key": "system.movement.disengage",
+          "mode": 3,
+          "value": "0",
+          "priority": null
+        }
+      ],
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "seconds": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.347",
+        "systemId": "draw-steel",
+        "systemVersion": "0.9.0",
+        "createdTime": 1758940905342,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      },
+      "_key": "!items.effects!wXnCVvnrDSeah9ks.iwDfJBIJlMiF4Olr"
+    }
+  ],
   "sort": 0,
   "ownership": {
     "default": 0
@@ -124,7 +212,7 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1755703906248,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Bruxer_HSUqmBWYzQjG5khd.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Bruxer_HSUqmBWYzQjG5khd.json
@@ -40,8 +40,8 @@
     "movement": {
       "value": 5,
       "types": [
-        "climb",
-        "walk"
+        "walk",
+        "climb"
       ],
       "hover": false,
       "disengage": 1
@@ -502,6 +502,129 @@
     },
     {
       "folder": "03K0sUwNwFfBqFBD",
+      "name": "Rat Race",
+      "type": "ability",
+      "_id": "0zjdyVm5OyRADecM",
+      "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
+      "system": {
+        "source": {
+          "book": "Monsters",
+          "page": "225",
+          "license": "Draw Steel Creator License"
+        },
+        "_dsid": "rat-race",
+        "story": "",
+        "keywords": [],
+        "type": "none",
+        "category": "heroic",
+        "resource": 5,
+        "trigger": "A Radenwight's turn starts.",
+        "distance": {
+          "type": "special"
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "special",
+          "value": null
+        },
+        "power": {
+          "roll": {
+            "formula": "@chr",
+            "characteristics": []
+          },
+          "effects": {}
+        },
+        "effect": {
+          "before": "<p>Each radenwight in the encounter shifts up to their speed. If a radenwight ends this shift adjacent to one or more radenwights, they can make a melee free strike against each enemy adjacent to them.</p>",
+          "after": ""
+        },
+        "spend": {
+          "text": "",
+          "value": null
+        }
+      },
+      "effects": [],
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "R75FAhxK5fADaoJF": 3
+      },
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.1",
+        "lastModifiedBy": null,
+        "modifiedTime": null
+      },
+      "_key": "!actors.items!HSUqmBWYzQjG5khd.0zjdyVm5OyRADecM"
+    },
+    {
+      "folder": "03K0sUwNwFfBqFBD",
+      "name": "Rally the Rodents",
+      "type": "ability",
+      "_id": "jhYQClVszlAUFkeJ",
+      "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
+      "system": {
+        "source": {
+          "book": "Monsters",
+          "page": "225",
+          "license": "Draw Steel Creator License"
+        },
+        "_dsid": "rally-the-rodents",
+        "story": "",
+        "keywords": [],
+        "type": "none",
+        "category": "heroic",
+        "resource": 7,
+        "trigger": "A Radenwight's turn starts.",
+        "distance": {
+          "type": "special"
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "special"
+        },
+        "power": {
+          "roll": {
+            "formula": "@chr",
+            "characteristics": []
+          },
+          "effects": {}
+        },
+        "effect": {
+          "before": "<p>A radenwight uses music to coordinate living rats, forming a 10 wall of rats scurrying atop one another into unoccupied spaces anywhere on the encounter map. The wall doesn’t block line of effect for radenwights and their allies, but it does for other creatures as the rats coordinate their movements with the radenwights. Each square of the wall has 10 Stamina.</p><p>If the last radenwight in the encounter dies and the wall is still standing, the rats let out a hideous screech as they disperse. Each enemy on the encounter map makes an Intuition test.</p><p></p><table><tbody><tr><td data-colwidth=\"104\"><p>11 or less</p></td><td><p>[[/damage 7 sonic]] damage; the target can’t take a respite activity during their next respite.</p></td></tr><tr><td data-colwidth=\"104\"><p>12-16</p></td><td><p>[[/damage 5 sonic]] damage.</p></td></tr><tr><td data-colwidth=\"104\"><p>17+</p></td><td><p>No effect.</p></td></tr></tbody></table>",
+          "after": ""
+        },
+        "spend": {
+          "text": "",
+          "value": null
+        }
+      },
+      "effects": [],
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "R75FAhxK5fADaoJF": 3
+      },
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "draw-steel",
+        "systemVersion": "0.8.1",
+        "lastModifiedBy": null,
+        "modifiedTime": null
+      },
+      "_key": "!actors.items!HSUqmBWYzQjG5khd.jhYQClVszlAUFkeJ"
+    },
+    {
+      "folder": "03K0sUwNwFfBqFBD",
       "name": "Trouser Cut",
       "type": "ability",
       "_id": "wXnCVvnrDSeah9ks",
@@ -531,7 +654,8 @@
         "damageDisplay": "melee",
         "target": {
           "type": "creature",
-          "value": 1
+          "value": 1,
+          "custom": ""
         },
         "power": {
           "roll": {
@@ -661,6 +785,56 @@
                   }
                 }
               }
+            },
+            "QdFMpIV605bQ2ACQ": {
+              "name": "Pantsed",
+              "img": null,
+              "type": "applied",
+              "_id": "QdFMpIV605bQ2ACQ",
+              "applied": {
+                "tier1": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
             }
           }
         },
@@ -673,147 +847,79 @@
           "value": null
         }
       },
-      "effects": [],
-      "sort": 200000,
+      "effects": [
+        {
+          "name": "Pantsed",
+          "img": "icons/equipment/leg/cuisses-leather-red.webp",
+          "type": "base",
+          "origin": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
+          "transfer": false,
+          "_id": "iwDfJBIJlMiF4Olr",
+          "system": {
+            "end": {
+              "type": "",
+              "roll": "1d10 + @combat.save.bonus"
+            }
+          },
+          "changes": [
+            {
+              "key": "system.movement.value",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            },
+            {
+              "key": "system.movement.disengage",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            }
+          ],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "combat": null,
+            "seconds": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [],
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "exportSource": null,
+            "coreVersion": "13.347",
+            "systemId": "draw-steel",
+            "systemVersion": "0.9.0",
+            "lastModifiedBy": null
+          },
+          "_key": "!actors.items.effects!HSUqmBWYzQjG5khd.wXnCVvnrDSeah9ks.iwDfJBIJlMiF4Olr"
+        }
+      ],
+      "sort": 0,
       "ownership": {
         "default": 0,
-        "R75FAhxK5fADaoJF": 3
+        "oHPurzNpicrNtJsX": 3
       },
       "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.347",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.1",
-        "lastModifiedBy": null,
-        "modifiedTime": null
+        "systemVersion": "0.9.0",
+        "createdTime": 1758945962759,
+        "modifiedTime": null,
+        "lastModifiedBy": null
       },
       "_key": "!actors.items!HSUqmBWYzQjG5khd.wXnCVvnrDSeah9ks"
-    },
-    {
-      "folder": "03K0sUwNwFfBqFBD",
-      "name": "Rat Race",
-      "type": "ability",
-      "_id": "0zjdyVm5OyRADecM",
-      "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
-      "system": {
-        "source": {
-          "book": "Monsters",
-          "page": "225",
-          "license": "Draw Steel Creator License"
-        },
-        "_dsid": "rat-race",
-        "story": "",
-        "keywords": [],
-        "type": "none",
-        "category": "heroic",
-        "resource": 5,
-        "trigger": "A Radenwight's turn starts.",
-        "distance": {
-          "type": "special"
-        },
-        "damageDisplay": "melee",
-        "target": {
-          "type": "special",
-          "value": null
-        },
-        "power": {
-          "roll": {
-            "formula": "@chr",
-            "characteristics": []
-          },
-          "effects": {}
-        },
-        "effect": {
-          "before": "<p>Each radenwight in the encounter shifts up to their speed. If a radenwight ends this shift adjacent to one or more radenwights, they can make a melee free strike against each enemy adjacent to them.</p>",
-          "after": ""
-        },
-        "spend": {
-          "text": "",
-          "value": null
-        }
-      },
-      "effects": [],
-      "sort": 0,
-      "ownership": {
-        "default": 0,
-        "R75FAhxK5fADaoJF": 3
-      },
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.348",
-        "systemId": "draw-steel",
-        "systemVersion": "0.8.1",
-        "lastModifiedBy": null,
-        "modifiedTime": null
-      },
-      "_key": "!actors.items!HSUqmBWYzQjG5khd.0zjdyVm5OyRADecM"
-    },
-    {
-      "folder": "03K0sUwNwFfBqFBD",
-      "name": "Rally the Rodents",
-      "type": "ability",
-      "_id": "jhYQClVszlAUFkeJ",
-      "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
-      "system": {
-        "source": {
-          "book": "Monsters",
-          "page": "225",
-          "license": "Draw Steel Creator License"
-        },
-        "_dsid": "rally-the-rodents",
-        "story": "",
-        "keywords": [],
-        "type": "none",
-        "category": "heroic",
-        "resource": 7,
-        "trigger": "A Radenwight's turn starts.",
-        "distance": {
-          "type": "special"
-        },
-        "damageDisplay": "melee",
-        "target": {
-          "type": "special"
-        },
-        "power": {
-          "roll": {
-            "formula": "@chr",
-            "characteristics": []
-          },
-          "effects": {}
-        },
-        "effect": {
-          "before": "<p>A radenwight uses music to coordinate living rats, forming a 10 wall of rats scurrying atop one another into unoccupied spaces anywhere on the encounter map. The wall doesn’t block line of effect for radenwights and their allies, but it does for other creatures as the rats coordinate their movements with the radenwights. Each square of the wall has 10 Stamina.</p><p>If the last radenwight in the encounter dies and the wall is still standing, the rats let out a hideous screech as they disperse. Each enemy on the encounter map makes an Intuition test.</p><p></p><table><tbody><tr><td data-colwidth=\"104\"><p>11 or less</p></td><td><p>[[/damage 7 sonic]] damage; the target can’t take a respite activity during their next respite.</p></td></tr><tr><td data-colwidth=\"104\"><p>12-16</p></td><td><p>[[/damage 5 sonic]] damage.</p></td></tr><tr><td data-colwidth=\"104\"><p>17+</p></td><td><p>No effect.</p></td></tr></tbody></table>",
-          "after": ""
-        },
-        "spend": {
-          "text": "",
-          "value": null
-        }
-      },
-      "effects": [],
-      "sort": 0,
-      "ownership": {
-        "default": 0,
-        "R75FAhxK5fADaoJF": 3
-      },
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.348",
-        "systemId": "draw-steel",
-        "systemVersion": "0.8.1",
-        "lastModifiedBy": null,
-        "modifiedTime": null
-      },
-      "_key": "!actors.items!HSUqmBWYzQjG5khd.jhYQClVszlAUFkeJ"
     }
   ],
   "folder": "DQYQ5rpRsohluWYD",
@@ -920,9 +1026,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.348",
+    "coreVersion": "13.347",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.1",
+    "systemVersion": "0.9.0",
     "createdTime": 1757284213396,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Maestro_mkez5eqX6Les2RJ9.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Maestro_mkez5eqX6Les2RJ9.json
@@ -361,198 +361,6 @@
       "_key": "!actors.items!mkez5eqX6Les2RJ9.0zjdyVm5OyRADecM"
     },
     {
-      "folder": "03K0sUwNwFfBqFBD",
-      "name": "Trouser Cut",
-      "type": "ability",
-      "_id": "wXnCVvnrDSeah9ks",
-      "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
-      "system": {
-        "source": {
-          "book": "Monsters",
-          "page": "225",
-          "license": "Draw Steel Creator License"
-        },
-        "_dsid": "trouser-cut",
-        "story": "",
-        "keywords": [
-          "melee",
-          "strike",
-          "weapon"
-        ],
-        "type": "main",
-        "category": "heroic",
-        "resource": 3,
-        "trigger": "",
-        "distance": {
-          "type": "melee",
-          "primary": 1,
-          "secondary": null
-        },
-        "damageDisplay": "melee",
-        "target": {
-          "type": "creature",
-          "value": 1
-        },
-        "power": {
-          "roll": {
-            "formula": "2",
-            "characteristics": []
-          },
-          "effects": {
-            "J8ZyFtvUeh7fUU06": {
-              "name": "Damage",
-              "img": null,
-              "type": "damage",
-              "_id": "J8ZyFtvUeh7fUU06",
-              "damage": {
-                "tier1": {
-                  "value": "7",
-                  "types": [],
-                  "properties": [],
-                  "potency": {
-                    "value": "@potency.weak",
-                    "characteristic": "none"
-                  }
-                },
-                "tier2": {
-                  "value": "10",
-                  "types": [],
-                  "properties": [],
-                  "potency": {
-                    "value": "@potency.average",
-                    "characteristic": ""
-                  }
-                },
-                "tier3": {
-                  "value": "13",
-                  "types": [],
-                  "properties": [],
-                  "potency": {
-                    "value": "@potency.strong",
-                    "characteristic": ""
-                  }
-                }
-              }
-            },
-            "UZvfj8gwWwSlTK6s": {
-              "name": "Push",
-              "img": null,
-              "type": "forced",
-              "_id": "UZvfj8gwWwSlTK6s",
-              "forced": {
-                "tier1": {
-                  "distance": "3",
-                  "display": "{{forced}}",
-                  "movement": [
-                    "push"
-                  ],
-                  "properties": [],
-                  "potency": {
-                    "value": "@potency.weak",
-                    "characteristic": "none"
-                  }
-                },
-                "tier2": {
-                  "distance": "3",
-                  "display": "{{forced}}",
-                  "movement": [
-                    "push"
-                  ],
-                  "properties": [],
-                  "potency": {
-                    "value": "@potency.average",
-                    "characteristic": ""
-                  }
-                },
-                "tier3": {
-                  "distance": "5",
-                  "display": "{{forced}}",
-                  "movement": [
-                    "push"
-                  ],
-                  "properties": [],
-                  "potency": {
-                    "value": "@potency.strong",
-                    "characteristic": ""
-                  }
-                }
-              }
-            },
-            "zQHVPeyhyCj2ux4J": {
-              "name": "Taunted",
-              "img": null,
-              "type": "applied",
-              "_id": "zQHVPeyhyCj2ux4J",
-              "applied": {
-                "tier1": {
-                  "display": "",
-                  "effects": {},
-                  "potency": {
-                    "value": "@potency.weak",
-                    "characteristic": "none"
-                  }
-                },
-                "tier3": {
-                  "display": "taunted (EoT)",
-                  "effects": {
-                    "taunted": {
-                      "condition": "always",
-                      "end": "turn",
-                      "properties": []
-                    }
-                  },
-                  "potency": {
-                    "value": "@potency.strong",
-                    "characteristic": ""
-                  }
-                },
-                "tier2": {
-                  "effects": {
-                    "taunted": {
-                      "condition": "always",
-                      "end": "turn",
-                      "properties": []
-                    }
-                  },
-                  "display": "taunted (EoT)",
-                  "potency": {
-                    "value": "@potency.average",
-                    "characteristic": ""
-                  }
-                }
-              }
-            }
-          }
-        },
-        "effect": {
-          "before": "",
-          "after": "<p>If the target is wearing clothing covering the lower half of their body, they must use a maneuver once to pull that clothing up before they can move.</p><p><strong>Special:</strong> This ability can’t be used by a minion.</p>"
-        },
-        "spend": {
-          "text": "",
-          "value": null
-        }
-      },
-      "effects": [],
-      "sort": 200000,
-      "ownership": {
-        "default": 0,
-        "R75FAhxK5fADaoJF": 3
-      },
-      "flags": {},
-      "_stats": {
-        "compendiumSource": "Item.wXnCVvnrDSeah9ks",
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.347",
-        "systemId": "draw-steel",
-        "systemVersion": "0.8.0",
-        "lastModifiedBy": null,
-        "modifiedTime": null
-      },
-      "_key": "!actors.items!mkez5eqX6Les2RJ9.wXnCVvnrDSeah9ks"
-    },
-    {
       "name": "Cacophony",
       "type": "ability",
       "system": {
@@ -1108,6 +916,304 @@
         "lastModifiedBy": null
       },
       "_key": "!actors.items!mkez5eqX6Les2RJ9.jhYQClVszlAUFkeJ"
+    },
+    {
+      "folder": "03K0sUwNwFfBqFBD",
+      "name": "Trouser Cut",
+      "type": "ability",
+      "_id": "wXnCVvnrDSeah9ks",
+      "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
+      "system": {
+        "source": {
+          "book": "Monsters",
+          "page": "225",
+          "license": "Draw Steel Creator License"
+        },
+        "_dsid": "trouser-cut",
+        "story": "",
+        "keywords": [
+          "melee",
+          "strike",
+          "weapon"
+        ],
+        "type": "main",
+        "category": "heroic",
+        "resource": 3,
+        "trigger": "",
+        "distance": {
+          "type": "melee",
+          "primary": 1,
+          "secondary": null
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "creature",
+          "value": 1,
+          "custom": ""
+        },
+        "power": {
+          "roll": {
+            "formula": "2",
+            "characteristics": []
+          },
+          "effects": {
+            "J8ZyFtvUeh7fUU06": {
+              "name": "Damage",
+              "img": null,
+              "type": "damage",
+              "_id": "J8ZyFtvUeh7fUU06",
+              "damage": {
+                "tier1": {
+                  "value": "7",
+                  "types": [],
+                  "properties": [],
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "value": "10",
+                  "types": [],
+                  "properties": [],
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "value": "13",
+                  "types": [],
+                  "properties": [],
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            },
+            "UZvfj8gwWwSlTK6s": {
+              "name": "Push",
+              "img": null,
+              "type": "forced",
+              "_id": "UZvfj8gwWwSlTK6s",
+              "forced": {
+                "tier1": {
+                  "distance": "3",
+                  "display": "{{forced}}",
+                  "movement": [
+                    "push"
+                  ],
+                  "properties": [],
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "distance": "3",
+                  "display": "{{forced}}",
+                  "movement": [
+                    "push"
+                  ],
+                  "properties": [],
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "distance": "5",
+                  "display": "{{forced}}",
+                  "movement": [
+                    "push"
+                  ],
+                  "properties": [],
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            },
+            "zQHVPeyhyCj2ux4J": {
+              "name": "Taunted",
+              "img": null,
+              "type": "applied",
+              "_id": "zQHVPeyhyCj2ux4J",
+              "applied": {
+                "tier1": {
+                  "display": "",
+                  "effects": {},
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier3": {
+                  "display": "taunted (EoT)",
+                  "effects": {
+                    "taunted": {
+                      "condition": "always",
+                      "end": "turn",
+                      "properties": []
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                },
+                "tier2": {
+                  "effects": {
+                    "taunted": {
+                      "condition": "always",
+                      "end": "turn",
+                      "properties": []
+                    }
+                  },
+                  "display": "taunted (EoT)",
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                }
+              }
+            },
+            "QdFMpIV605bQ2ACQ": {
+              "name": "Pantsed",
+              "img": null,
+              "type": "applied",
+              "_id": "QdFMpIV605bQ2ACQ",
+              "applied": {
+                "tier1": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            }
+          }
+        },
+        "effect": {
+          "before": "",
+          "after": "<p>If the target is wearing clothing covering the lower half of their body, they must use a maneuver once to pull that clothing up before they can move.</p><p><strong>Special:</strong> This ability can’t be used by a minion.</p>"
+        },
+        "spend": {
+          "text": "",
+          "value": null
+        }
+      },
+      "effects": [
+        {
+          "name": "Pantsed",
+          "img": "icons/equipment/leg/cuisses-leather-red.webp",
+          "type": "base",
+          "origin": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
+          "transfer": false,
+          "_id": "iwDfJBIJlMiF4Olr",
+          "system": {
+            "end": {
+              "type": "",
+              "roll": "1d10 + @combat.save.bonus"
+            }
+          },
+          "changes": [
+            {
+              "key": "system.movement.value",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            },
+            {
+              "key": "system.movement.disengage",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            }
+          ],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "combat": null,
+            "seconds": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [],
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "exportSource": null,
+            "coreVersion": "13.347",
+            "systemId": "draw-steel",
+            "systemVersion": "0.9.0",
+            "lastModifiedBy": null
+          },
+          "_key": "!actors.items.effects!mkez5eqX6Les2RJ9.wXnCVvnrDSeah9ks.iwDfJBIJlMiF4Olr"
+        }
+      ],
+      "sort": 200000,
+      "ownership": {
+        "default": 0,
+        "oHPurzNpicrNtJsX": 3
+      },
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.347",
+        "systemId": "draw-steel",
+        "systemVersion": "0.9.0",
+        "createdTime": 1758946135928,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      },
+      "_key": "!actors.items!mkez5eqX6Les2RJ9.wXnCVvnrDSeah9ks"
     }
   ],
   "effects": [],

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Piper_0gav5RD1rRDqtxqw.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Piper_0gav5RD1rRDqtxqw.json
@@ -581,7 +581,8 @@
         "damageDisplay": "melee",
         "target": {
           "type": "creature",
-          "value": 1
+          "value": 1,
+          "custom": ""
         },
         "power": {
           "roll": {
@@ -711,6 +712,56 @@
                   }
                 }
               }
+            },
+            "QdFMpIV605bQ2ACQ": {
+              "name": "Pantsed",
+              "img": null,
+              "type": "applied",
+              "_id": "QdFMpIV605bQ2ACQ",
+              "applied": {
+                "tier1": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
             }
           }
         },
@@ -723,22 +774,77 @@
           "value": null
         }
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Pantsed",
+          "img": "icons/equipment/leg/cuisses-leather-red.webp",
+          "type": "base",
+          "origin": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
+          "transfer": false,
+          "_id": "iwDfJBIJlMiF4Olr",
+          "system": {
+            "end": {
+              "type": "",
+              "roll": "1d10 + @combat.save.bonus"
+            }
+          },
+          "changes": [
+            {
+              "key": "system.movement.value",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            },
+            {
+              "key": "system.movement.disengage",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            }
+          ],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "combat": null,
+            "seconds": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [],
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "exportSource": null,
+            "coreVersion": "13.347",
+            "systemId": "draw-steel",
+            "systemVersion": "0.9.0",
+            "lastModifiedBy": null
+          },
+          "_key": "!actors.items.effects!0gav5RD1rRDqtxqw.wXnCVvnrDSeah9ks.iwDfJBIJlMiF4Olr"
+        }
+      ],
       "sort": 0,
       "ownership": {
         "default": 0,
-        "R75FAhxK5fADaoJF": 3
+        "oHPurzNpicrNtJsX": 3
       },
       "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.347",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.1",
-        "lastModifiedBy": null,
-        "modifiedTime": null
+        "systemVersion": "0.9.0",
+        "createdTime": 1758946174923,
+        "modifiedTime": null,
+        "lastModifiedBy": null
       },
       "_key": "!actors.items!0gav5RD1rRDqtxqw.wXnCVvnrDSeah9ks"
     }

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Ratcrobat_EvGzzdiWClb2el1r.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Ratcrobat_EvGzzdiWClb2el1r.json
@@ -529,7 +529,8 @@
         "damageDisplay": "melee",
         "target": {
           "type": "creature",
-          "value": 1
+          "value": 1,
+          "custom": ""
         },
         "power": {
           "roll": {
@@ -659,6 +660,56 @@
                   }
                 }
               }
+            },
+            "QdFMpIV605bQ2ACQ": {
+              "name": "Pantsed",
+              "img": null,
+              "type": "applied",
+              "_id": "QdFMpIV605bQ2ACQ",
+              "applied": {
+                "tier1": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "effects": {
+                    "iwDfJBIJlMiF4Olr": {
+                      "condition": "always",
+                      "end": "",
+                      "properties": []
+                    }
+                  },
+                  "display": "",
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
             }
           }
         },
@@ -671,22 +722,77 @@
           "value": null
         }
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Pantsed",
+          "img": "icons/equipment/leg/cuisses-leather-red.webp",
+          "type": "base",
+          "origin": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
+          "transfer": false,
+          "_id": "iwDfJBIJlMiF4Olr",
+          "system": {
+            "end": {
+              "type": "",
+              "roll": "1d10 + @combat.save.bonus"
+            }
+          },
+          "changes": [
+            {
+              "key": "system.movement.value",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            },
+            {
+              "key": "system.movement.disengage",
+              "mode": 3,
+              "value": "0",
+              "priority": null
+            }
+          ],
+          "disabled": false,
+          "duration": {
+            "startTime": null,
+            "combat": null,
+            "seconds": null,
+            "rounds": null,
+            "turns": null,
+            "startRound": null,
+            "startTurn": null
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [],
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "exportSource": null,
+            "coreVersion": "13.347",
+            "systemId": "draw-steel",
+            "systemVersion": "0.9.0",
+            "lastModifiedBy": null
+          },
+          "_key": "!actors.items.effects!EvGzzdiWClb2el1r.wXnCVvnrDSeah9ks.iwDfJBIJlMiF4Olr"
+        }
+      ],
       "sort": 0,
       "ownership": {
         "default": 0,
-        "R75FAhxK5fADaoJF": 3
+        "oHPurzNpicrNtJsX": 3
       },
       "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.draw-steel.monster-features.Item.wXnCVvnrDSeah9ks",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.347",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.1",
-        "lastModifiedBy": null,
-        "modifiedTime": null
+        "systemVersion": "0.9.0",
+        "createdTime": 1758946197980,
+        "modifiedTime": null,
+        "lastModifiedBy": null
       },
       "_key": "!actors.items!EvGzzdiWClb2el1r.wXnCVvnrDSeah9ks"
     }


### PR DESCRIPTION
Pantsed downgrades speed & disengage to 0.
Replace old Trouser Cut ability with updated version.