### PR TITLE
[#1412] Handle non-base-type AEs gracefully when determining context menu options

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -656,7 +656,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
         icon: "<i class=\"fa-solid fa-fw fa-dice-d10\"></i>",
         condition: (target) => {
           const effect = this._getEmbeddedDocument(target);
-          return (effect.documentName === "ActiveEffect") && (effect.system.end.type === "save");
+          return (effect.documentName === "ActiveEffect") && (effect.system.end?.type === "save");
         },
         callback: async (target) => {
           const effect = this._getEmbeddedDocument(target);

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -354,7 +354,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         icon: "<i class=\"fa-solid fa-fw fa-dice-d10\"></i>",
         condition: (target) => {
           const effect = this._getEmbeddedDocument(target);
-          return effect.system.end.type === "save";
+          return effect.system.end?.type === "save";
         },
         callback: async (target) => {
           const effect = this._getEmbeddedDocument(target);


### PR DESCRIPTION
Closes #1412
Elsewhere (like in `HeroModel#takeRespite`) this is handled with something like:
```js
if (!(effect.system instanceof BaseEffectModel)) continue;
```
Could do similar here, if that's desired, i.e.
```diff
  const effect = this._getEmbeddedDocument(target);
- return (effect.documentName === "ActiveEffect") && (effect.system.end.type === "save");
+ return (effect.system instanceof BaseEffectModel) && (effect.system.end.type === "save");
```
and
```diff
  const effect = this._getEmbeddedDocument(target);
- return effect.system.end.type === "save";
+ return (effect.system instanceof BaseEffectModel) && (effect.system.end.type === "save");
```