### PR TITLE
Goblin Monarch Fix

### DIFF
--- a/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Monarch_Vxxc0EcLHPPnpSbK.json
+++ b/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Monarch_Vxxc0EcLHPPnpSbK.json
@@ -310,7 +310,25 @@
               "agility"
             ]
           },
-          "effects": {}
+          "effects": {
+            "ezQZliRdrGmIeS70": {
+              "name": "",
+              "img": null,
+              "type": "damage",
+              "_id": "ezQZliRdrGmIeS70",
+              "damage": {
+                "tier1": {
+                  "value": "7"
+                },
+                "tier2": {
+                  "value": "10"
+                },
+                "tier3": {
+                  "value": "13"
+                }
+              }
+            }
+          }
         },
         "effect": {
           "before": "",
@@ -335,9 +353,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.348",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.0",
+        "systemVersion": "0.9.0",
         "lastModifiedBy": null,
         "modifiedTime": null
       },


### PR DESCRIPTION
Added damage to the Handaxe ability, which was missing before.