### PR TITLE
fix giant clickboxes for hero sheet resource buttons

### DIFF
--- a/templates/sheets/actor/hero-sheet/stats.hbs
+++ b/templates/sheets/actor/hero-sheet/stats.hbs
@@ -4,7 +4,7 @@
   <fieldset class="resources flexrow">
     <legend>{{localize "DRAW_STEEL.SHEET.Resources"}}</legend>
     <div class="resource stamina flexcol">
-      <label class="resource-label">
+      <div class="resource-label">
         {{#if editable}}
         <button
           type="button"
@@ -18,7 +18,7 @@
         {{else}}
         <span>{{systemFields.stamina.label}}</span>
         {{/if}}
-      </label>
+      </div>
       <div class="form-group resource-content">
         <div class="resource-temporary">
           {{formGroup
@@ -49,7 +49,7 @@
       </div>
     </div>
     <div class="resource recoveries flexcol">
-      <label class="resource-label">
+      <div class="resource-label">
         {{#if editable}}
         <button
           type="button"
@@ -63,7 +63,7 @@
         {{else}}
         <span>{{systemFields.recoveries.label}}</span>
         {{/if}}
-      </label>
+      </div>
       <div class="form-group resource-content">
         <div class="resource-current">
           {{formGroup systemFields.recoveries.fields.value value=system.recoveries.value dataset=datasets.notSource classes="stacked"}}


### PR DESCRIPTION
Issue #1271 

Hi there! Big fan of the app.

## Summary of Changes
Resolves the Hero Sheet bug where the "Stamina" and "Recoveries" buttons had HUGE activation areas compared to the size of the button itself.

Follows the suggested solution proposed by @JPMeehan in the Issue comments.

## Alternative Code Solution
I also worked on an alternate version of this bugfix that preserves the `label` element, as a way to support screen reader accessibility. If you're interested in seeing that solution instead, [you can view the Draft PR here](https://github.com/MetaMorphic-Digital/draw-steel/pull/1285). Happy to go with either solution, and also happy to answer any questions! Let me know what you think.

## Video Demo
https://github.com/user-attachments/assets/8edb6b60-4d9c-4b88-a65a-7b5e18fba46a

