### PR TITLE
Alternate - fix giant clickboxes for hero sheet resource buttons

### DIFF
--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -119,8 +119,13 @@
     .resource-label {
       font-weight: 600;
       text-align: center;
-      display: flex;
+      display: inline-block;
       justify-content: space-around;
+    }
+
+    .resource-label-wrapper {
+      display: flex;
+      justify-content: center;
     }
 
     .resource-divider {

--- a/templates/sheets/actor/hero-sheet/stats.hbs
+++ b/templates/sheets/actor/hero-sheet/stats.hbs
@@ -4,21 +4,23 @@
   <fieldset class="resources flexrow">
     <legend>{{localize "DRAW_STEEL.SHEET.Resources"}}</legend>
     <div class="resource stamina flexcol">
-      <label class="resource-label">
-        {{#if editable}}
-        <button
-          type="button"
-          data-action="spendStaminaHeroToken"
-          data-tooltip="DRAW_STEEL.Setting.HeroTokens.RegainStamina.tooltip"
-          data-tooltip-direction="UP"
-        >
-          <i class="fa-solid fa-circle-bolt"></i>
-          {{systemFields.stamina.label}}
-        </button>
-        {{else}}
-        <span>{{systemFields.stamina.label}}</span>
-        {{/if}}
-      </label>
+      <div class="resource-label-wrapper">
+        <label class="resource-label">
+          {{#if editable}}
+          <button
+            type="button"
+            data-action="spendStaminaHeroToken"
+            data-tooltip="DRAW_STEEL.Setting.HeroTokens.RegainStamina.tooltip"
+            data-tooltip-direction="UP"
+          >
+            <i class="fa-solid fa-circle-bolt"></i>
+            {{systemFields.stamina.label}}
+          </button>
+          {{else}}
+            <span>{{systemFields.stamina.label}}</span>
+          {{/if}}
+        </label>
+      </div>
       <div class="form-group resource-content">
         <div class="resource-temporary">
           {{formGroup
@@ -49,21 +51,23 @@
       </div>
     </div>
     <div class="resource recoveries flexcol">
-      <label class="resource-label">
-        {{#if editable}}
-        <button
-          type="button"
-          data-action="spendRecovery"
-          data-tooltip="DRAW_STEEL.Actor.base.SpendRecovery.tooltip"
-          data-tooltip-direction="UP"
-        >
-          <i class="fa-solid fa-heart-pulse"></i>
-          {{systemFields.recoveries.label}}
-        </button>
-        {{else}}
-        <span>{{systemFields.recoveries.label}}</span>
-        {{/if}}
-      </label>
+      <div class="resource-label-wrapper">
+        <label class="resource-label">
+          {{#if editable}}
+          <button
+            type="button"
+            data-action="spendRecovery"
+            data-tooltip="DRAW_STEEL.Actor.base.SpendRecovery.tooltip"
+            data-tooltip-direction="UP"
+          >
+            <i class="fa-solid fa-heart-pulse"></i>
+            {{systemFields.recoveries.label}}
+          </button>
+          {{else}}
+          <span>{{systemFields.recoveries.label}}</span>
+          {{/if}}
+        </label>
+      </div>
       <div class="form-group resource-content">
         <div class="resource-current">
           {{formGroup systemFields.recoveries.fields.value value=system.recoveries.value dataset=datasets.notSource classes="stacked"}}


### PR DESCRIPTION
Issue #1271 

## Summary of Changes
Resolves the Hero Sheet bug where the "Stamina" and "Recoveries" buttons had HUGE activation areas compared to the size of the button itself.

This is an alternate solution to the issue, which preserves the "label" element for the sake of screen readers and general accessibility. Adjusts CSS styling and adds a wrapper div to prevent the label from spreading over the entire column.

## Video Demo
https://github.com/user-attachments/assets/8edb6b60-4d9c-4b88-a65a-7b5e18fba46a