### PR TITLE
Reformat & refactor of gain enricher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
   - This will not prevent application but will prevent their effects and show a warning when applied.
 - Added an "Additional" configuration to Item Grant advancements, which allows players to drop in items. (#708)
 - Added support for marking actors as unflankable with `system.statuses.flankable`. (#714)
-- Added a `[[/gain]]` enricher which can be used to distribute heroic resources and surges. (#606, #1252)
+- Added a `[[/gain]]` enricher which can be used to distribute heroic resources, surges, and other properties. (#606, #1252, #1319)
 - Added an `[[/apply]]` enricher which can be used to apply effects without a power roll. (#791)
 - Added a project events table field to projects and a context menu option on the actor sheet to draw an event from the table. (#797)
 - Added suggested books and licenses in the source input form. (#841)

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -38,42 +38,25 @@ Healing enrichers work similarly to damage enrichers, except the leading command
 
 The `[[/gain]]` enricher allows you to grant heroic resources (like Ferocity, Focus, Insight, etc.), epic resources (like Virtue, Divine Power, Breath, etc.), surges, or other progression resources (renown, wealth, victories) to selected hero actors. This is useful for abilities or effects that provide resources to party members.
 
-**Syntax:**
-- `[[/gain formula heroic]]` - Modifies heroic resources
-- `[[/gain formula surge]]` - Modifies surges
-- `[[/gain formula epic]]` - Modifies epic resources
-- `[[/gain formula renown]]` - Modifies renown
-- `[[/gain formula wealth]]` - Modifies wealth
-- `[[/gain formula victory]]` - Modifies victories
-- `[[/gain formula victories]]` - Modifies victories
-- `[[/heroic formula]]` - Equivalent to `/gain formula heroic`
-- `[[/surge formula]]` - Equivalent to `/gain formula surge`
-
-**Note:** You must specify the resource type (`heroic`, `surge`, `epic`, `renown`, `wealth`, or `victories`).
-
 **Examples:**
 
-- [&ZeroWidthSpace;[/gain 2 heroic]]: Gain 2 heroic resources.
-- [&ZeroWidthSpace;[/gain 2 hr]]: Gain 2 heroic resources.
-- [&ZeroWidthSpace;[/heroic 2]]: Gain 2 heroic resources.
-- [&ZeroWidthSpace;[/gain 1 surge]]: Gain 1 surge.
-- [&ZeroWidthSpace;[/surge 1]]: Gain 1 surge.
+- [&ZeroWidthSpace;[/gain 2 heroic]]: Gain 2 of a heroic resource. The basic structure is `/gain formula type`.
+- [&ZeroWidthSpace;[/gain formula=2 type=heroic]]: You can explicitly assign the `type` and `formula`.
+- [&ZeroWidthSpace;[/heroic 2]]: You can use the type in place of `/gain`.
 - [&ZeroWidthSpace;[/gain 2 epic]]: Gain 2 epic resources.
+- [&ZeroWidthSpace;[/gain 1 surge]]: Gain 1 surge. (Alias: `surges`)
 - [&ZeroWidthSpace;[/gain 3 renown]]: Gain 3 renown.
 - [&ZeroWidthSpace;[/gain 5 wealth]]: Gain 5 wealth.
-- [&ZeroWidthSpace;[/gain 1 victory]]: Gain 1 victory.
-- [&ZeroWidthSpace;[/gain 1d6 heroic]]: Gain a random amount of heroic resources based on a roll.
-- [&ZeroWidthSpace;[/gain 1d6 surge]]: Gain a random amount of surges based on a roll.
-- [&ZeroWidthSpace;[/gain 1d6 victories]]: Gain a random amount of victories based on a roll.
-- [&ZeroWidthSpace;[/gain @level heroic]]: Gain heroic resources equal to the owner's level.
-- [&ZeroWidthSpace;[/gain @level surge]]: Gain surges equal to the owner's level.
+- [&ZeroWidthSpace;[/gain 1 victory]]: Gain 1 victory. (Alias: `victories`)
+- [&ZeroWidthSpace;[/gain 2 hr]]: `hr` is a valid alias of `heroic`.
+- [&ZeroWidthSpace;[/gain 1d6 heroic]]: Rolls are made when the enricher is clicked.
+- [&ZeroWidthSpace;[/gain @A surge]]: The gain enricher supports roll data.
 - [&ZeroWidthSpace;[/gain 3 heroic]]{Gain Focus}: Brackets will replace the default text for the command.
 
 **Notes:**
-- Gain enrichers only work on hero actors (characters with heroic resources).
+- Gain enrichers only work on hero actors.
 - The roll is made once and the total is applied to all selected tokens.
 - Non-hero actors will be skipped when gaining resources.
-- When using /gain, you must specify the type (e.g. "heroic", "surge", "renown").
 
 ## Apply Effect
 


### PR DESCRIPTION
I had started to work on the 0.10 Test enricher when I realized that the implementation of `/gain` was unnecessarily using the `multiple` option to `parseConfig`. This led to a series of refactors. The end result is the same in terms of support but I believe this implementation is cleaner.