### PR TITLE
fix: size of monster is now modified correctly

### DIFF
--- a/src/packs/monster-features/Animal_Traits_QDpGXDDyQUqaWzoW/Supernatural_Traits_y82tzOi2Jyl31NrN/feature_Imposer_8YqnoTDMkNGHoRdL.json
+++ b/src/packs/monster-features/Animal_Traits_QDpGXDDyQUqaWzoW/Supernatural_Traits_y82tzOi2Jyl31NrN/feature_Imposer_8YqnoTDMkNGHoRdL.json
@@ -104,7 +104,7 @@
           "priority": null
         },
         {
-          "key": "system.size.value",
+          "key": "system.combat.size.value",
           "mode": 2,
           "value": "1",
           "priority": null
@@ -130,7 +130,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "draw-steel",
         "systemVersion": "0.8.1",
         "createdTime": 1757723381290,


### PR DESCRIPTION
Was creating a custom animal with the Imposer trait and saw that the size was not properly updated. Seemed like an easy fix, so here it is!