### PR TITLE
Conduit and Revenant corrections

### DIFF
--- a/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_2_PHc6UC7plzhbbd8e/Protection_dMRN0MF04qxJAXY9/ability_Sacred_Bond_SoSmdyoPB32dhQlz.json
+++ b/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_2_PHc6UC7plzhbbd8e/Protection_dMRN0MF04qxJAXY9/ability_Sacred_Bond_SoSmdyoPB32dhQlz.json
@@ -16,7 +16,7 @@
       "magic",
       "ranged"
     ],
-    "type": "main",
+    "type": "maneuver",
     "category": "heroic",
     "resource": 5,
     "trigger": "",

--- a/src/packs/origins/Ancestries_g8kLlrl0nzciXfRF/Revenant_jAT3sb3QtWQpc3iw/Features_uWYEH9fs5ogusKkP/ancestryTrait_Tough_But_Withered_S2OsBBFHqBoHZYUu.json
+++ b/src/packs/origins/Ancestries_g8kLlrl0nzciXfRF/Revenant_jAT3sb3QtWQpc3iw/Features_uWYEH9fs5ogusKkP/ancestryTrait_Tough_But_Withered_S2OsBBFHqBoHZYUu.json
@@ -33,7 +33,7 @@
       },
       "changes": [
         {
-          "key": "system.damage.immunities.acid",
+          "key": "system.damage.immunities.cold",
           "mode": 4,
           "value": "1",
           "priority": null
@@ -83,7 +83,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "draw-steel",
         "systemVersion": "0.8.0",
         "createdTime": 1754628983679,


### PR DESCRIPTION
Corrections:
2nd-Level Domain Ability - Sacred Bond - changed to maneuver, was listed as a main action 
Revenant ancestry trait “Tough But Withered” - the effect was adding immunity to acid and not to cold