### PR TITLE
Proposed table CSS Refactor

### DIFF
--- a/src/styles/system/applications/sheets/journal-entry-sheet.css
+++ b/src/styles/system/applications/sheets/journal-entry-sheet.css
@@ -349,7 +349,9 @@ aside[role="tooltip"] section.content {
     }
   }
 
-  /*laser lines on captions */
+
+  /* STANDARD HTML TABLES */
+
   caption {
     text-align: center;
     position: relative;
@@ -412,71 +414,6 @@ aside[role="tooltip"] section.content {
 
   }
 
-  /*laser lines on figcaptions*/
-  figure {
-    display: table;
-  }
-
-  figcaption {
-    display: table-caption;
-    caption-side: top;
-    text-align: center;
-    position: relative;
-    line-height: 0.75em;
-    padding-top: 0.85em;
-    width: 100%;
-    border-image: linear-gradient(to right, #ffffff03, #866d4b99, #ffffff03) 1;
-    border-image-slice: 1;
-    margin-bottom: 2em;
-
-    cite {
-      float: right;
-    }
-
-    /*if it has the table title in a strong tag*/
-    &:has(strong) {
-      border-bottom: 2px solid var(--draw-steel-c-laserline);
-
-      strong {
-        background: var(--draw-steel-c-white);
-        margin: -0.2em;
-        position: absolute;
-        transform: translate(-50%, 0%);
-        font-style: normal;
-      }
-
-      strong::before {
-        content: "®";
-        font-family: Draw Steel Glyphs;
-        color: #866d4b;
-
-
-      }
-
-      strong::after {
-        content: "®";
-        font-family: Draw Steel Glyphs;
-        color: #866d4b;
-      }
-
-      cite {
-        position: absolute;
-        top: 1.75em;
-        right: 0;
-      }
-
-      cite::before {
-        content: '';
-        clear: both;
-        /*margin-top: 2em;*/
-      }
-    }
-
-    p {
-      padding: 0.5em;
-    }
-  }
-
   .ability-bordered {
     &.default {
       --ability-border: var(--ability-default-border);
@@ -505,6 +442,70 @@ aside[role="tooltip"] section.content {
       .equipment dl {
         display: grid;
         grid-template-columns: auto 1fr auto 1fr auto 1fr;
+      }
+    }
+
+    /* EMBEDDED ROLL TABLES */
+
+    figure:has(table) {
+      cite {
+        float: right;
+      }
+    }
+
+    figcaption:has(+ table) {
+      caption-side: top;
+      text-align: center;
+      position: relative;
+      line-height: 0.75em;
+      padding-top: 0.85em;
+      width: 100%;
+      border-image: linear-gradient(to right, #ffffff03, #866d4b99, #ffffff03) 1;
+      border-image-slice: 1;
+      margin-bottom: 2em;
+
+
+      /*if it has the table title in a strong tag*/
+      &:has(strong) {
+        border-bottom: 2px solid var(--draw-steel-c-laserline);
+
+        strong {
+          background: var(--draw-steel-c-white);
+          margin: -0.2em;
+          position: absolute;
+          transform: translate(-50%, 0%);
+          font-style: normal;
+        }
+
+        strong::before {
+          content: "®";
+          font-family: Draw Steel Glyphs;
+          color: #866d4b;
+
+
+        }
+
+        strong::after {
+          content: "®";
+          font-family: Draw Steel Glyphs;
+          color: #866d4b;
+        }
+
+        cite {
+          position: absolute;
+          top: 1.75em;
+          right: 0;
+        }
+
+        cite::before {
+          content: '';
+          clear: both;
+          /*margin-top: 2em;*/
+        }
+      }
+
+      p {
+        padding: 0.5em;
       }
     }
   }


### PR DESCRIPTION
While poking around at the internal embed logic, I noticed that there's a `captionPosition=top` option. This does a few things
1. Makes our laser lines captions more specific and table only
2. Makes the laser lines require specifying `captionPosition=top` to actually move the caption *to* the top of the table
3. Ensures that the cite still floats right if it's kept. Not that I think we generally should.

<img width="820" height="250" alt="image" src="https://github.com/user-attachments/assets/6433eaeb-9bc1-4087-b669-b26c9914cbb9" />

The table is just embedded with `@Embed[Compendium.draw-steel.tables.RollTable.jjtM55JUzmW6TaG2 captionPosition=top rollable]{Complications}`
