### PR TITLE
[#1389] Fixed parent combat reference in CombatantGroup.createFromTokens

### DIFF
--- a/src/module/documents/combatant-group.mjs
+++ b/src/module/documents/combatant-group.mjs
@@ -130,7 +130,7 @@ export default class DrawSteelCombatantGroup extends foundry.documents.Combatant
     const type = tokens.some(t => t.actor?.system.isMinion) ? "squad" : "base";
     const group = await this.create({
       type,
-      name: tokens.every(t => t.actor?.name === actorName) ? actorName : this.defaultName({ type, parent: this.viewed }),
+      name: tokens.every(t => t.actor?.name === actorName) ? actorName : this.defaultName({ type, parent: combat }),
       img: tokens.every(t => t.texture.src === tokenImage) ? tokenImage : null,
     }, { parent: combat });
     const updateData = combatants.map(c => ({ _id: c.id, group: group.id }));


### PR DESCRIPTION
Bug from being factored out of a CombatTracker method

Closes #1389 