### PR TITLE
Implemented jump coloration

### DIFF
--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -158,7 +158,28 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       const value = foundry.utils.getProperty(this, "token.document.actor.system.movement.value") ?? Infinity;
       // Total cost, up to 1x is green, up to 2x is yellow, over that is red
       const index = Math.clamp(Math.floor((waypoint.measurement.cost - 1) / value), 0, 2);
-      style.color = colors[index];
+
+      const { might, agility } = foundry.utils.getProperty(this, "token.actor.system.characteristics") ?? {};
+
+      // Jumping is evaluated on its own terms, separate from the overall movement highlighting,
+      // Unless the total distance exceeds 2x the actor's speed
+      if ((index < 2) && (waypoint.action === "jump") && (might && agility)) {
+        const jumpColors = [0x33BC4E, 0xF1D836, 0xffa500, 0xE72124];
+        const maxDistance = Math.max(1, might.value, agility.value);
+
+        let jumpDistance = waypoint.cost;
+        let wp = waypoint.previous;
+        while (wp && !wp.explicit) {
+          jumpDistance += wp?.cost ?? 0;
+          wp = wp.previous;
+        }
+
+        // Green jump distance is equal to or less than higher of Might and Agility
+        // Yellow for +1 (tier 2 test result), Orange for +2 (tier 3 test result), red beyond that.
+        const jumpIndex = Math.clamp(Math.max(0, Math.ceil(jumpDistance - maxDistance)), 0, 3);
+        style.color = jumpColors[jumpIndex];
+      }
+      else style.color = colors[index];
     }
   }
 }


### PR DESCRIPTION

<img width="416" height="356" alt="image" src="https://github.com/user-attachments/assets/f79d2aac-ef95-4f34-9de5-9095e0bd4f61" />


<img width="294" height="216" alt="image" src="https://github.com/user-attachments/assets/24c36855-9e69-4a33-85a9-65aba50cccd2" />

- Jumps are evaluated as their own segment, unless the overall movement exceeds 2x the actor's speed
- Green is within automatic jump, yellow for tier 2 test result, orange for tier 3.
