### PR TITLE
Fix display of unowned forced movement PREs

### DIFF
--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -115,6 +115,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
 
     // Group movement types by their final distance value (base + bonus)
     const distanceGroups = Map.groupBy([...tierValue.movement], movementType => {
+      if (!this.actor) return baseDistance;
       return baseDistance + (this.bonuses ? this.bonuses[movementType] ?? 0 : 0);
     });
 


### PR DESCRIPTION
While working on #1568, discovered that unowned abilities with forced movement PREs were having 0 appended to the end of the distance because the distance is a formula/string field, so "1" distance was becoming "10".