### PR TITLE
Small Undead Update

### DIFF
--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Ghost_hCxrYde7uzidWWWp.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Ghost_hCxrYde7uzidWWWp.json
@@ -683,7 +683,7 @@
                   },
                   "potency": {
                     "value": "@potency.weak",
-                    "characteristic": "none"
+                    "characteristic": "presence"
                   }
                 },
                 "tier2": {
@@ -785,7 +785,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
         "systemVersion": "0.9.0",
         "lastModifiedBy": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Ghoul_DXM53Md2acyvSVNo.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Ghoul_DXM53Md2acyvSVNo.json
@@ -276,7 +276,7 @@
                 "tier3": {
                   "potency": {
                     "characteristic": "might",
-                    "value": "2"
+                    "value": "@potency.strong"
                   },
                   "display": "{{potency}} bleeding (save ends)",
                   "effects": {

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Rotting_Zombie_2KiVCGcov7SmCkWU.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Rotting_Zombie_2KiVCGcov7SmCkWU.json
@@ -315,7 +315,7 @@
                     "characteristic": "might",
                     "value": "@potency.strong"
                   },
-                  "display": "prone if size 1, or slowed (save ends) otherwise",
+                  "display": "{{potency}} prone if size 1, or slowed (save ends) otherwise",
                   "effects": {
                     "prone": {
                       "condition": "failure",
@@ -372,7 +372,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
         "systemVersion": "0.9.0",
         "lastModifiedBy": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Skeleton_2h6PhbOuGeraFQZm.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Skeleton_2h6PhbOuGeraFQZm.json
@@ -388,7 +388,7 @@
                 "tier1": {
                   "display": "{{potency}} bleeding (save ends)",
                   "potency": {
-                    "value": "0",
+                    "value": "@potency.weak",
                     "characteristic": "might"
                   },
                   "effects": {
@@ -401,7 +401,7 @@
                 },
                 "tier2": {
                   "potency": {
-                    "value": "1",
+                    "value": "@potency.average",
                     "characteristic": ""
                   },
                   "display": "",
@@ -415,7 +415,7 @@
                 },
                 "tier3": {
                   "potency": {
-                    "value": "2",
+                    "value": "@potency.strong",
                     "characteristic": ""
                   },
                   "display": "",
@@ -451,7 +451,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
         "systemVersion": "0.9.0",
         "lastModifiedBy": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Zombie_G7bFOGyqq0Z4xJ7F.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Zombie_G7bFOGyqq0Z4xJ7F.json
@@ -429,7 +429,7 @@
                   "display": "{{potency}} Dazed (save ends)",
                   "potency": {
                     "characteristic": "might",
-                    "value": "2"
+                    "value": "@potency.strong"
                   },
                   "effects": {
                     "dazed": {
@@ -442,7 +442,7 @@
                 "tier2": {
                   "display": "{{potency}} Weakened (save ends)",
                   "potency": {
-                    "value": "1",
+                    "value": "@potency.average",
                     "characteristic": "might"
                   },
                   "effects": {


### PR DESCRIPTION
Updated several Undead monsters.

Ghost - added Presence to potency for Spirited Away
Rotting Zombie - added {{potency}} to tier 3
Skeleton, Ghoul, Zombie - added @potency instead of hard coded values so they can interact with active effects.