### PR TITLE
Add language sorting to the language picker

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -272,7 +272,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
     }
     return {
       list: formatter.format(languageList),
-      options: languageOptions.sort((a,b) => a.label.localeCompare(b.label)),
+      options: languageOptions,
     };
   }
 

--- a/templates/sheets/actor/shared/partials/biography/languages.hbs
+++ b/templates/sheets/actor/shared/partials/biography/languages.hbs
@@ -17,6 +17,6 @@
   {{#if isPlay}}
   {{languages.list}}
   {{else}}
-  {{formInput systemFields.biography.fields.languages value=systemSource.biography.languages dataset=datasets.isSource options=languages.options}}
+  {{formInput systemFields.biography.fields.languages value=systemSource.biography.languages dataset=datasets.isSource options=languages.options sort=true}}
   {{/if}}
 </fieldset>


### PR DESCRIPTION
QOL change to add sorting to the language picker options on the actor sheets, ordering them A-Z based on the label.

No clue if this is the best way to go about it, but it does work.