### PR TITLE
Fix expanded descriptions not staying expanded on re-render

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -327,7 +327,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
   async _prepareItemContext(item) {
     const context = {
       item,
-      expanded: this._expandedDocumentDescriptions.has(item.id),
+      expanded: this._expandedDocumentDescriptions.has(item.uuid),
     };
 
     // only generate the item embed when it's expanded
@@ -514,7 +514,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
         expanded: false,
       };
 
-      if (this._expandedDocumentDescriptions.has(e.id)) {
+      if (this._expandedDocumentDescriptions.has(e.uuid)) {
         effectContext.expanded = true;
         effectContext.enrichedDescription = await e.system.toEmbed({});
       }

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -291,7 +291,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         expanded: false,
       };
 
-      if (this._expandedDocumentDescriptions.has(e.id)) {
+      if (this._expandedDocumentDescriptions.has(e.uuid)) {
         effectContext.expanded = true;
         effectContext.enrichedDescription = await e.system.toEmbed({});
       }


### PR DESCRIPTION
I noticed that item/effect descriptions weren't maintaining their expanded status on sheet re-render.  Context prep was looking for `id`s when the set was using `uuid`s.