### PR TITLE
[bugfix] Default value for flankable on actors to true

### DIFF
--- a/src/module/data/actor/base.mjs
+++ b/src/module/data/actor/base.mjs
@@ -114,7 +114,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     };
 
     Object.assign(this.statuses, {
-      flankable: false,
+      flankable: true,
       slowed: {
         speed: CONFIG.statusEffects.find(e => e.id === "slowed").defaultSpeed,
       },


### PR DESCRIPTION
Change default for `flankable` to `true` in `prepareBaseData`.

There's also a line to return false by default in `DrawSteelToken.canBeFlanked` but that's handling an unexpected/error condition, and still seems appropriate.