### PR TITLE
[#1324] Implement potency ability modifier

### DIFF
--- a/src/docs/Active-Effects.md
+++ b/src/docs/Active-Effects.md
@@ -224,3 +224,4 @@ Ability modifiers support a far more limited set of keys, but still use the same
 |`damage.tier1.value`|Give a bonus to the first damage effect's tier 1 damage|
 |`damage.tier2.value`|Give a bonus to the first damage effect's tier 2 damage|
 |`damage.tier3.value`|Give a bonus to the first damage effect's tier 3 damage|
+|`potency`|Give a bonus to all potency values|

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -189,6 +189,18 @@ export default class AbilityModel extends BaseItemModel {
           foundry.utils.setProperty(firstDamageEffect, bonus.key, formulaField.applyChange(currentValue, this, bonus));
         }
       }
+
+      if (bonus.key === "potency") {
+        // For potency effects, apply to all power roll effects and all tiers
+        for (const effect of this.power.effects) {
+          for (const tierNumber of [1, 2, 3]) {
+            const key = `${effect.constructor.TYPE}.tier${tierNumber}.potency.value`;
+            const formulaField = effect.schema.getField(key);
+            const currentValue = foundry.utils.getProperty(effect, key);
+            foundry.utils.setProperty(effect, key, formulaField.applyChange(currentValue, this, bonus));
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Closes #1324 

In `_applyAbilityBonuses` apply the value specified in `potency` to all potency values across all tiers of all PREs on the ability.