### PR TITLE
Disable power roll reactive checkbox in play mode

### DIFF
--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -14,7 +14,7 @@
   <fieldset class="power-roll-data">
     <legend>{{localize "DRAW_STEEL.Item.ability.FIELDS.power.label"}}</legend>
     {{#with systemFields.power.fields.roll.fields as |powerRoll|}}
-    {{formGroup powerRoll.reactive value=@root.system.power.roll.reactive}}
+    {{formGroup powerRoll.reactive value=@root.system.power.roll.reactive disabled=@root.isPlay}}
     {{formGroup powerRoll.characteristics value=@root.system.power.roll.characteristics options=@root.characteristics disabled=@root.isPlay}}
     {{#unless @root.system.power.roll.reactive}}
     {{formGroup powerRoll.formula value=@root.system.power.roll.formula placeholder=powerRoll.formula.initial disabled=@root.isPlay}}


### PR DESCRIPTION
While working #1616, I noticed that the reactive checkbox wasn't properly disabled.