### PR TITLE
Shipwrecked Exploration Skill Fix

### DIFF
--- a/src/packs/character-options/Complications_luKqW8QDTBJo5AM4/complication_Shipwrecked_qyqeTSPtjabrGGyj.json
+++ b/src/packs/character-options/Complications_luKqW8QDTBJo5AM4/complication_Shipwrecked_qyqeTSPtjabrGGyj.json
@@ -25,9 +25,10 @@
         "chooseN": 2,
         "skills": {
           "groups": [
-            "crafting"
+            "exploration"
           ]
-        }
+        },
+        "description": "<p>You have two skills of your choice from the exploration skill group.</p>"
       }
     }
   },
@@ -43,9 +44,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754715846118,
     "modifiedTime": null,
     "lastModifiedBy": null


### PR DESCRIPTION
Corrected Skill in Shipwrecked complication from Crafting to Exploration.