### PR TITLE
Career Perk Choices

### DIFF
--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Agent_IVbwiJjMAvMCCCsH.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Agent_IVbwiJjMAvMCCCsH.json
@@ -28,8 +28,8 @@
         "languages": []
       },
       "MaEsyqUb2QzTHZqt": {
-        "name": "One Intrigue Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
@@ -37,7 +37,7 @@
         "_id": "MaEsyqUb2QzTHZqt",
         "chooseN": 1,
         "pool": [],
-        "description": "",
+        "description": "<p>One intrigue perk (<em>Quick Build:</em> Forgettable Face.)</p>",
         "additional": {
           "type": "perk",
           "perkType": [
@@ -107,7 +107,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.348",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
     "systemVersion": "0.9.0",
     "createdTime": 1754426094706,

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Aristocrat_pIJIHKNtDaGVNeny.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Aristocrat_pIJIHKNtDaGVNeny.json
@@ -62,14 +62,21 @@
         "languages": []
       },
       "XtDHNqCcXbifP1pu": {
-        "name": "One Lore Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "XtDHNqCcXbifP1pu",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One lore perk (<em>Quick Build:</em> I’ve Read About This Place.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "lore"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -85,9 +92,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754426096082,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Artisan_Dwr9SEvHa5ngc3aE.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Artisan_Dwr9SEvHa5ngc3aE.json
@@ -42,14 +42,21 @@
         "chooseN": 1
       },
       "nS8bobDV2p1szqhy": {
-        "name": "One Crafting Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "nS8bobDV2p1szqhy",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One crafting perk (<em>Quick Build:</em> Area of Expertise.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "crafting"
+          ]
+        }
       }
     },
     "projectPoints": 240,
@@ -66,9 +73,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754489545841,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Beggar_r3b55XTVHZI9dqTB.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Beggar_r3b55XTVHZI9dqTB.json
@@ -73,14 +73,21 @@
         "chooseN": 2
       },
       "I3Of5vFcJc2dmJmd": {
-        "name": "One Interpersonal Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "I3Of5vFcJc2dmJmd",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One interpersonal perk (<em>Quick Build:</em> Spot the Tell.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "interpersonal"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -97,9 +104,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.348",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.1",
+    "systemVersion": "0.9.0",
     "createdTime": 1754493987708,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Criminal_fGcRL5zHgfDEm1Xr.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Criminal_fGcRL5zHgfDEm1Xr.json
@@ -58,14 +58,21 @@
         "chooseN": 1
       },
       "r4ukphkeedBJWuOB": {
-        "name": "One Intrigue Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "r4ukphkeedBJWuOB",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One intrigue perk (<em>Quick Build:</em> Criminal Contacts.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "intrigue"
+          ]
+        }
       }
     },
     "projectPoints": 120,
@@ -82,9 +89,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754494798775,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Disciple_W78lARpSZDafGYku.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Disciple_W78lARpSZDafGYku.json
@@ -48,14 +48,21 @@
         }
       },
       "rUEv1cZVO8FQYAng": {
-        "name": "One Supernatural Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "rUEv1cZVO8FQYAng",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One supernatural perk (<em>Quick Build:</em> Ritualist.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "supernatural"
+          ]
+        }
       }
     },
     "projectPoints": 240,
@@ -72,9 +79,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754495048112,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Explorer_jxpNH7xxabOfndL9.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Explorer_jxpNH7xxabOfndL9.json
@@ -57,14 +57,21 @@
         "chooseN": 2
       },
       "nxm4CEs4PyrCuRYI": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "nxm4CEs4PyrCuRYI",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Wood Wise.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -81,9 +88,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754495272172,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Farmer_uDsG68ZOjAjm14jt.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Farmer_uDsG68ZOjAjm14jt.json
@@ -57,14 +57,21 @@
         "chooseN": 1
       },
       "9irT21rReWy51aje": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "9irT21rReWy51aje",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Monster Whisperer.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 120,
@@ -81,9 +88,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754495426718,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Gladiator_PF5jwtdBhNLwtuiE.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Gladiator_PF5jwtdBhNLwtuiE.json
@@ -42,14 +42,21 @@
         "chooseN": 1
       },
       "4Ue5ZNT1dLtuVL6j": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "4Ue5ZNT1dLtuVL6j",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Friend Catapult.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -66,9 +73,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754495575282,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Laborer_Rtmos3SUinHJf6Bx.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Laborer_Rtmos3SUinHJf6Bx.json
@@ -58,14 +58,21 @@
         "chooseN": 1
       },
       "AlOrDwMy2S589YIi": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "AlOrDwMy2S589YIi",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Brawny.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 120,
@@ -82,9 +89,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754495708332,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Mage_s_Apprentice_MRPgUpmDxPMLVZx8.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Mage_s_Apprentice_MRPgUpmDxPMLVZx8.json
@@ -57,14 +57,21 @@
         "chooseN": 1
       },
       "nuMXjpqMu11xyn9d": {
-        "name": "One Supernatural Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "nuMXjpqMu11xyn9d",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One supernatural perk (<em>Quick Build:</em> Arcane Trick.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "supernatural"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -81,9 +88,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754495856715,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Performer_svaIVkN07dCZvEN7.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Performer_svaIVkN07dCZvEN7.json
@@ -49,14 +49,21 @@
         }
       },
       "WVygUyuzVToTgz0b": {
-        "name": "One Interpersonal Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "WVygUyuzVToTgz0b",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One interpersonal perk (<em>Quick Build:</em> Harmonizer.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "interpersonal"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -73,9 +80,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754496676738,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Politician_9pVxAzPBxQaezK7m.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Politician_9pVxAzPBxQaezK7m.json
@@ -42,14 +42,21 @@
         "chooseN": 1
       },
       "7UFOc1UUzdwGiru7": {
-        "name": "One Interpersonal Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "7UFOc1UUzdwGiru7",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One interpersonal perk (<em>Quick Build:</em> Engrossing Monologue.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "interpersonal"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -66,9 +73,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754496819585,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Sage_iBQnUpwdmdz9x2Ui.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Sage_iBQnUpwdmdz9x2Ui.json
@@ -42,14 +42,21 @@
         "chooseN": 1
       },
       "jszhgYCA0kH3nopS": {
-        "name": "One Lore Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "jszhgYCA0kH3nopS",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One lore perk (<em>Quick Build:</em> Expert Sage.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "lore"
+          ]
+        }
       }
     },
     "projectPoints": 240,
@@ -66,9 +73,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754496963701,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Sailor_c4npwGpqgXJSLiV1.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Sailor_c4npwGpqgXJSLiV1.json
@@ -57,14 +57,21 @@
         "chooseN": 2
       },
       "TV4AP72vGiOHxG8w": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "TV4AP72vGiOHxG8w",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Put Your Back Into It!)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -81,9 +88,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754497099224,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Soldier_y63JszkYGerkvHFz.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Soldier_y63JszkYGerkvHFz.json
@@ -57,14 +57,21 @@
         "chooseN": 2
       },
       "2l0eIkltgaCcuYoC": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "2l0eIkltgaCcuYoC",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Teamwork.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -81,9 +88,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754497307695,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Warden_fp9H1kMYG7NV86qD.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Warden_fp9H1kMYG7NV86qD.json
@@ -72,14 +72,21 @@
         "chooseN": 1
       },
       "Wl0sl4YdU5pMBf0z": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "Wl0sl4YdU5pMBf0z",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Camouflage Hunter.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 120,
@@ -96,9 +103,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754497446877,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Watch_Officer_bRDSvTZosGxkfvvo.json
+++ b/src/packs/origins/Backgrounds_g8icN9n7dCBGOsej/Careers_DNgMG9rHu4ULguZr/career_Watch_Officer_bRDSvTZosGxkfvvo.json
@@ -57,14 +57,21 @@
         "chooseN": 2
       },
       "5foDIQsDExw6rBOK": {
-        "name": "One Exploration Perk",
-        "img": null,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
         "type": "itemGrant",
         "requirements": {
           "level": null
         },
         "_id": "5foDIQsDExw6rBOK",
-        "chooseN": 1
+        "chooseN": 1,
+        "description": "<p>One exploration perk (<em>Quick Build:</em> Team Leader.)</p>",
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "exploration"
+          ]
+        }
       }
     },
     "projectPoints": 0,
@@ -81,9 +88,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754497598343,
     "modifiedTime": null,
     "lastModifiedBy": null


### PR DESCRIPTION
Added Perk selection and updated icons and text for Perk selection under all careers.

Issue: Odd behavior in Agent where perk selection is not giving it as Intrigue in the json text even though that is selected and even reselected in an attempt to correct. Other careers don't have this problem.

Observation: While I have selected the Perk selection for a group of perks, there is no active selection. Is the selection meant to pull from a list of these Perks? Or do we still need to add every perk of that type in the list below? This would apply for both Class perks and Career perk selection for advancement. Current result on it as treated as a list that should be pulled from results in an empty dialog box on advancement at this time.