### PR TITLE
Censor and tactician data fixes

### DIFF
--- a/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Subclasses_NLxB1ruArthWoUkL/subclass_Exorcist_4sIzvWJt4GkrIceK.json
+++ b/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Subclasses_NLxB1ruArthWoUkL/subclass_Exorcist_4sIzvWJt4GkrIceK.json
@@ -61,7 +61,7 @@
             "uuid": "Compendium.draw-steel.classes.Item.B8fo12vf0L7IyyOG"
           }
         ],
-        "chooseN": 1
+        "chooseN": null
       },
       "RxfuFaih3NrwfJui": {
         "name": "2nd-Level Exorcist Ability",

--- a/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Subclasses_NLxB1ruArthWoUkL/subclass_Oracle_xOrDR2a0Kf7B4BcV.json
+++ b/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Subclasses_NLxB1ruArthWoUkL/subclass_Oracle_xOrDR2a0Kf7B4BcV.json
@@ -53,7 +53,7 @@
         },
         "_id": "DKJY61hBCi6htcOC",
         "description": "<p>Your censor order grants you the following two features.</p>",
-        "chooseN": 1,
+        "chooseN": null,
         "pool": [
           {
             "uuid": "Compendium.draw-steel.classes.Item.fpRHi8PhbESrISpL"

--- a/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Subclasses_NLxB1ruArthWoUkL/subclass_Paragon_G7CW919PYBzeVnH9.json
+++ b/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Subclasses_NLxB1ruArthWoUkL/subclass_Paragon_G7CW919PYBzeVnH9.json
@@ -53,7 +53,7 @@
         },
         "_id": "Lu6wUAmY7uFi55em",
         "description": "<p>Your censor order grants you the following two features.</p>",
-        "chooseN": 1,
+        "chooseN": null,
         "pool": [
           {
             "uuid": "Compendium.draw-steel.classes.Item.EMISeV8nG8wuQ5yo"

--- a/src/packs/classes/Tactician_kCN3c3aC6ziHDp5c/Subclasses_86F9T9t6YK1WafzV/subclass_Vanguard_OjWhetKz8boQxExU.json
+++ b/src/packs/classes/Tactician_kCN3c3aC6ziHDp5c/Subclasses_86F9T9t6YK1WafzV/subclass_Vanguard_OjWhetKz8boQxExU.json
@@ -77,7 +77,8 @@
           {
             "uuid": "Compendium.draw-steel.abilities.Item.kT1PdUuDnWdd8E5j"
           }
-        ]
+        ],
+        "chooseN": 1
       },
       "f40tgLeXPDoEE2xs": {
         "name": "Doctrine Triggered Action",


### PR DESCRIPTION
In my session I noticed some advancement data errors. 

The level 2 censor gives two features, but the advancement was configured to allow only 1 choice. The level 2 vanguard gets a choice of 1 ability, but the advancement was giving all.