### PR TITLE
[#431] Prone application/removal ensures a valid `movementAction` is set

### DIFF
--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -53,6 +53,26 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    if (this.modifiesActor && this.statuses.has("prone")) {
+      for (const token of this.target.getDependentTokens()) token.refreshMovementAction();
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDelete(options, userId) {
+    super._onDelete(options, userId);
+    if (this.modifiesActor && this.statuses.has("prone")) {
+      for (const token of this.target.getDependentTokens()) token.refreshMovementAction();
+    }
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Modify the effectData for the new effect with the changes to include the imposing actor's UUID in the appropriate flag.
    * @param {string} statusId

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -40,6 +40,20 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
   /* -------------------------------------------------- */
 
   /**
+   * If the token's movementAction is invalid, force it to null (default)
+   * @returns {Promise<boolean>} true if the refresh has caused a change in movementAction, otherwise false
+   */
+  async refreshMovementAction() {
+    if (!CONFIG.Token.movement.actions[this.movementAction].canSelect(this)) {
+      await this.update({ movementAction: null }, { diff: false });
+      return true;
+    }
+    return false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Get hostile tokens within range of movement.
    * @param {Point[]} [points]              An array of points describing a segment of movement.
    * @returns {DrawSteelTokenDocument[]}    Hostile tokens.


### PR DESCRIPTION
Closes #431 
Has to be a `diff: false` update in case the existing `movementAction` is default.