### PR TITLE
[#1579] Add tooltip to lookup enricher

### DIFF
--- a/src/module/applications/ux/enrichers/lookup.mjs
+++ b/src/module/applications/ux/enrichers/lookup.mjs
@@ -64,6 +64,7 @@ export async function enricher(match, options) {
   if (!value && (options.documents === false)) return null;
   else if (!value) span.classList.add("not-found");
   span.innerText = value ?? parsedConfig.formula;
+  span.dataset.tooltip = (value === fallback) ? parsedConfig.formula : fallback;
   return span;
 }
 

--- a/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Domains_IJYwaJKLrKj0XHJ1/Life_OEijCNUyItdVx5Mv/feature_Revitalizing_Ritual_z0B62LJOs3hnnzdo.json
+++ b/src/packs/classes/Censor_ScAs0Dx7zp2fbcYH/Domains_IJYwaJKLrKj0XHJ1/Life_OEijCNUyItdVx5Mv/feature_Revitalizing_Ritual_z0B62LJOs3hnnzdo.json
@@ -6,7 +6,7 @@
   "img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
   "system": {
     "description": {
-      "value": "<p>Each time you finish a respite, you can choose yourself or one ally who is also finishing a respite to gain the benefit of a divine ritual. The chosen character gains a bonus to their recovery value equal to [[@level]] that lasts until you finish another respite.</p>",
+      "value": "<p>Each time you finish a respite, you can choose yourself or one ally who is also finishing a respite to gain the benefit of a divine ritual. The chosen character gains a bonus to their recovery value equal to [[lookup @level]]{your level} that lasts until you finish another respite.</p>",
       "director": ""
     },
     "source": {
@@ -34,9 +34,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.351",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.10.0",
     "createdTime": 1754754730085,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/classes/Conduit_1KqNzItDbgiZLVOP/Domains_SSkm34n3jRW0PFQ9/Life_WyTvReOtaBUPsvk2/feature_Revitalizing_Ritual_kDa1rc6xRuBARDpJ.json
+++ b/src/packs/classes/Conduit_1KqNzItDbgiZLVOP/Domains_SSkm34n3jRW0PFQ9/Life_WyTvReOtaBUPsvk2/feature_Revitalizing_Ritual_kDa1rc6xRuBARDpJ.json
@@ -6,7 +6,7 @@
   "img": "icons/magic/symbols/runes-star-pentagon-blue.webp",
   "system": {
     "description": {
-      "value": "<p>Each time you finish a respite, you can choose yourself or one ally who is also finishing a respite to gain the benefit of a divine ritual. The chosen character gains a bonus to their recovery value equal to your level [[@level]] that lasts until you finish another respite.</p>",
+      "value": "<p>Each time you finish a respite, you can choose yourself or one ally who is also finishing a respite to gain the benefit of a divine ritual. The chosen character gains a bonus to their recovery value equal to [[lookup @level]]{your level} that lasts until you finish another respite.</p>",
       "director": ""
     },
     "source": {
@@ -27,9 +27,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.351",
     "systemId": "draw-steel",
-    "systemVersion": "0.8.0",
+    "systemVersion": "0.10.0",
     "createdTime": 1755755164919,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/styles/system/applications/ux/enrichers.css
+++ b/src/styles/system/applications/ux/enrichers.css
@@ -17,4 +17,8 @@ enriched-content {
     text-wrap-mode: nowrap;
     word-break: break-all;
   }
+
+  &[enricher="ds.lookup"] {
+    text-decoration: underline dotted;
+  }
 }


### PR DESCRIPTION
Closes #1579 

Updated Revitalizing Ritual just for testing purposes. Added a dotted underline to indicate that the text is hoverable.

With Actor Owner
<img width="819" height="151" alt="owned lookup" src="https://github.com/user-attachments/assets/1bdac316-d0ba-421a-9e58-9b2a22e3afee" />

Without Actor Owner
<img width="818" height="149" alt="unowned lookup" src="https://github.com/user-attachments/assets/5e29f9e8-a79b-44e5-badf-65f5daabcd64" />
