### PR TITLE
[bugfix] Update Fury ability Back!

### DIFF
--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_1_9cPQyQCXUIXRme9R/3_Ferocity_LezUXC0TBZaiXyoz/ability_Back__h8HLdTWTOgXRT7j7.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_1_9cPQyQCXUIXRme9R/3_Ferocity_LezUXC0TBZaiXyoz/ability_Back__h8HLdTWTOgXRT7j7.json
@@ -61,10 +61,8 @@
           "type": "forced",
           "_id": "C4VqqXoM1Zm8t8zj",
           "forced": {
-            "tier1": {
-              "distance": "",
-              "display": "",
-              "movement": []
+            "tier2": {
+              "distance": "1"
             },
             "tier3": {
               "distance": "3"


### PR DESCRIPTION
Hey, I think there is a bug with "Back!" ability. In the book effects are push 1 for Tier 2 or push 3 for Tier 3 (p. 133)

Also, `tier1` entry is redundant here.