### PR TITLE
Allow users to always "reconfigure" item grants even if not a choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - PseudoDocument.create now returns the pseudo document instead of the parent.
 - Widened space for advancement labels to reduce need for line wrapping.
 - Items created with a default name (e.g. "Ability") will no longer have their _dsid set, instead allowing it to remain blank.
+- Item grant advancements can now always be reconfigured whether or not they're a choice to recreate the associated items.
 
 ### Removed
 

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -81,6 +81,16 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  get canReconfigure() {
+    const actor = this.document.parent;
+    // Removed check for isChoice, as an item grant advancement can always be reconfigured
+    // to delete old versions of items and make new ones
+    return !!actor && (this.requirements.level <= actor.system.level);
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Does this item grant advancement use point buy rather than a simple count.
    * @type {boolean}


### PR DESCRIPTION
Now even non-choice item grant advancements allow reconfiguring. This allows cleanly re-running the advancement to recreate a deleted feature or ability.

<img width="519" height="83" alt="image" src="https://github.com/user-attachments/assets/db5b8e43-e838-49ae-aa2d-d524c1a599bd" />
