### PR TITLE
[#1385] Adjusted scrollbar CSS for tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 ### Fixed
 
 - Player-Facing Compendium Data Fixes:
+  - Corrected action type for the 1st & 2nd Grave Domain abilities for the Censor and Conduit.
+- Normalized scrollbar experience across browsers for document sheet tabs. (#1385)
+- Fixed interaction with AE subtypes provided by modules. (#1412)
 - Fixed an issue where double-guaranteed characteristic advances would give bonuses to all characteristics instead of only two.
 
 ## 0.9.0

--- a/src/styles/system/applications/components/forms.css
+++ b/src/styles/system/applications/components/forms.css
@@ -39,6 +39,10 @@
 
   section.tab {
     overflow: auto;
+    --scroll-margin: 0.75rem;
+    margin-right: calc(-1 * var(--scroll-margin));
+    padding-right: var(--scroll-margin);
+    scrollbar-gutter: stable;
 
     &.standard-form {
       padding-top: 0.5rem;

--- a/templates/sheets/actor/hero-sheet/equipment.hbs
+++ b/templates/sheets/actor/hero-sheet/equipment.hbs
@@ -40,7 +40,7 @@
           <div class="item-column item-ranged-bonus">{{> kitDamageBonuses damage=kitContext.item.system.bonuses.ranged.damage}}</div>
           <div class="item-column item-controls">
             <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="documentListContext"></a>
-            <a class="fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
+            <a class="fa-fw fa-solid fa-angle-{{ifThen kitContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if kitContext.expanded}}expanded{{/if}}">
@@ -92,7 +92,7 @@
             </a>
           </div>
           <div class="item-column item-controls">
-            <a class="fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
+            <a class="fa-fw fa-solid fa-angle-{{ifThen treasureContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if treasureContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/hero-sheet/features.hbs
+++ b/templates/sheets/actor/hero-sheet/features.hbs
@@ -25,7 +25,7 @@
           </div>
           <div class="item-column item-controls">
             <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="documentListContext"></a>
-            <a class="fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
+            <a class="fa-fw fa-solid fa-angle-{{ifThen complicationContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if complicationContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/hero-sheet/projects.hbs
+++ b/templates/sheets/actor/hero-sheet/projects.hbs
@@ -29,7 +29,7 @@
           <div class="item-column item-type">{{lookup (lookup @root.config.projects.types projectContext.item.system.type) "label"}}</div>
           <div class="item-column item-controls">
             <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="documentListContext"></a>
-            <a class="fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
+            <a class="fa-fw fa-solid fa-angle-{{ifThen projectContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed {{#if projectContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/shared/abilities.hbs
+++ b/templates/sheets/actor/shared/abilities.hbs
@@ -53,7 +53,7 @@
           <div class="item-column item-target">{{abilityContext.formattedLabels.target}}</div>
           <div class="item-column item-controls">
             <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="documentListContext"></a>
-            <a class="fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
+            <a class="fa-fw fa-solid fa-angle-{{ifThen abilityContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
           </div>
         </div>
         <div class="document-description item-embed content-embed {{#if abilityContext.expanded}}expanded{{/if}}">

--- a/templates/sheets/actor/shared/partials/features/features.hbs
+++ b/templates/sheets/actor/shared/partials/features/features.hbs
@@ -26,7 +26,7 @@
         <div class="item-column item-type">{{localize typeLabel}}</div>
         <div class="item-column item-controls">
           <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="documentListContext"></a>
-          <a class="fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
+          <a class="fa-fw fa-solid fa-angle-{{ifThen featureContext.expanded "down" "right"}}" data-action="toggleDocumentDescription"></a>
         </div>
       </div>
       <div class="document-description item-embed {{#if featureContext.expanded}}expanded{{/if}}">


### PR DESCRIPTION
- I now understand why `scrollable` isn't just overflow handling, it has the extra padding & margin bits I've now copied to our `tab` class handling.
- I also took the liberty of adjusting a bunch of these <a> tags to use fa-fw. It's likely we should also just switch these to <button> elements, but that felt too aggressive for a hotfix.