### PR TITLE
Implemented smarter _dsid setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Sealed the characteristics object to prevent adding or removing characteristics.
 - PseudoDocument.create now returns the pseudo document instead of the parent.
 - Widened space for advancement labels to reduce need for line wrapping.
+- Items created with a default name (e.g. "Ability") will no longer have their _dsid set, instead allowing it to remain blank.
 
 ### Removed
 

--- a/src/module/data/item/base.mjs
+++ b/src/module/data/item/base.mjs
@@ -102,7 +102,9 @@ export default class BaseItemModel extends DrawSteelSystemModel {
       }
     }
 
-    if (!this._dsid) updates._dsid = data.name.slugify({ strict: true });
+    const defaultName = game.i18n.localize(CONFIG.Item.typeLabels[data.type]);
+
+    if (!this._dsid && !data.name.startsWith(defaultName)) updates._dsid = data.name.slugify({ strict: true });
 
     if (!foundry.utils.isEmpty(updates)) this.updateSource(updates);
   }


### PR DESCRIPTION
Our `Item#dsid` getter has a smart fallback if the item doesn't have the _dsid set. One common foible is if someone just creates an item while only relying on the default name (e.g. item creation on an actor sheet, which doesn't prompt for a name before creation). This PR addresses this by checking if the name that would be slugified is just the default name, and if so it leaves the _dsid blank and allows the getter to do its fallback.