### PR TITLE
[#1149] Fix AE sorting and SortingHelpers deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
     - Corrected the description of the Destructive Path feature per errata.
   - Corrected monster roles to the Grulqin, Orliq, and Wobalas. (#1173)
   - Radenwight "Trouser Cut" applies a custom "Pantsed" effect. (#1146)
+- Fixed active effects not sorting on actor and item sheets. (#1149)
+- Addressed the SortingHelpers.performIntegerSort depreciation warning. (#1155)
 
 ## 0.8.1
 

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -448,7 +448,8 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
     };
 
     // Iterate over active effects, classifying them into categories
-    for (const e of this.actor.allApplicableEffects()) {
+    const applicableEffects = [...this.actor.allApplicableEffects()].sort((a, b) => a.sort - b.sort);
+    for (const e of applicableEffects) {
       const effectContext = {
         id: e.id,
         uuid: e.uuid,
@@ -859,6 +860,24 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
   /*   Drag and Drop                                    */
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  async _onDragStart(event) {
+    const target = event.currentTarget;
+    if ("link" in event.target.dataset) return;
+    let dragData;
+
+    if (target.dataset.documentUuid) {
+      const document = this._getEmbeddedDocument(target);
+      dragData = document.toDragData();
+    }
+
+    // Set data transfer
+    if (!dragData) return;
+    event.dataTransfer.setData("text/plain", JSON.stringify(dragData));
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Handle a dropped Active Effect on the Actor Sheet.
    * The default implementation creates an Active Effect embedded document on the Actor.
@@ -905,7 +924,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheetMixin(sheets.Act
     }
 
     // Perform the sort
-    const sortUpdates = SortingHelpers.performIntegerSort(effect, {
+    const sortUpdates = foundry.utils.performIntegerSort(effect, {
       target,
       siblings,
     });

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -259,7 +259,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     };
 
     // Iterate over active effects, classifying them into categories
-    for (const e of this.item.effects) {
+    const effects = this.item.effects.contents.sort((a, b) => a.sort - b.sort);
+    for (const e of effects) {
       const effectContext = {
         id: e.id,
         uuid: e.uuid,
@@ -787,7 +788,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     }
 
     // Perform the sort
-    const sortUpdates = SortingHelpers.performIntegerSort(effect, {
+    const sortUpdates = foundry.utils.performIntegerSort(effect, {
       target,
       siblings,
     });


### PR DESCRIPTION
Closes #1149 
Closes #1155 

I did something wrong when I rebased the last PR, so I just closed and opened a new one.

At the end of the last PR I had mentioned I could probably remove parentId, effectId, and itemId. Further reviewing those are actually still used in the core `_onSortItem` and our `onEffectSort` methods. It felt like more of a change than this should handle for a bug/deprecation fix. It's also more than I can handle right now as I'm in the process of moving. Possibly these can be added to the document sheet mixin with a generalized handling once we implement sudoku drag/drop and sorting with #907.