### PR TITLE
[#1390] Fixed save threshold check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
   - Corrected the skill grant on the Shipwrecked complication.
   - Added missing potency characteristics to Purifying Fire, Optic Blast, and Smolder.
   - Moved the erroneous inclusion of a push in the tier 1 result of the fury's "Back!" to tier 2.
+  - Corrected action type for Berserker "Wrecking Ball".
 - Director-Facing Compendium Data fixes:
   - Implemented the "custom" target text for many abilities.
   - Converted "With Captain" features to "With Captain" effects.
@@ -157,11 +158,13 @@
   - Radenwight "Trouser Cut" applies a custom "Pantsed" effect. (#1146)
   - Corrected monster roles to the Grulqin, Orliq, and Wobalas. (#1173)
   - Added missing potency characteristics to abilities on the Rival Tactician, Wode Hag, and Ghost.
+  - Corrected data path for "Imposter" animal trait.
 - Fixed "undefined" target value for abilities created on an actor sheet. (#1138)
 - Fixed active effects not sorting on actor and item sheets. (#1149)
 - Addressed the SortingHelpers.performIntegerSort depreciation warning. (#1155)
 - Fixed issues with "Alternative" initiative. (#1168)
 - Stability is properly capped at a minimum of 0. (#1308)
+- Fixed save threshold adjustments not being applied. (#1390)
 - Fixed broken image links in the in-game documentation.
 
 ## 0.8.1

--- a/src/module/data/effect/base.mjs
+++ b/src/module/data/effect/base.mjs
@@ -114,7 +114,7 @@ export default class BaseEffectModel extends foundry.abstract.TypeDataModel {
     dialogOptions.context ??= {};
     dialogOptions.context.effectFormula = formula;
     dialogOptions.context.successThreshold = rollOptions.successThreshold ??
-      foundry.utils.getProperty(rollData, "combat.save.threshold") ?? 6;
+      foundry.utils.getProperty(this.parent.target, "system.combat.save.threshold") ?? 6;
 
     const fd = await SavingThrowDialog.create(dialogOptions);
 


### PR DESCRIPTION
The saving throw dialog now properly initializes the threshold based on the actor data

Closes #1390 