### PR TITLE
Fixed characteristic advance issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - Player-Facing Compendium Data Fixes:
+- Fixed an issue where double-guaranteed characteristic advances would give bonuses to all characteristics instead of only two.
 
 ## 0.9.0
 

--- a/src/module/utils/advancement-chain.mjs
+++ b/src/module/utils/advancement-chain.mjs
@@ -126,7 +126,7 @@ export default class AdvancementChain {
       }
     } else if (advancement.type === "characteristic") {
       for (const [chr, { label }] of Object.entries(ds.CONFIG.characteristics)) {
-        if (advancement.characteristics[chr] === -1) continue;
+        if (!(advancement.characteristics[chr] >= 0)) continue;
 
         const choice = node.choices[chr] = {
           node,


### PR DESCRIPTION
For some reason the NEVER would end up showing as `undefined`, which meant the explicit check wasn't working.