### PR TITLE
Potency fixes

### DIFF
--- a/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/5_Wrath_GOehKV6ApzuE7vxg/ability_Purifying_Fire_4m5rgK9RH2QXg9S5.json
+++ b/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/5_Wrath_GOehKV6ApzuE7vxg/ability_Purifying_Fire_4m5rgK9RH2QXg9S5.json
@@ -77,8 +77,12 @@
               "display": "{{potency}}, the target has fire weakness 3 (save ends)",
               "effects": {
                 "hBGO4yodWA8gyLNk": {
-                  "condition": "failure"
+                  "condition": "failure",
+                  "end": ""
                 }
+              },
+              "potency": {
+                "characteristic": "might"
               }
             },
             "tier2": {
@@ -163,9 +167,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1754757295039,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_9_ZdH4O2rMxAChZUDK/Exorcist_mpEhZreyN7MCucXa/ability_Banish_Fl6R6GdRGEu9NQGj.json
+++ b/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_9_ZdH4O2rMxAChZUDK/Exorcist_mpEhZreyN7MCucXa/ability_Banish_Fl6R6GdRGEu9NQGj.json
@@ -69,6 +69,9 @@
                   "condition": "failure",
                   "end": ""
                 }
+              },
+              "potency": {
+                "characteristic": "presence"
               }
             },
             "tier2": {
@@ -82,7 +85,8 @@
             "tier3": {
               "effects": {
                 "ztBgmMZaY9rbNmZD": {
-                  "condition": "failure"
+                  "condition": "failure",
+                  "end": ""
                 }
               }
             }

--- a/src/packs/abilities/Tactician_If39E6GsmUaOGSIx/Level_9_YuxxYrrPRBwPO0xN/Insurgent_hi7Jt2CwJ92o8UXQ/ability_Their_Lack_of_Focus_Is_Their_Undoing_h6aDBmqcW9wAXMzt.json
+++ b/src/packs/abilities/Tactician_If39E6GsmUaOGSIx/Level_9_YuxxYrrPRBwPO0xN/Insurgent_hi7Jt2CwJ92o8UXQ/ability_Their_Lack_of_Focus_Is_Their_Undoing_h6aDBmqcW9wAXMzt.json
@@ -52,6 +52,9 @@
                   "condition": "failure",
                   "end": ""
                 }
+              },
+              "potency": {
+                "characteristic": "reason"
               }
             },
             "tier2": {
@@ -65,7 +68,8 @@
             "tier3": {
               "effects": {
                 "dazed": {
-                  "condition": "failure"
+                  "condition": "failure",
+                  "end": ""
                 }
               }
             }

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/3_Clarity_DDQszc7f2JZLgbRD/ability_Smolder_ubBYqHf4LxOZZw4G.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/3_Clarity_DDQszc7f2JZLgbRD/ability_Smolder_ubBYqHf4LxOZZw4G.json
@@ -69,6 +69,9 @@
                   "condition": "failure",
                   "end": "save"
                 }
+              },
+              "potency": {
+                "characteristic": "reason"
               }
             },
             "tier2": {
@@ -83,7 +86,8 @@
               "display": "{{potency}}, the target has weakness equal to 5 + your Reason score (save ends)",
               "effects": {
                 "LUcaVS8NL6mNDwb6": {
-                  "condition": "failure"
+                  "condition": "failure",
+                  "end": ""
                 }
               }
             }
@@ -209,9 +213,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.9.0",
     "createdTime": 1755872266582,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Optic_Blast_9eXjhpEgsqkgc3Dq.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Optic_Blast_9eXjhpEgsqkgc3Dq.json
@@ -66,6 +66,9 @@
                   "condition": "failure",
                   "end": ""
                 }
+              },
+              "potency": {
+                "characteristic": "might"
               }
             },
             "tier2": {
@@ -79,7 +82,8 @@
             "tier3": {
               "effects": {
                 "prone": {
-                  "condition": "failure"
+                  "condition": "failure",
+                  "end": ""
                 }
               }
             }

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_2_cXM7Hf95KOdau9wz/Telekinesis_NBTVqJoKmvoc5a2t/ability_Levity_and_Gravity_dwhjMDvFu6CMO1Dv.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_2_cXM7Hf95KOdau9wz/Telekinesis_NBTVqJoKmvoc5a2t/ability_Levity_and_Gravity_dwhjMDvFu6CMO1Dv.json
@@ -69,6 +69,9 @@
                   "condition": "failure",
                   "end": ""
                 }
+              },
+              "potency": {
+                "characteristic": "might"
               }
             },
             "tier2": {
@@ -158,9 +161,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.348",
+    "coreVersion": "13.350",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.1",
+    "systemVersion": "0.9.0",
     "createdTime": 1756182083735,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Jurist_u2LQOxcBMlktfPgQ.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Jurist_u2LQOxcBMlktfPgQ.json
@@ -271,7 +271,7 @@
                   },
                   "potency": {
                     "value": "@potency.average",
-                    "characteristic": ""
+                    "characteristic": "agility"
                   }
                 },
                 "tier3": {

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Warden_oOrOtSddf3x85DG3.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Warden_oOrOtSddf3x85DG3.json
@@ -473,7 +473,7 @@
                   "display": "{{potency}} Slowed (Save Ends)",
                   "potency": {
                     "value": "@potency.weak",
-                    "characteristic": "none"
+                    "characteristic": "agility"
                   },
                   "effects": {
                     "slowed": {

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Hill_Giant_Clobberer_kXSSWU0exe6iGF7V.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Hill_Giant_Clobberer_kXSSWU0exe6iGF7V.json
@@ -465,7 +465,7 @@
                   },
                   "potency": {
                     "value": "@potency.average",
-                    "characteristic": ""
+                    "characteristic": "might"
                   }
                 },
                 "tier3": {

--- a/src/packs/monsters/Hag_Xlv2aLypC87MCZAS/npc_Wode_Hag_FTLYZPKo0ZIJ0n5q.json
+++ b/src/packs/monsters/Hag_Xlv2aLypC87MCZAS/npc_Wode_Hag_FTLYZPKo0ZIJ0n5q.json
@@ -664,7 +664,7 @@
                   "effects": {},
                   "potency": {
                     "value": "@potency.weak",
-                    "characteristic": "none"
+                    "characteristic": "reason"
                   }
                 }
               }
@@ -697,9 +697,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.1",
+        "systemVersion": "0.9.0",
         "lastModifiedBy": null,
         "modifiedTime": null
       },

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Scyza_Emq63NO4oAwQQmEZ.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Scyza_Emq63NO4oAwQQmEZ.json
@@ -704,6 +704,9 @@
                       "condition": "failure",
                       "end": "save"
                     }
+                  },
+                  "potency": {
+                    "characteristic": "reason"
                   }
                 },
                 "tier2": {

--- a/src/packs/monsters/Rivals_JYYzmjl4NO5qaYjj/Rivals___1st_Echelon_SFuvViqB8j9ZtHt6/npc_Rival_Tactician_6ipD4f10bXqtf0jn.json
+++ b/src/packs/monsters/Rivals_JYYzmjl4NO5qaYjj/Rivals___1st_Echelon_SFuvViqB8j9ZtHt6/npc_Rival_Tactician_6ipD4f10bXqtf0jn.json
@@ -428,7 +428,7 @@
                   },
                   "potency": {
                     "value": "@potency.weak",
-                    "characteristic": "none"
+                    "characteristic": "might"
                   }
                 },
                 "tier2": {
@@ -486,9 +486,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
-        "systemVersion": "0.8.0",
+        "systemVersion": "0.9.0",
         "lastModifiedBy": null,
         "modifiedTime": null
       },

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Ghost_hCxrYde7uzidWWWp.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Ghost_hCxrYde7uzidWWWp.json
@@ -683,7 +683,7 @@
                   },
                   "potency": {
                     "value": "@potency.weak",
-                    "characteristic": "none"
+                    "characteristic": "presence"
                   }
                 },
                 "tier2": {
@@ -785,7 +785,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
         "systemVersion": "0.9.0",
         "lastModifiedBy": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_Mischievite_INnXF5QdysGbBcAY.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_Mischievite_INnXF5QdysGbBcAY.json
@@ -274,7 +274,7 @@
                   },
                   "potency": {
                     "value": "@potency.strong",
-                    "characteristic": ""
+                    "characteristic": "reason"
                   }
                 }
               }
@@ -348,7 +348,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "draw-steel",
         "systemVersion": "0.9.0",
         "lastModifiedBy": null,


### PR DESCRIPTION
Purifying Fire | Fire Weakness
Optic Blast | Prone
Banish | Banished
Levity and Gravity | Prone
Their Lack of Focus is Their Undoing | Dazed
Smolder | Weakness

Rival Tactician | I'll Cover You! | Weakened
Scyza | Crestfall | Dazed
Wode Hag | Turned Upside Down | Restrained
War Dog Mischievite | Fuse-Iron Knives | Dazzled
Ghost | Spirited Away | Levitated
Hill Giant Clobberer | Stomp | can't stand
Dwarf Warden | Concussive Shockwave | Slowed
Devil Jurist | Fire and Brimston | Burning