### PR TITLE
v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,15 @@
 
 ## 0.10.1
 
+### Added
+
+- Added `aside.malice` as a new style block.
+
 ### Fixed
 
+- Fixed project roll dialog failing to render. (#1653)
+- Fixed light mode style bleed into tooltips. (#1654)
 - Fixed potency glyph formatting on unowned abilities when the potency strength was a number.
-
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 ### Known Issues
 -->
 
+
+## 0.10.1
+
+### Fixed
+
+- Fixed potency glyph formatting on unowned abilities when the potency strength was a number.
+
+
 ## 0.10.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 - Added `aside.malice` as a new style block.
 
+### Changed
+
+- Added validation to rolls in message parts to ensure they are evaluated.
+
 ### Fixed
 
 - Fixed project roll dialog failing to render. (#1653)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Fixed forced movement bonuses not stacking properly. (#1652)
 - Fixed project roll dialog failing to render. (#1653)
 - Fixed light mode style bleed into tooltips. (#1654)
 - Fixed potency glyph formatting on unowned abilities when the potency strength was a number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fixed forced movement bonuses not stacking properly. (#1652)
 - Fixed project roll dialog failing to render. (#1653)
 - Fixed light mode style bleed into tooltips. (#1654)
+- Successful lookup enrichers without a fallback will provide the formula as a tooltip instead of "undefined". (#1660)
 - Fixed potency glyph formatting on unowned abilities when the potency strength was a number.
 
 ## 0.10.0

--- a/assets/ui/end.svg
+++ b/assets/ui/end.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 727.15 12">
+  <!-- Generator: Adobe Illustrator 30.1.0, SVG Export Plug-In . SVG Version: 2.1.1 Build 136)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #88764d;
+      }
+    </style>
+  </defs>
+  <path class="st0" d="M726.71,4.22v.41H-.3v-.41"/>
+</svg>

--- a/src/docs/Journal-Entry-Pages.md
+++ b/src/docs/Journal-Entry-Pages.md
@@ -121,3 +121,12 @@ The `div.ability-bordered` element and class pads the left side of the container
 ```
 
 The "class-spread" block and its descendant elements puts together a contained image with a pull quote positioned in the top left and a class intro positioned in the bottom left.
+
+```html
+<aside class="malice">
+  <div>@Embed[Compendium.draw-steel.abilities.Item.wU69Y06G9lYFrvp6]</div>
+  <div>@Embed[Compendium.draw-steel.abilities.Item.eqUobBcm81mqZVgJ]</div>
+</aside>
+```
+
+The "aside.malice" element and class provides a gray-shaded block for displaying malice abilities and features.

--- a/src/module/applications/ux/enrichers/lookup.mjs
+++ b/src/module/applications/ux/enrichers/lookup.mjs
@@ -66,7 +66,7 @@ export async function enricher(match, options) {
   if (!value && (options.documents === false)) return null;
   else if (!value) span.classList.add("not-found");
   span.innerText = value ?? parsedConfig.formula;
-  span.dataset.tooltip = (value === fallback) ? parsedConfig.formula : fallback;
+  span.dataset.tooltip = (!fallback || (value === fallback)) ? parsedConfig.formula : fallback;
   return span;
 }
 

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -250,6 +250,7 @@ export default class ProjectModel extends BaseItemModel {
       actor: this.actor,
       evaluation: "evaluate",
       data: rollData,
+      skillModifiers: this.actor?.system.hero?.skillModifiers ?? {},
     });
 
     return promptValue;

--- a/src/module/data/pseudo-documents/message-parts/base-message-part.mjs
+++ b/src/module/data/pseudo-documents/message-parts/base-message-part.mjs
@@ -41,7 +41,7 @@ export default class BaseMessagePart extends TypedPseudoDocument {
   /** @override */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      rolls: new ArrayField(new JSONField({ validate: this.#validateRoll })),
+      rolls: new ArrayField(new JSONField({ validate: BaseMessagePart.#validateRoll })),
       flavor: new StringField({ required: true }),
     });
   }

--- a/src/module/data/pseudo-documents/message-parts/base-message-part.mjs
+++ b/src/module/data/pseudo-documents/message-parts/base-message-part.mjs
@@ -41,9 +41,20 @@ export default class BaseMessagePart extends TypedPseudoDocument {
   /** @override */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      rolls: new ArrayField(new JSONField()),
+      rolls: new ArrayField(new JSONField({ validate: this.#validateRoll })),
       flavor: new StringField({ required: true }),
     });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Validate that Rolls belonging to the message part are valid.
+   * @param {string} rollJSON     The serialized Roll data.
+   */
+  static #validateRoll(rollJSON) {
+    const roll = JSON.parse(rollJSON);
+    if (!roll.evaluated) throw new Error("Roll objects added to message parts must be evaluated");
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -198,7 +198,7 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
     const characteristic = ds.CONFIG.characteristics[tierValue.potency.characteristic]?.rollKey ?? "";
     const strength = this.actor
       ? ds.utils.evaluateFormula(tierValue.potency.value, this.item.getRollData(), { contextName: this.uuid })
-      : tierValue.potency.value.split("@potency.")[1];
+      : tierValue.potency.value.split("@potency.")[1] ?? Number(tierValue.potency.value);
 
     const potencySpan = this.constructor.constructPotencyHTML(characteristic, strength);
     return potencySpan.outerHTML;

--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -41,6 +41,19 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+
+    this.bonuses = {
+      push: 0,
+      pull: 0,
+      slide: 0,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
 
@@ -116,7 +129,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
     // Group movement types by their final distance value (base + bonus)
     const distanceGroups = Map.groupBy([...tierValue.movement], movementType => {
       if (!this.actor) return baseDistance;
-      return baseDistance + (this.bonuses ? this.bonuses[movementType] ?? 0 : 0);
+      return baseDistance + this.bonuses[movementType];
     });
 
     // Format the output

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -97,6 +97,7 @@ export default class ProjectRoll extends DSRoll {
     const context = {
       modifiers: options.modifiers,
       skills: options.skills,
+      skillModifiers: options.skillModifiers,
     };
 
     const promptValue = await PowerRollDialog.create({

--- a/src/styles/system/applications/sheets/journal-entry-sheet.css
+++ b/src/styles/system/applications/sheets/journal-entry-sheet.css
@@ -152,6 +152,10 @@
   /*contents*/
   li .page-heading {}
 
+  .toc li.page {
+    border-top: none;
+  }
+
   .toc ol li ol,
   .toc ol li ol li {
     position: relative;
@@ -438,6 +442,7 @@ aside[role="tooltip"] section.content {
 
   .ability-bordered {
     --ability-border: var(--ability-default-border);
+
     &.quick {
       --ability-border: var(--ability-quick-border);
     }
@@ -623,6 +628,7 @@ aside[role="tooltip"] section.content {
 
 /* dark theme specific art*/
 .theme-dark .draw-steel.journal-sheet:not(.theme-light),
+
 .draw-steel.journal-sheet.theme-dark {
   .journal-sidebar {
     background-image: url('/systems/draw-steel/assets/ui/drawsteel-dark.png');

--- a/src/styles/system/applications/sheets/journal-entry-sheet.css
+++ b/src/styles/system/applications/sheets/journal-entry-sheet.css
@@ -352,7 +352,26 @@ aside[role="tooltip"] section.content {
     }
   }
 
+  aside.malice {
+    background: linear-gradient(rgba(128, 128, 128, 0.3), rgba(128, 128, 128, 0.05));
+    padding: 12px;
+    corner-shape: bevel;
+    border-radius: 12px;
 
+    document-embed:after {
+      content: url(/systems/draw-steel/assets/ui/continue.svg);
+      width: 100%;
+      height: auto;
+    }
+
+    document-embed:last-of-type:after {
+      content: url(/systems/draw-steel/assets/ui/continue.svg);
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  /*laser lines on captions */
   /* STANDARD HTML TABLES */
 
   caption {

--- a/src/styles/system/helpers/interaction/tooltip-manager.css
+++ b/src/styles/system/helpers/interaction/tooltip-manager.css
@@ -1,20 +1,21 @@
-#tooltip.draw-steel, aside[role="tooltip"] {
-  background: var(--draw-steel-c-white);
-  color: var(--draw-steel-c-light);
-
+#tooltip.draw-steel,
+aside[role="tooltip"] {
   header.metadata {
     display: flex;
     justify-content: space-between;
     gap: 1rem;
+
     h3.name {
       padding-top: 0.5rem;
       margin-bottom: 0;
     }
+
     aside.category {
       border: 2px inset var(--draw-steel-c-laserline);
       background-color: var(--draw-steel-c-black);
       padding: 0.25rem 0.5rem;
       margin: 0.5rem 0;
+
       h4 {
         text-align: right;
         line-height: 1rem;

--- a/src/styles/variables/colors.css
+++ b/src/styles/variables/colors.css
@@ -1,4 +1,4 @@
-:root,
+/*:root,*/
 body.system-draw-steel.theme-light,
 .draw-steel.themed.theme-light {
   --draw-steel-c-dark: #191813;
@@ -20,6 +20,7 @@ body.system-draw-steel.theme-light,
   --button-hover-background-color: var(--draw-steel-c-dark);
   --ability-default-border: url("/systems/draw-steel/assets/ui/abilityborderblack.svg");
   --ability-quick-border: url("/systems/draw-steel/assets/ui/abilityborderdark.svg");
+
 }
 
 body.system-draw-steel.theme-dark,

--- a/system.json
+++ b/system.json
@@ -169,7 +169,7 @@
       "thumbnail": "systems/draw-steel/assets/anvil-impact.png"
     }
   ],
-  "version": "0.10.0",
+  "version": "0.10.1",
   "compatibility": {
     "minimum": "13.351",
     "verified": "13"
@@ -248,7 +248,7 @@
   ],
   "socket": true,
   "manifest": "https://raw.githubusercontent.com/MetaMorphic-Digital/draw-steel/refs/heads/main/system.json",
-  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.10.0/draw-steel-release-0.10.0.zip",
+  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.10.1/draw-steel-release-0.10.1.zip",
   "background": "systems/draw-steel/assets/anvil-impact.png",
   "grid": {
     "type": 1,


### PR DESCRIPTION

### Added

- Added `aside.malice` as a new style block.

### Changed

- Added validation to rolls in message parts to ensure they are evaluated.

### Fixed

- Fixed forced movement bonuses not stacking properly. (#1652)
- Fixed project roll dialog failing to render. (#1653)
- Fixed light mode style bleed into tooltips. (#1654)
- Successful lookup enrichers without a fallback will provide the formula as a tooltip instead of "undefined". (#1660)
- Fixed potency glyph formatting on unowned abilities when the potency strength was a number.
