### PR TITLE
Adjusted embed logic and styling

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -264,17 +264,15 @@ export default class AbilityModel extends BaseItemModel {
    * @param {EnrichmentOptions} options
    */
   async toEmbed(config, options = {}) {
-    // All abilities are rendered inline
-    config.inline = true;
-
     // If unspecified assume all three tiers are desired for display
     if (!(("tier1" in config) || ("tier2" in config) || ("tier3" in config))) {
       config.tier1 = config.tier2 = config.tier3 = this.power.effects.size > 0;
     }
 
-    const embed = document.createElement("div");
+    // Ability embeds do not have citations
+    const embed = document.createElement("document-embed");
     embed.classList.add("draw-steel", "ability");
-    if (config.includeName !== false) embed.insertAdjacentHTML("afterbegin", `<h5>${this.parent.name}</h5>`);
+    if (config.includeName !== false) embed.innerHTML = `<h5>${config.cite ? this.parent.toAnchor().outerHTML : this.parent.name}</h5>`;
     const context = {
       system: this,
       systemFields: this.schema.fields,

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -1,6 +1,9 @@
 /* Sheets do not include the document-embed wrapper but do use a `.content-embed` div class */
 document-embed, .content-embed {
-  div.ability, &.immediate-embed.ability {
+  &.inline {
+    display: inline;
+  }
+  &.ability, &.immediate-embed.ability {
     h5 {
       margin: 0;
       font-size: var(--font-h5-size);

--- a/src/styles/system/applications/sheets/journal-entry-sheet.css
+++ b/src/styles/system/applications/sheets/journal-entry-sheet.css
@@ -415,9 +415,7 @@ aside[role="tooltip"] section.content {
   }
 
   .ability-bordered {
-    &.default {
-      --ability-border: var(--ability-default-border);
-    }
+    --ability-border: var(--ability-default-border);
     &.quick {
       --ability-border: var(--ability-quick-border);
     }


### PR DESCRIPTION
- Ability embeds now directly return a `document-embed` element
- Putting `classes=inline` in the config will make the whole embed `display: inline`. I could make this more specific so it's just for scene embeds and tied to `config.inline`. The basic issue was trying to make the links to the scene flow with the text.