### PR TITLE
Update icon element class

### DIFF
--- a/src/module/applications/elements/icon-element.mjs
+++ b/src/module/applications/elements/icon-element.mjs
@@ -49,11 +49,11 @@ export default class DSIconElement extends HTMLElement {
 
   /**
    * Fetch and cache SVG element.
-   * @param {string} src                          File path of the svg element.
-   * @returns {SVGElement|Promise<SVGElement>}    Promise if the element is not cached, otherwise the element directly.
+   * @param {string} src                  File path of the image element.
+   * @returns {string|Promise<string>}    Promise if the element is not cached, otherwise the element directly.
    */
   static fetch(src) {
-    if (!src.endsWith(".svg")) return foundry.utils.parseHTML(`<img src="${src}">`);
+    if (!src.endsWith(".svg")) return `<img src="${src}">`;
     if (!DSIconElement.#svgCache.has(src)) DSIconElement.#svgCache.set(src, fetch(src)
       .then(b => b.text())
       .then(t => this.#svgCache.set(src, t).get(src)));


### PR DESCRIPTION
Updates the `DSIconElement` class:
- Store only raw html, no elements.
- Replace strings such as `__1__` with random ids; this allows for using `mask` and `clipPath` in the SVGs which requires having an id; these are then replaced when the element is inserted, removing the possibility of duplicate ids across the DOM.

Example:
```svg
<mask id="__1__">
  <rect width="100%" height="100%" fill="black" />
</mask>
<g mask="url(#__1__)" fill="purple">
  <circle cx="120" cy="75" r="50" />
</g>
```