### PR TITLE
[#1201] Moved item post actor prep step

### DIFF
--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -166,11 +166,6 @@ export default class BaseActorModel extends DrawSteelSystemModel {
       if (isSlowed && (this.movement.value > this.statuses.slowed.speed)) this.movement.value = this.statuses.slowed.speed;
       if (isGrabbedOrRestrained) this.movement.value = 0;
     }
-
-    // prepare derived item data that relies on derived actor values (i.e. ability potencies)
-    for (const item of this.parent.items) {
-      item.system.preparePostActorPrepData();
-    }
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -47,6 +47,12 @@ export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+
+    // prepare derived item data that relies on derived actor values (i.e. ability potencies)
+    for (const item of this.items) {
+      item.system.preparePostActorPrepData();
+    }
+
     Hooks.callAll("ds.prepareActorData", this);
   }
 


### PR DESCRIPTION
This means the item post-actor prep now runs *after* the actor subtype's prepareDerivedData, e.g. guaranteeing that it's after trait advancements are applied.

Closes #1201