### PR TITLE
Fixed potency glyph formatting on unowned abilities when the potency strength was a number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 ### Known Issues
 -->
 
+
+## 0.10.1
+
+### Fixed
+
+- Fixed potency glyph formatting on unowned abilities when the potency strength was a number.
+
+
 ## 0.10.0
 
 ### Added

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -198,7 +198,7 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
     const characteristic = ds.CONFIG.characteristics[tierValue.potency.characteristic]?.rollKey ?? "";
     const strength = this.actor
       ? ds.utils.evaluateFormula(tierValue.potency.value, this.item.getRollData(), { contextName: this.uuid })
-      : tierValue.potency.value.split("@potency.")[1];
+      : tierValue.potency.value.split("@potency.")[1] ?? Number(tierValue.potency.value);
 
     const potencySpan = this.constructor.constructPotencyHTML(characteristic, strength);
     return potencySpan.outerHTML;


### PR DESCRIPTION
The strength was returning `undefined` when the strength was a number on unowned abilities. This solution assumes that on an unowned ability, the value is either one of the potency roll data or a number which seems fine.