### PR TITLE
Improved docs asset usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - Fixed active effects not sorting on actor and item sheets. (#1149)
 - Addressed the SortingHelpers.performIntegerSort depreciation warning. (#1155)
 - Fixed issues with "Alternative" initiative. (#1168)
+- Fixed broken image links in the in-game documentation.
 
 ## 0.8.1
 

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -51,4 +51,4 @@ If an enricher is not working as intended, in the text editor in which you are t
 1. click on the `Ⱦ` symbol to "clear formatting" from any selected text (or the whole text box if nothing is selected), this usually fixes the issue. If not, then
 2. click on the `</>` symbol to enter HTML mode and make sure, there is not unnecessary characters or code interfering with the enricher.
 
-![HTML clean-up mode explainer](draw-steel/assets/docs/HTML-mode-explainer.png?raw=true "HTML Mode explainer")
+![HTML clean-up mode explainer](https://github.com/MetaMorphic-Digital/draw-steel/blob/develop/assets/docs/HTML-mode-explainer.png)

--- a/tools/pullJSONtoLDB.mjs
+++ b/tools/pullJSONtoLDB.mjs
@@ -41,7 +41,11 @@ async function transformEntry(entry) {
     const mdSource = await fs.readFile(docsPath, {
       encoding: "utf8",
     });
-    const htmlContent = converter.makeHtml(mdSource);
+
+    // re-route wiki image links to in-game asset links
+    const htmlContent = converter.makeHtml(
+      mdSource.replaceAll("https://github.com/MetaMorphic-Digital/draw-steel/blob/develop/assets/docs", "systems/draw-steel/assets/docs"),
+    );
     jep.text.markdown = mdSource;
     jep.text.content = htmlContent;
   }

--- a/tools/pushLDBtoJSON.mjs
+++ b/tools/pushLDBtoJSON.mjs
@@ -71,7 +71,11 @@ async function transformEntry(entry) {
 
   for (const jep of entry.pages) {
     const docsPath = path.join("src", "docs", jep.flags["draw-steel"].wikiPath);
-    await fs.writeFile(docsPath, jep.text.markdown, { encoding: "utf8" });
+
+    // re-route in-game asset links to wiki image links
+    const mdContent = jep.text.markdown.replaceAll("https://github.com/MetaMorphic-Digital/draw-steel/blob/develop/assets/docs", "systems/draw-steel/assets/docs");
+
+    await fs.writeFile(docsPath, mdContent, { encoding: "utf8" });
     jep.text = { format: 2 };
   }
 }


### PR DESCRIPTION
Currently just using the /develop branch as our reference point, open to considering if it should be main instead.