### PR TITLE
Implement static references in PseudoDocument collections

### DIFF
--- a/src/module/applications/api/document-sheet-mixin.mjs
+++ b/src/module/applications/api/document-sheet-mixin.mjs
@@ -214,7 +214,7 @@ export default base => {
     static #createPseudoDocument(event, target) {
       const documentName = target.closest("[data-pseudo-document-name]").dataset.pseudoDocumentName;
       const type = target.closest("[data-pseudo-type]")?.dataset.pseudoType;
-      const Cls = this.document.getEmbeddedPseudoDocumentCollection(documentName).documentClass;
+      const Cls = this.document.getEmbeddedCollection(documentName).documentClass;
 
       if (!type && (foundry.utils.isSubclass(Cls, ds.data.pseudoDocuments.TypedPseudoDocument))) {
         Cls.createDialog({}, { parent: this.document });

--- a/src/module/applications/apps/power-roll-dialog.mjs
+++ b/src/module/applications/apps/power-roll-dialog.mjs
@@ -95,7 +95,7 @@ export default class PowerRollDialog extends RollDialog {
     context.damageOptions = null;
     for (const tier of PowerRoll.TIER_NAMES) {
 
-      const effect = context.ability.system.power.effects.getByType("damage").find(e => e.damage[tier].types.size > 1);
+      const effect = context.ability.system.power.effects.documentsByType.damage.find(e => e.damage[tier].types.size > 1);
       if (!effect) continue;
 
       context.damageOptions = Object.entries(ds.CONFIG.damageTypes)

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -501,7 +501,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
           const name = game.i18n.format("DRAW_STEEL.Item.project.Craft.ItemName", { name: item.name });
           return { name, type: "project", "system.yield.item": item.uuid };
         }
-        else if (item.supportsAdvancements && (item.getEmbeddedPseudoDocumentCollection("Advancement").size > 0)) {
+        else if (item.supportsAdvancements && (item.getEmbeddedCollection("Advancement").size > 0)) {
           ui.notifications.error("DRAW_STEEL.SHEET.NoCreateAdvancement", { format: { name: item.name } });
           return null;
         }

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -192,7 +192,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheetMixin(sheets.Item
     // Advancements
     const advs = {};
     /** @type {foundry.utils.Collection<string, BaseAdvancement>} */
-    const models = this.document.getEmbeddedPseudoDocumentCollection("Advancement")[
+    const models = this.document.getEmbeddedCollection("Advancement")[
       this.isPlayMode ? "contents" : "sourceContents"
     ];
     for (const model of models) {

--- a/src/module/data/fields/lazy-typed-schema-field.mjs
+++ b/src/module/data/fields/lazy-typed-schema-field.mjs
@@ -9,4 +9,26 @@ export default class LazyTypedSchemaField extends foundry.data.fields.TypedSchem
     if (!value || (value.type in this.types)) return super._validateSpecial(value);
     return true;
   }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  _updateCommit(source, key, value, diff, options) {
+    const s = source[key];
+
+    // Special Cases: * -> undefined, * -> null, undefined -> *, null -> *
+    if (!s || !value) {
+      source[key] = value;
+      return;
+    }
+
+    // Update fields in source which changed in the diff
+    const element = this.types[value.type];
+    for (let [k, d] of Object.entries(diff)) {
+      k = foundry.utils.isDeletionKey(k) ? k.slice(2) : k;
+      const field = element.getField(k);
+      if (!field) continue;
+      field._updateCommit(s, k, value[k], d, options);
+    }
+  }
 }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -474,7 +474,7 @@ export default class AbilityModel extends BaseItemModel {
         }
 
         // Filter to the non-zero damage tiers and map them to the tier damage in one loop.
-        const damageEffects = this.power.effects.getByType("damage").reduce((effects, currentEffect) => {
+        const damageEffects = this.power.effects.documentsByType.damage.reduce((effects, currentEffect) => {
           const damage = currentEffect.damage[`tier${tierNumber}`];
           if (Number(damage.value) !== 0) effects.push(damage);
           return effects;

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -110,7 +110,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
       if ((advancementFlags?.advancementId === this.id) && (advancementFlags.parentId === this.document.id)) {
         items.add(item);
         if (item.hasGrantedItems) {
-          for (const advancement of item.getEmbeddedPseudoDocumentCollection("Advancement")) {
+          for (const advancement of item.getEmbeddedCollection("Advancement")) {
             for (const a of advancement.grantedItemsChain?.() ?? []) items.add(a);
           }
         }

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -100,13 +100,8 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * @type {string}
    */
   get fieldPath() {
-    const fp = this.schema.fieldPath;
-    let path = fp.slice(0, fp.lastIndexOf("element") - 1);
-
-    if (this.parent instanceof PseudoDocument) {
-      path = [this.parent.fieldPath, this.parent.id, path].join(".");
-    }
-
+    let path = this.parent.constructor.metadata.embedded[this.documentName];
+    if (this.parent instanceof PseudoDocument) path = [this.parent.fieldPath, this.parent.id, path].join(".");
     return path;
   }
 

--- a/src/module/data/pseudo-documents/pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/pseudo-document.mjs
@@ -139,7 +139,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   prepareBaseData() {
     const documentNames = Object.keys(this.constructor.metadata.embedded);
     for (const documentName of documentNames) {
-      for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) {
+      for (const pseudoDocument of this.getEmbeddedCollection(documentName)) {
         pseudoDocument.prepareBaseData();
       }
     }
@@ -154,7 +154,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
   prepareDerivedData() {
     const documentNames = Object.keys(this.constructor.metadata.embedded);
     for (const documentName of documentNames) {
-      for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) {
+      for (const pseudoDocument of this.getEmbeddedCollection(documentName)) {
         pseudoDocument.prepareDerivedData();
       }
     }
@@ -202,12 +202,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * @returns {PseudoDocument|null}
    */
   getEmbeddedDocument(embeddedName, id, { invalid = false, strict = false } = {}) {
-    const embeds = this.constructor.metadata.embedded ?? {};
-    if (embeddedName in embeds) {
-      const path = embeds[embeddedName];
-      return foundry.utils.getProperty(this, path).get(id, { invalid, strict }) ?? null;
-    }
-    return null;
+    return this.getEmbeddedCollection(embeddedName).get(id, { invalid, strict }) ?? null;
   }
 
   /* -------------------------------------------------- */
@@ -217,7 +212,7 @@ export default class PseudoDocument extends foundry.abstract.DataModel {
    * @param {string} embeddedName   The document name of the embedded collection.
    * @returns {ModelCollection}     The embedded collection.
    */
-  getEmbeddedPseudoDocumentCollection(embeddedName) {
+  getEmbeddedCollection(embeddedName) {
     const collectionPath = this.constructor.metadata.embedded[embeddedName];
     if (!collectionPath) {
       throw new Error(`${embeddedName} is not a valid embedded Pseudo-Document within the [${this.type}] ${this.documentName} subtype!`);

--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -34,7 +34,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
    * @type {Record<string, typeof TypedPseudoDocument>}
    */
   static get TYPES() {
-    return Object.values(ds.CONFIG[this.metadata.documentName]).reduce((acc, { documentClass }) => {
+    return Object.values(this.documentConfig).reduce((acc, { documentClass }) => {
       if (documentClass.TYPE) acc[documentClass.TYPE] = documentClass;
       return acc;
     }, {});
@@ -47,10 +47,20 @@ export default class TypedPseudoDocument extends PseudoDocument {
 
   /* -------------------------------------------------- */
 
+  /**
+   * The object that defines this model's subtypes.
+   * @type {object}
+   */
+  static get documentConfig() {
+    return ds.CONFIG[this.metadata.documentName];
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   prepareBaseData() {
     super.prepareBaseData();
-    this.img ||= ds.CONFIG[this.constructor.metadata.documentName][this.type].defaultImage;
+    this.img ||= this.constructor.documentConfig[this.type].defaultImage;
   }
 
   /* -------------------------------------------------- */
@@ -81,7 +91,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
   static _prepareCreateDialogContext(parent) {
 
     /** @type {FormSelectOption[]} */
-    const typeOptions = Object.entries(ds.CONFIG[this.metadata.documentName]).map(([value, { label }]) => ({ value, label }));
+    const typeOptions = Object.entries(this.documentConfig).map(([value, { label }]) => ({ value, label }));
 
     return {
       typeOptions,
@@ -95,7 +105,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
   static _createDialogRenderCallback(event, dialog) {
     const typeInput = dialog.element.querySelector("[name=\"type\"]");
     const nameInput = dialog.element.querySelector("[name=\"name\"]");
-    nameInput.placeholder = ds.CONFIG[this.metadata.documentName][typeInput.value].label;
-    typeInput.addEventListener("change", () => nameInput.placeholder = ds.CONFIG[this.metadata.documentName][typeInput.value].label);
+    nameInput.placeholder = this.documentConfig[typeInput.value].label;
+    typeInput.addEventListener("change", () => nameInput.placeholder = this.documentConfig[typeInput.value].label);
   }
 }

--- a/src/module/documents/base-document-mixin.mjs
+++ b/src/module/documents/base-document-mixin.mjs
@@ -42,7 +42,7 @@ export default base => {
     prepareBaseData() {
       super.prepareBaseData();
 
-      for (const collection of Object.values(this.pseudoCollections ?? {}))
+      for (const collection of Object.values(this.pseudoCollections))
         for (const pseudo of collection)
           pseudo.prepareBaseData();
     }
@@ -53,7 +53,7 @@ export default base => {
     prepareDerivedData() {
       super.prepareDerivedData();
 
-      for (const collection of Object.values(this.pseudoCollections ?? {}))
+      for (const collection of Object.values(this.pseudoCollections))
         for (const pseudo of collection)
           pseudo.prepareDerivedData();
     }

--- a/src/module/documents/base-document-mixin.mjs
+++ b/src/module/documents/base-document-mixin.mjs
@@ -33,7 +33,7 @@ export default base => {
 
     /** @inheritdoc */
     getEmbeddedCollection(embeddedName) {
-      return this.pseudoCollections?.[embeddedName] ?? super.getEmbeddedCollection(embeddedName);
+      return this.pseudoCollections[embeddedName] ?? super.getEmbeddedCollection(embeddedName);
     }
 
     /* -------------------------------------------------- */

--- a/src/module/documents/base-document-mixin.mjs
+++ b/src/module/documents/base-document-mixin.mjs
@@ -23,8 +23,7 @@ export default base => {
       for (const [documentName, fieldPath] of Object.entries(embedded)) {
         const data = foundry.utils.getProperty(this._source, fieldPath);
         const field = model.schema.getField(fieldPath.slice("system.".length));
-        const c = collections[documentName] = new field.constructor.implementation(documentName, this, data);
-        Object.defineProperty(this, documentName, { value: c, writable: false });
+        collections[documentName] = new field.constructor.implementation(documentName, this, data);
       }
 
       Object.defineProperty(this, "pseudoCollections", { value: Object.seal(collections), writable: false });
@@ -32,29 +31,9 @@ export default base => {
 
     /* -------------------------------------------------- */
 
-    /**
-     * Obtain the embedded collection of a given pseudo-document type.
-     * @param {string} embeddedName   The document name of the embedded collection.
-     * @returns {ModelCollection}     The embedded collection.
-     */
-    getEmbeddedPseudoDocumentCollection(embeddedName) {
-      const collectionPath = this.system?.constructor.metadata.embedded?.[embeddedName];
-      if (!collectionPath) {
-        throw new Error(`${embeddedName} is not a valid embedded Pseudo-Document within the [${this.type}] ${this.documentName} subtype!`);
-      }
-      return foundry.utils.getProperty(this, collectionPath);
-    }
-
-    /* -------------------------------------------------- */
-
     /** @inheritdoc */
-    getEmbeddedDocument(embeddedName, id, { invalid = false, strict = false } = {}) {
-      const systemEmbeds = this.system?.constructor.metadata.embedded ?? {};
-      if (embeddedName in systemEmbeds) {
-        const path = systemEmbeds[embeddedName];
-        return foundry.utils.getProperty(this, path).get(id, { invalid, strict }) ?? null;
-      }
-      return super.getEmbeddedDocument(embeddedName, id, { invalid, strict });
+    getEmbeddedCollection(embeddedName) {
+      return this.pseudoCollections?.[embeddedName] ?? super.getEmbeddedCollection(embeddedName);
     }
 
     /* -------------------------------------------------- */
@@ -62,12 +41,10 @@ export default base => {
     /** @inheritdoc */
     prepareBaseData() {
       super.prepareBaseData();
-      const documentNames = Object.keys(this.system?.constructor.metadata?.embedded ?? {});
-      for (const documentName of documentNames) {
-        for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) {
-          pseudoDocument.prepareBaseData();
-        }
-      }
+
+      for (const collection of Object.values(this.pseudoCollections ?? {}))
+        for (const pseudo of collection)
+          pseudo.prepareBaseData();
     }
 
     /* -------------------------------------------------- */
@@ -75,12 +52,10 @@ export default base => {
     /** @inheritdoc */
     prepareDerivedData() {
       super.prepareDerivedData();
-      const documentNames = Object.keys(this.system?.constructor.metadata?.embedded ?? {});
-      for (const documentName of documentNames) {
-        for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) {
-          pseudoDocument.prepareDerivedData();
-        }
-      }
+
+      for (const collection of Object.values(this.pseudoCollections ?? {}))
+        for (const pseudo of collection)
+          pseudo.prepareDerivedData();
     }
   };
 };

--- a/src/module/documents/item.mjs
+++ b/src/module/documents/item.mjs
@@ -2,10 +2,6 @@ import { systemID, systemPath } from "../constants.mjs";
 import BaseDocumentMixin from "./base-document-mixin.mjs";
 
 /**
- * @import {ActiveEffectData} from "@common/documents/_types.mjs";
- */
-
-/**
  * A document subclass adding system-specific behavior and registered in CONFIG.Item.documentClass.
  */
 export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.Item) {
@@ -84,7 +80,7 @@ export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.I
    * @type {boolean}
    */
   get supportsAdvancements() {
-    return !!this.pseudoCollections?.Advancement;
+    return "Advancement" in this.pseudoCollections;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/item.mjs
+++ b/src/module/documents/item.mjs
@@ -126,7 +126,7 @@ export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.I
     content.append(this.toAnchor());
 
     const itemIds = new Set([this.id]);
-    for (const advancement of this.getEmbeddedPseudoDocumentCollection("Advancement").getByType("itemGrant")) {
+    for (const advancement of this.getEmbeddedPseudoDocumentCollection("Advancement").documentsByType.itemGrant) {
       for (const item of advancement.grantedItemsChain()) {
         content.append(item.toAnchor());
         itemIds.add(item.id);

--- a/src/module/documents/item.mjs
+++ b/src/module/documents/item.mjs
@@ -84,7 +84,7 @@ export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.I
    * @type {boolean}
    */
   get supportsAdvancements() {
-    return !!this.system.constructor.metadata.embedded?.Advancement;
+    return !!this.pseudoCollections?.Advancement;
   }
 
   /* -------------------------------------------------- */
@@ -96,7 +96,8 @@ export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.I
   get hasGrantedItems() {
     if (!this.supportsAdvancements || !this.parent) return false;
     return this.collection.some(item => {
-      if (item.getFlag(systemID, "advancement.parentId") === this.id) return !!this.getEmbeddedPseudoDocumentCollection("Advancement").get(item.getFlag(systemID, "advancement.advancementId"));
+      if (item.getFlag(systemID, "advancement.parentId") === this.id)
+        return !!this.getEmbeddedCollection("Advancement").get(item.getFlag(systemID, "advancement.advancementId"));
       return false;
     });
   }
@@ -126,7 +127,7 @@ export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.I
     content.append(this.toAnchor());
 
     const itemIds = new Set([this.id]);
-    for (const advancement of this.getEmbeddedPseudoDocumentCollection("Advancement").documentsByType.itemGrant) {
+    for (const advancement of this.getEmbeddedCollection("Advancement").documentsByType.itemGrant) {
       for (const item of advancement.grantedItemsChain()) {
         content.append(item.toAnchor());
         itemIds.add(item.id);

--- a/src/module/utils/advancement-chain.mjs
+++ b/src/module/utils/advancement-chain.mjs
@@ -150,7 +150,7 @@ export default class AdvancementChain {
     if (!item.supportsAdvancements) return choice;
 
     // Find any "child" advancements.
-    for (const advancement of item.getEmbeddedPseudoDocumentCollection("Advancement")) {
+    for (const advancement of item.getEmbeddedCollection("Advancement")) {
       const validRange = advancement.levels.some(level => {
         if (Number.isNumeric(level)) return level.between(levelStart, levelEnd);
         else return levelStart === null;

--- a/src/module/utils/model-collection.mjs
+++ b/src/module/utils/model-collection.mjs
@@ -73,6 +73,15 @@ export default class ModelCollection extends foundry.utils.Collection {
   invalidDocumentIds = new Set();
 
   /* -------------------------------------------------- */
+
+  /**
+   * Underlying source data of each embedded pseudo-document. The
+   * collection is responsible for performing mutations to this data.
+   * @type {Record<string, object>}
+   */
+  _source;
+
+  /* -------------------------------------------------- */
   /*  Methods                                           */
   /* -------------------------------------------------- */
 

--- a/src/module/utils/model-collection.mjs
+++ b/src/module/utils/model-collection.mjs
@@ -1,29 +1,57 @@
-/** @import DataModel from "@common/abstract/data.mjs" */
+/**
+ * @import DataModel from "@common/abstract/data.mjs";
+ * @import PseudoDocument from "../data/pseudo-documents/pseudo-document.mjs";
+ * @import Collection from "@common/utils/collection.mjs";
+ */
+
+import BaseAdvancement from "../data/pseudo-documents/advancements/base-advancement.mjs";
+import BasePowerRollEffect from "../data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs";
 
 /**
  * Specialized collection type for stored data models.
  * @param {Array<string, DataModel>} entries    Array containing the data models to store.
  * @template {DataModel} Model The model class contained by this collection.
- * @extends {foundry.utils.Collection<string, Model>}
+ * @extends {Collection<string, Model>}
  */
 export default class ModelCollection extends foundry.utils.Collection {
+  constructor(documentName, document, data) {
+    super();
+    Object.defineProperties(this, {
+      name: { value: documentName, writable: false },
+      _source: { value: data, writable: false },
+      documentClass: { value: ModelCollection.documentClasses[documentName], writable: false },
+    });
+  }
+
   /* -------------------------------------------------- */
   /*  Properties                                        */
   /* -------------------------------------------------- */
 
   /**
    * Pseudo-document base model.
-   * @type {typeof ds.data.pseudoDocuments.PseudoDocument}
+   * @type {typeof PseudoDocument}
    */
   documentClass;
 
   /* -------------------------------------------------- */
 
   /**
-   * Pre-organized arrays of data models by type.
-   * @type {Map<string, Set<string>>}
+   * The base classes of the pseudo-documents that can be stored in a model such as this.
+   * Each class must implement `documentConfig` to map to the subtype.
+   * @type {Record<string, PseudoDocument>}
    */
-  #types = new Map();
+  static documentClasses = {
+    Advancement: BaseAdvancement,
+    PowerRollEffect: BasePowerRollEffect,
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * A cache of this collection's contents grouped by subtype.
+   * @type {Record<string, Model[]>|null}
+   */
+  #documentsByType = null;
 
   /* -------------------------------------------------- */
 
@@ -38,50 +66,86 @@ export default class ModelCollection extends foundry.utils.Collection {
   /* -------------------------------------------------- */
 
   /**
-   * A set of the un-initialized pseudo-documents.
-   * Stored safely for debugging purposes.
-   * @type {Set<object>}
+   * The set of invalid document ids.
+   * @param {Set<string>}
    */
-  #invalid = new Set();
+  invalidDocumentIds = new Set();
 
   /* -------------------------------------------------- */
   /*  Methods                                           */
   /* -------------------------------------------------- */
 
   /**
-   * Fetch an array of data models of a certain type.
-   * @param {string} type     The subtype of the data models.
-   * @returns {Model[]}   The data models of this type.
+   * The subtypes sorted by type.
+   * @type {Record<string, Model[]>}
    */
-  getByType(type) {
-    return Array.from(this.#types.get(type) ?? []).map(key => this.get(key));
+  get documentsByType() {
+    if (this.#documentsByType) return this.#documentsByType;
+    const types = Object.fromEntries(Object.keys(this.documentClass.documentConfig).map(t => [t, []]));
+    for (const doc of this.values()) types[doc._source.type ?? "base"]?.push(doc);
+    return this.#documentsByType = types;
   }
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  set(key, value) {
-    if (!this.#types.has(value.type)) this.#types.set(value.type, new Set());
-    this.#types.get(value.type).add(key);
+  set(key, value, { modifySource = true } = {}) {
+    if (modifySource) this._set(key, value);
+    if (super.get(key) !== value) this.#documentsByType = null;
     return super.set(key, value);
   }
 
   /* -------------------------------------------------- */
 
   /**
-   * Store invalid pseudo-documents.
-   * @param {object} value    The un-initialized data model.
+   * Perform the modifications to the source when adding a new entry.
+   * @param {string} key
+   * @param {Model} model
    */
-  setInvalid(value) {
-    this.#invalid.add(value);
+  _set(key, model) {
+    this._source[key] = model._source;
   }
 
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  delete(key) {
-    this.#types.get(this.get(key)?.type)?.delete(key);
-    return super.delete(key);
+  delete(key, { modifySource = true } = {}) {
+    if (modifySource) this._delete(key);
+    const result = super.delete(key);
+    if (result) this.#documentsByType = null;
+    return result;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle modifications to the source data when deleting an entry.
+   * @param {string} k
+   */
+  _delete(k) {
+    delete this._source[k];
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Retrieve an invalid document.
+   * @param {string} id   The id of the invalid pseudo-document.
+   * @param {object} [options={}]
+   * @param {boolean} [options.strict=true]   Throw an error if the id does not exist.
+   * @returns {Model|void}
+   * @throws If the id does not exist.
+   */
+  getInvalid(id, { strict = true } = {}) {
+    if (!this.invalidDocumentIds.has(id) && strict) {
+      throw new Error(`The '${id}' does not exist in the invalid collection.`);
+    }
+
+    if (!this.invalidDocumentIds.has(id)) return;
+
+    const data = this._source[id];
+    const Cls = this.documentClass.documentConfig[data.type] ?? this.documentClass;
+    return Cls.fromSource(foundry.utils.deepClone(data), { parent: this.parent });
   }
 
   /* -------------------------------------------------- */
@@ -103,5 +167,101 @@ export default class ModelCollection extends foundry.utils.Collection {
    */
   toObject() {
     return this.map(doc => doc.toObject(true));
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Initialize the model collection. Existing entries are retained, but new source data is used.
+   * @param {foundry.abstract.DataModel} model    The parent data model that holds this collection.
+   * @param {object} [options={}]
+   */
+  initialize(model, options = {}) {
+    this.parent = model;
+    this._initialized = false;
+    this.#documentsByType = null;
+
+    const initIds = new Set();
+    for (const o of Object.values(this._source)) {
+      const d = this._initializeDocument(o, options);
+      if (d) initIds.add(d.id);
+    }
+
+    if (this.size !== initIds.size) {
+      for (const k of this.keys()) if (!initIds.has(k)) this.delete(k, { modifySource: false });
+    }
+
+    this._initialized = true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Initialize a pseudo-document and store it in this collection.
+   * If it exists, reinitialize with new data, otherwise create a new instance.
+   * @param {object} data   Source data.
+   * @param {object} [options]
+   * @returns {Model|null}
+   */
+  _initializeDocument(data, options) {
+    let d = this.get(data._id);
+    if (d) {
+      // The document exists, reinitialize with new source data.
+      d._initialize(options);
+      return d;
+    }
+
+    if (!data._id) data._id = foundry.utils.randomID();
+    try {
+      // Create a new instance.
+      d = this.createDocument(data, options);
+      super.set(d.id, d);
+    } catch (err) {
+      this._handleInvalidDocument(data._id, err, options);
+      return null;
+    }
+
+    return d;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create a new instance of the pseudo-document.
+   * @param {object} data   Pseudo-document data.
+   * @param {object} [context={}]
+   * @returns {Model}
+   */
+  createDocument(data, context = {}) {
+    const Cls = this.documentClass.TYPES[data.type];
+    if (!Cls)
+      throw new Error(`Type '${data.type}' is not a valid subtype for a ${this.documentClass.metadata.documentName}.`);
+    return new Cls(data, { ...context, parent: this.parent });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Emulate the core handling of invalid documents by throwing warnings, storing the id in the `invalidDocumentIds` set.
+   * @param {string} id   The id of the model.
+   * @param {string} err    The error message.
+   * @param {object} [options={}]
+   * @param {boolean} [options.strict=true]   Throw an error.
+   */
+  _handleInvalidDocument(id, err, { strict = true } = {}) {
+    const documentName = this.documentClass.metadata.documentName;
+    const parent = this.parent;
+    this.invalidDocumentIds.add(id);
+
+    // Wrap the error with more information
+    const uuid = foundry.utils.buildUuid({ id, documentName, parent });
+    const msg = `Failed to initialize ${documentName} [${uuid}]:\n${err.message}`;
+    const error = new Error(msg, { cause: err });
+
+    if (strict) console.error(error);
+    else console.warn(error);
+    if (strict) {
+      globalThis.Hooks?.onError(`${this.constructor.name}#_initializeDocument`, error, { id, documentName });
+    }
   }
 }

--- a/src/module/utils/model-collection.mjs
+++ b/src/module/utils/model-collection.mjs
@@ -174,7 +174,7 @@ export default class ModelCollection extends foundry.utils.Collection {
 
     const initIds = new Set();
     for (const o of Object.values(this._source)) {
-      const d = this._initializeDocument(o, options);
+      const d = this.#initializeDocument(o, options);
       if (d) initIds.add(d.id);
     }
 
@@ -194,7 +194,7 @@ export default class ModelCollection extends foundry.utils.Collection {
    * @param {object} [options]
    * @returns {Model|null}
    */
-  _initializeDocument(data, options) {
+  #initializeDocument(data, options) {
     let d = this.get(data._id);
     if (d) {
       // The document exists, reinitialize with new source data.
@@ -211,7 +211,7 @@ export default class ModelCollection extends foundry.utils.Collection {
       d = this.#createDocument(data, options);
       super.set(d.id, d);
     } catch (err) {
-      this._handleInvalidDocument(data._id, err, options);
+      this.#handleInvalidDocument(data._id, err, options);
       return null;
     }
 
@@ -242,7 +242,7 @@ export default class ModelCollection extends foundry.utils.Collection {
    * @param {object} [options={}]
    * @param {boolean} [options.strict=true]   Throw an error.
    */
-  _handleInvalidDocument(id, err, { strict = true } = {}) {
+  #handleInvalidDocument(id, err, { strict = true } = {}) {
     const documentName = this.documentClass.metadata.documentName;
     const parent = this.parent;
     this.invalidDocumentIds.add(id);

--- a/src/module/utils/model-collection.mjs
+++ b/src/module/utils/model-collection.mjs
@@ -16,8 +16,9 @@ import BasePowerRollEffect from "../data/pseudo-documents/power-roll-effects/bas
 export default class ModelCollection extends foundry.utils.Collection {
   constructor(documentName, document, data) {
     super();
+    const name = CONFIG[document.documentName].dataModels[document._source.type].metadata.embedded[documentName];
     Object.defineProperties(this, {
-      name: { value: documentName, writable: false },
+      name: { value: name, writable: false },
       _source: { value: data, writable: false },
       documentClass: { value: ModelCollection.documentClasses[documentName], writable: false },
     });


### PR DESCRIPTION
Closes #1171.

This was fun, and it led to being able to remove a lot of code I wasn't entirely happy with.

The basic premise is thus:
- The collection of pseudo-documents is assigned to the root of the document and is never re-assigned.
- The collection handles altering the source data, which it holds, when a pseudo-document is added, updated, or removed entirely.
- The collection handles storing the models as usual, but will never *replace* the entries when they are updated; instead when updating a PseudoDocument it is re-initialized with the new source data. This results in the reference to the pseudo being static (just like regular Documents and embedded documents).

In other words,
```js
const item = fromUuidSync("Item.VplOyY21TDNkWsYH");
const advancement = item.pseudoCollections.Advancement.get("1XgNokBXzQVdKWN8");
await advancement.update({ "name": "NEW NAME!" }); // perform the update, which usually borked the reference
item.pseudoCollections.Advancement.get("1XgNokBXzQVdKWN8") === advancement; // TRUE!
```

There is some follow-up work to do for pseudo-documents that don't have subtypes, but we are yet to use these.

There is also some follow-up work to do for pseudo-documents that hold collections of pseudo-documents, but we are also yet to use these.