### PR TITLE
Implement mvp party actor

### DIFF
--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -29,6 +29,7 @@
 
 /* Sheet Imports*/
 @import url("../src/styles/system/applications/sheets/actor-sheet.css");
+@import url("../src/styles/system/applications/sheets/party.css");
 @import url("../src/styles/system/applications/sheets/combatant-group-config.css");
 @import url("../src/styles/system/applications/sheets/item-sheet.css");
 @import url("../src/styles/system/applications/sheets/journal-entry-page.css");

--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -37,6 +37,7 @@
 
 /* Sidebar Imports */
 @import url("../src/styles/system/applications/sidebar/apps/table-of-contents.css");
+@import url("../src/styles/system/applications/sidebar/tabs/actor.css");
 @import url("../src/styles/system/applications/sidebar/tabs/chat.css");
 @import url("../src/styles/system/applications/sidebar/tabs/combat.css");
 

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -158,6 +158,7 @@ Hooks.once("init", function () {
 
   // Register replacements for core UI elements
   Object.assign(CONFIG.ui, {
+    actors: applications.sidebar.tabs.DrawSteelActorDirectory,
     combat: applications.sidebar.tabs.DrawSteelCombatTracker,
     players: applications.ui.DrawSteelPlayers,
   });

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -106,6 +106,11 @@ Hooks.once("init", function () {
     makeDefault: true,
     label: "DRAW_STEEL.SHEET.Labels.Object",
   });
+  Actors.registerSheet(DS_CONST.systemID, applications.sheets.DrawSteelPartySheet, {
+    types: ["party"],
+    makeDefault: true,
+    label: "DRAW_STEEL.SHEET.Labels.Party",
+  });
   Actors.registerSheet(DS_CONST.systemID, applications.sheets.DrawSteelRetainerSheet, {
     types: ["retainer"],
     makeDefault: true,

--- a/lang/en.json
+++ b/lang/en.json
@@ -828,6 +828,9 @@
           "DialogTitle": "Update Object Metadata"
         }
       },
+      "party": {
+        "FIELDS": {}
+      },
       "retainer": {
         "FIELDS": {
           "retainer": {
@@ -2184,6 +2187,7 @@
       "hero": "Hero",
       "npc": "NPC",
       "object": "Object",
+      "party": "Party",
       "retainer": "Retainer"
     },
     "Advancement": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -304,6 +304,7 @@
         "Character": "Draw Steel Character Sheet",
         "NPC": "Draw Steel NPC Sheet",
         "Object": "Draw Steel Object Sheet",
+        "Party": "Draw Steel Party Sheet",
         "Retainer": "Draw Steel Retainer Sheet",
         "Item": "Draw Steel Item Sheet",
         "JournalEntry": "Draw Steel Journal Entry Sheet",
@@ -829,7 +830,14 @@
         }
       },
       "party": {
-        "FIELDS": {}
+        "FIELDS": {},
+        "TABS": {
+          "details": "Details",
+          "members": "Members"
+        },
+        "placeMembers": "Place Members",
+        "stamina": "Stamina",
+        "recoveries": "Recoveries"
       },
       "retainer": {
         "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2177,6 +2177,12 @@
           "hint": "Should this wall block line of effect between tokens?"
         }
       }
+    },
+    "SIDEBAR": {
+      "ACTORS": {
+        "contextMenuAssignPrimaryParty": "Assign Primary Party",
+        "contextMenuRemovePrimaryParty": "Remove Primary Party"
+      }
     }
   },
   "TYPES": {

--- a/src/module/applications/sheets/_module.mjs
+++ b/src/module/applications/sheets/_module.mjs
@@ -6,6 +6,7 @@ export { default as DrawSteelItemSheet } from "./item-sheet.mjs";
 export { default as DrawSteelJournalEntrySheet } from "./journal-entry-sheet.mjs";
 export { default as DrawSteelNPCSheet } from "./npc-sheet.mjs";
 export { default as DrawSteelObjectSheet } from "./object-sheet.mjs";
+export { default as DrawSteelPartySheet } from "./party.mjs";
 export { default as DrawSteelRetainerSheet } from "./retainer-sheet.mjs";
 export { default as DrawSteelWallConfig } from "./wall-config.mjs";
 

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -10,6 +10,9 @@ import { systemPath } from "../../constants.mjs";
  * @import { ActorSheetItemContext, ActorSheetTreasureContext, ActorSheetComplicationsContext } from "./_types.js";
  */
 
+/**
+ * An implementation of an actor sheet for Hero actors.
+ */
 export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -1,6 +1,7 @@
 import { DocumentSourceInput, MonsterMetadataInput } from "../apps/_module.mjs";
 import { systemID, systemPath } from "../../constants.mjs";
 import DrawSteelActorSheet from "./actor-sheet.mjs";
+
 /**
  * @import { FormSelectOption } from "@client/applications/forms/fields.mjs";
  */

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -2,6 +2,9 @@ import { DocumentSourceInput, ObjectMetadataInput } from "../apps/_module.mjs";
 import DrawSteelActorSheet from "./actor-sheet.mjs";
 import { systemPath } from "../../constants.mjs";
 
+/**
+ * An implementation of an actor sheet for Object actors.
+ */
 export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/src/module/applications/sheets/party.mjs
+++ b/src/module/applications/sheets/party.mjs
@@ -1,0 +1,199 @@
+import DrawSteelActorSheet from "./actor-sheet.mjs";
+import enrichHTML from "../../utils/enrich-html.mjs";
+import { systemPath } from "../../constants.mjs";
+
+/**
+ * @import DrawSteelActor from "../../documents/actor.mjs";
+ */
+
+/**
+ * An implementation of an actor sheet for Party actors.
+ */
+export default class DrawSteelPartySheet extends DrawSteelActorSheet {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      placeMembers: DrawSteelPartySheet.#placeMembers,
+      removeMember: DrawSteelPartySheet.#removeMember,
+      showMember: DrawSteelPartySheet.#showMember,
+    },
+    classes: ["party"],
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    header: {
+      template: systemPath("templates/sheets/actor/party/header.hbs"),
+    },
+    navigation: {
+      template: "templates/generic/tab-navigation.hbs",
+    },
+    members: {
+      template: systemPath("templates/sheets/actor/party/members.hbs"),
+      classes: ["tab"],
+      scrollable: [".contents"],
+    },
+    details: {
+      template: systemPath("templates/sheets/actor/party/details.hbs"),
+      classes: ["tab"],
+      scrollable: [".contents"],
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static TABS = {
+    primary: {
+      tabs: [
+        { id: "members" },
+        { id: "details" },
+      ],
+      initial: "members",
+      labelPrefix: "DRAW_STEEL.Actor.party.TABS",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * External actors who re-render this application.
+   * @type {Set<DrawSteelActor>}
+   */
+  #appActors = new Set();
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+
+    context.header = await this.#prepareHeader();
+    context.members = await this.#prepareMembers();
+    context.details = await this.#prepareDetails();
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare details context.
+   * @returns {Promise<object>}
+   */
+  async #prepareDetails() {
+    const value = this.document.system._source.description.value;
+    const enriched = await enrichHTML(value, { relativeTo: this.document });
+    return {
+      isOwner: this.document.isOwner,
+      description: { value, enriched },
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare header context.
+   * @returns {Promise<object>}
+   */
+  async #prepareHeader() {
+    const members = this.document.system.members;
+    return {
+      canPlaceMembers: game.user.isGM && canvas?.ready && members.size,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare members context.
+   * @returns {Promise<object[]>}
+   */
+  async #prepareMembers() {
+    const members = [];
+    for (const member of this.document.system.members) {
+      const ctx = { ...member };
+      const { recoveries, stamina } = member.actor.system;
+      Object.assign(ctx, {
+        recoveries, stamina,
+        rootId: [this.id, member.actor.id].join("-"),
+        canView: member.actor.testUserPermission(game.user, "OBSERVER"),
+      });
+      members.push(ctx);
+    }
+    return members;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    for (const actor of this.#appActors) delete actor.apps[this.id];
+    this.#appActors.clear();
+    for (const { actor } of this.document.system.members) {
+      actor.apps[this.id] = this;
+      this.#appActors.add(actor);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onClose(options) {
+    for (const actor of this.#appActors) delete actor.apps[this.id];
+    this.#appActors.clear();
+    return super._onClose(options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDropActor(event, actor) {
+    await this.document.system.addMembers([actor]);
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this DrawSteelPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static async #placeMembers(event, target) {
+    if (!this.document.system.members.size) return;
+    const isMaximized = this.rendered && !this.minimized;
+    if (isMaximized) await this.minimize();
+    await this.document.system.placeMembers();
+    if (isMaximized) this.maximize();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this DrawSteelPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #removeMember(event, target) {
+    const id = target.closest("[data-member-id]").dataset.memberId;
+    const actor = game.actors.get(id);
+    this.document.system.removeMembers([actor]);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this DrawSteelPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #showMember(event, target) {
+    const id = target.closest("[data-member-id]").dataset.memberId;
+    const actor = game.actors.get(id);
+    actor.sheet.render({ force: true });
+  }
+}

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -2,6 +2,9 @@ import DrawSteelActorSheet from "./actor-sheet.mjs";
 import RetainerMetadataInput from "../apps/retainer-metadata-input.mjs";
 import { systemPath } from "../../constants.mjs";
 
+/**
+ * An implementation of an actor sheet for Retainer actors.
+ */
 export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/src/module/applications/sidebar/tabs/_module.mjs
+++ b/src/module/applications/sidebar/tabs/_module.mjs
@@ -1,1 +1,2 @@
+export { default as DrawSteelActorDirectory } from "./actors.mjs";
 export { default as DrawSteelCombatTracker } from "./combat-tracker.mjs";

--- a/src/module/applications/sidebar/tabs/actors.mjs
+++ b/src/module/applications/sidebar/tabs/actors.mjs
@@ -1,0 +1,59 @@
+export default class DrawSteelActorDirectory extends foundry.applications.sidebar.tabs.ActorDirectory {
+  /** @inheritdoc */
+  _getEntryContextOptions() {
+    const getActor = li => game.actors.get(li.dataset.entryId);
+
+    const isV14 = game.release.generation >= 14;
+
+    const options = [{
+      name: "DRAW_STEEL.SIDEBAR.ACTORS.contextMenuAssignPrimaryParty",
+      icon: "fa-solid fa-fw fa-medal",
+      condition: (li) => {
+        const actor = getActor(li);
+        return game.user.isGM && (actor.type === "party") && (actor !== game.actors.party);
+      },
+      visible: target => {
+        const actor = getActor(target);
+        return game.user.isGM && (actor.type === "party") && (actor !== game.actors.party);
+      },
+      callback: (li) => game.actors.setParty(getActor(li)),
+      onClick: (event, target) => game.actors.setParty(getActor(target)),
+      group: "system",
+    }, {
+      name: "DRAW_STEEL.SIDEBAR.ACTORS.contextMenuRemovePrimaryParty",
+      icon: "fa-solid fa-fw fa-times",
+      condition: (li) => game.user.isGM && (getActor(li) === game.actors.party),
+      visible: target => game.user.isGM && (getActor(target) === game.actors.party),
+      callback: (li) => game.actors.unsetParty(),
+      onClick: (event, target) => game.actors.unsetParty(),
+      group: "system",
+    }];
+
+    options.forEach(option => {
+      if (isV14) {
+        delete option.condition;
+        delete option.callback;
+        option.label = option.name;
+        delete option.name;
+      } else {
+        delete option.visible;
+        delete option.onClick;
+        option.icon = `<i class="${option.icon}"></i>`;
+      }
+    });
+
+    return super._getEntryContextOptions().concat(options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+
+    const party = game.actors.party;
+    if (!party) return;
+    const element = this.element.querySelector(`[data-entry-id="${party.id}"]`);
+    if (element) element.classList.add("primary-party");
+  }
+}

--- a/src/module/canvas/layers/tokens.mjs
+++ b/src/module/canvas/layers/tokens.mjs
@@ -19,7 +19,7 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
    * @param {ActorData} [options.actorUpdates]  Additional token data to merge into the placed token.
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
    */
-  async performTokenPlacement(actor, options = {}) {
+  async placeToken(actor, options = {}) {
     // Ensure the user has permission to drop the actor and create a Token.
     if (!game.user.can("TOKEN_CREATE")) {
       ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.TOKEN_CREATE", { localize: true });
@@ -41,6 +41,8 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
 
     return createdTokens;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Fetch token data, making appropriate adjustments to token and actor data.
@@ -64,13 +66,11 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
     if (tokenDocument.actorLink) {
       const { effects, items, ...rest } = actorUpdates;
       await tokenDocument.actor.update(rest);
-      await tokenDocument.actor.updateEmbeddedDocuments("Item", items);
+      await tokenDocument.actor.updateEmbeddedDocuments("Item", items ?? []);
 
-      const { newEffects, oldEffects } = effects.reduce((acc, curr) => {
-        const target = tokenDocument.actor.effects.get(curr._id) ? "oldEffects" : "newEffects";
-        acc[target].push(curr);
-        return acc;
-      }, { newEffects: [], oldEffects: [] });
+      const { newEffects = [], oldEffects = [] } = Object.groupBy(effects ?? [], effect => {
+        return tokenDocument.actor.effects.get(effect._id) ? "oldEffects" : "newEffects";
+      });
 
       await tokenDocument.actor.updateEmbeddedDocuments("ActiveEffect", oldEffects);
       await tokenDocument.actor.createEmbeddedDocuments("ActiveEffect", newEffects, { keepId: true });
@@ -80,5 +80,27 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
     }
 
     return tokenDocument.toObject();
+  }
+
+  /* -------------------------------------------------- */
+  /*   Deprecations                                     */
+  /* -------------------------------------------------- */
+
+  /**
+   * Helper function to place a token on the canvas given an actor.
+   * @param {DrawSteelActor} actor              The actor to place one or more copies of.
+   * @param {object} [options]
+   * @param {number} [options.count]            Actor instances to place (default: 1).
+   * @param {TokenData} [options.tokenUpdates]  Additional token data to merge into the placed token.
+   * @param {ActorData} [options.actorUpdates]  Additional token data to merge into the placed token.
+   * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
+   * @deprecated
+   */
+  async performTokenPlacement(actor, options = {}) {
+    foundry.utils.logCompatibilityWarning(
+      "DRAW STEEL | The `canvas.tokens.performTokenPlacement` method has been deprecated in favor of `canvas.tokens.placeToken`.",
+      { once: true, since: "0.11.0", until: "1.0.0" },
+    );
+    return this.placeToken(actor, options);
   }
 }

--- a/src/module/canvas/layers/tokens.mjs
+++ b/src/module/canvas/layers/tokens.mjs
@@ -19,7 +19,7 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
    * @param {ActorData} [options.actorUpdates]  Additional token data to merge into the placed token.
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
    */
-  async placeToken(actor, options = {}) {
+  async performTokenPlacement(actor, options = {}) {
     // Ensure the user has permission to drop the actor and create a Token.
     if (!game.user.can("TOKEN_CREATE")) {
       ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.TOKEN_CREATE", { localize: true });
@@ -80,27 +80,5 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
     }
 
     return tokenDocument.toObject();
-  }
-
-  /* -------------------------------------------------- */
-  /*   Deprecations                                     */
-  /* -------------------------------------------------- */
-
-  /**
-   * Helper function to place a token on the canvas given an actor.
-   * @param {DrawSteelActor} actor              The actor to place one or more copies of.
-   * @param {object} [options]
-   * @param {number} [options.count]            Actor instances to place (default: 1).
-   * @param {TokenData} [options.tokenUpdates]  Additional token data to merge into the placed token.
-   * @param {ActorData} [options.actorUpdates]  Additional token data to merge into the placed token.
-   * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
-   * @deprecated
-   */
-  async performTokenPlacement(actor, options = {}) {
-    foundry.utils.logCompatibilityWarning(
-      "DRAW STEEL | The `canvas.tokens.performTokenPlacement` method has been deprecated in favor of `canvas.tokens.placeToken`.",
-      { once: true, since: "0.11.0", until: "1.0.0" },
-    );
-    return this.placeToken(actor, options);
   }
 }

--- a/src/module/canvas/placeables/tokens/token-placement.mjs
+++ b/src/module/canvas/placeables/tokens/token-placement.mjs
@@ -259,4 +259,20 @@ export default class TokenPlacement {
     if (tokenDocument instanceof foundry.documents.TokenDocument) tokenDocument.updateSource({ name });
     else tokenDocument.name = name;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Place tokens on the current scene from placement data.
+   * @param {TokenPlacementData[]} placements
+   * @returns {Promise<TokenDocument[]>}
+   */
+  static createTokens(placements) {
+    const data = placements.map(placement => {
+      const { x, y, rotation, prototypeToken } = placement;
+      const actorId = prototypeToken.actor.id;
+      return foundry.utils.mergeObject(prototypeToken.toObject(), { x, y, rotation, actorId });
+    });
+    return canvas.scene.createEmbeddedDocuments("Token", data);
+  }
 }

--- a/src/module/data/actor/_module.mjs
+++ b/src/module/data/actor/_module.mjs
@@ -3,4 +3,5 @@ export { default as CreatureModel } from "./creature.mjs";
 export { default as HeroModel } from "./hero.mjs";
 export { default as NPCModel } from "./npc.mjs";
 export { default as ObjectModel } from "./object.mjs";
+export { default as PartyModel } from "./party.mjs";
 export { default as RetainerModel } from "./retainer.mjs";

--- a/src/module/data/actor/party.mjs
+++ b/src/module/data/actor/party.mjs
@@ -1,0 +1,133 @@
+/**
+ * @import DrawSteelActor from "../../documents/actor.mjs";
+ * @import DrawSteelTokenDocument from "../../documents/token.mjs";
+ */
+
+const { HTMLField, SchemaField, TypedObjectField } = foundry.data.fields;
+
+export default class PartyModel extends foundry.abstract.TypeDataModel {
+  /** @type {*} */
+  static get metadata() {
+    return {
+      type: "party",
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      description: new SchemaField({
+        value: new HTMLField(),
+      }),
+      members: new TypedObjectField(
+        new SchemaField({}),
+        { validateKey: key => foundry.data.validators.isValidId(key) },
+      ),
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat([
+    "DRAW_STEEL.Actor.party",
+  ]);
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+
+    const update = {};
+    if (!foundry.utils.hasProperty(data, "prototypeToken.actorLink"))
+      foundry.utils.setProperty(update, "prototypeToken.actorLink", true);
+
+    if (!foundry.utils.hasProperty(data, "prototypeToken.sight.enabled"))
+      foundry.utils.setProperty(update, "prototypeToken.sight.enabled", false);
+
+    if (!foundry.utils.hasProperty(data, "prototypeToken.disposition"))
+      foundry.utils.setProperty(update, "prototypeToken.disposition", CONST.TOKEN_DISPOSITIONS.FRIENDLY);
+
+    if (!foundry.utils.isEmpty(update)) this.parent.updateSource(update);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+
+    Object.defineProperty(this, "members", {
+      enumerable: true,
+      get() {
+        return Object.entries(this._source.members).reduce((acc, [id, data]) => {
+          const actor = game.actors.get(id);
+          if (this.validMember(actor)) acc.set(actor.id, { ...data, actor });
+          return acc;
+        }, new foundry.utils.Collection());
+      },
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Is a given actor valid to be a member of this party?
+   * @param {DrawSteelActor} actor
+   * @returns {boolean}
+   */
+  validMember(actor) {
+    return (actor instanceof foundry.documents.Actor) && ["hero"].includes(actor.type)
+      && !actor.inCompendium && !actor.isToken;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Add members to the party.
+   * @param {DrawSteelActor[]} [actors]    The actors to add.
+   * @returns {Promise<DrawSteelActor>}    A promise that resolves to the updated party actor.
+   */
+  async addMembers(actors = []) {
+    actors = new Set(actors.filter(this.validMember)).filter(actor => !this.members.has(actor.id));
+    const ids = [...this.members.keys(), ...actors.map(a => a.id)];
+    const update = Object.entries(this.toObject().members).reduce((acc, [id, src]) => {
+      if (ids.includes(id)) acc[id] = src;
+      return acc;
+    }, {});
+    ids.forEach(id => update[id] = {});
+    await this.parent.update({ "system.==members": update });
+    return this.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Remove members from the party.
+   * @param {DrawSteelActor[]} [actors]    The actors to remove.
+   * @returns {Promise<DrawSteelActor>}    A promise that resolves to the updated party actor.
+   */
+  async removeMembers(actors = []) {
+    const update = {};
+    actors.forEach(actor => {
+      if (this.validMember(actor) && this.members.has(actor.id)) update[`-=${actor.id}`] = null;
+    });
+    await this.parent.update({ "system.members": update });
+    return this.parent;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Place down the members of this party.
+   * @returns {Promise<DrawSteelTokenDocument[]>}    A promise that resolves to the created tokens.
+   */
+  async placeMembers() {
+    const config = { tokens: this.members.map(m => m.actor.prototypeToken) };
+    const data = await ds.canvas.placeables.tokens.TokenPlacement.place(config);
+    return ds.canvas.placeables.tokens.TokenPlacement.createTokens(data);
+  }
+}

--- a/src/module/data/actor/party.mjs
+++ b/src/module/data/actor/party.mjs
@@ -1,3 +1,5 @@
+import DrawSteelSystemModel from "../system-model.mjs";
+
 /**
  * @import DrawSteelActor from "../../documents/actor.mjs";
  * @import DrawSteelTokenDocument from "../../documents/token.mjs";
@@ -5,13 +7,21 @@
 
 const { HTMLField, SchemaField, TypedObjectField } = foundry.data.fields;
 
-export default class PartyModel extends foundry.abstract.TypeDataModel {
-  /** @type {*} */
+export default class PartyModel extends DrawSteelSystemModel {
+  /** @inheritdoc */
   static get metadata() {
-    return {
+    return foundry.utils.mergeObject(super.metadata, {
       type: "party",
-    };
+    });
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The Actor subtypes allowed as members of a party.
+   * @type {Set<string>}
+   */
+  static ALLOWED_ACTOR_TYPES = new Set(["hero"]);
 
   /* -------------------------------------------------- */
 
@@ -41,15 +51,15 @@ export default class PartyModel extends foundry.abstract.TypeDataModel {
   async _preCreate(data, options, user) {
     if ((await super._preCreate(data, options, user)) === false) return false;
 
-    const update = {};
-    if (!foundry.utils.hasProperty(data, "prototypeToken.actorLink"))
-      foundry.utils.setProperty(update, "prototypeToken.actorLink", true);
-
-    if (!foundry.utils.hasProperty(data, "prototypeToken.sight.enabled"))
-      foundry.utils.setProperty(update, "prototypeToken.sight.enabled", false);
-
-    if (!foundry.utils.hasProperty(data, "prototypeToken.disposition"))
-      foundry.utils.setProperty(update, "prototypeToken.disposition", CONST.TOKEN_DISPOSITIONS.FRIENDLY);
+    const update = foundry.utils.mergeObject({
+      prototypeToken: {
+        actorLink: true,
+        disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+        sight: {
+          enabled: false,
+        },
+      },
+    }, data, { insertKeys: false, insertValues: false });
 
     if (!foundry.utils.isEmpty(update)) this.parent.updateSource(update);
   }
@@ -80,7 +90,7 @@ export default class PartyModel extends foundry.abstract.TypeDataModel {
    * @returns {boolean}
    */
   validMember(actor) {
-    return (actor instanceof foundry.documents.Actor) && ["hero"].includes(actor.type)
+    return (actor instanceof foundry.documents.Actor) && this.constructor.ALLOWED_ACTOR_TYPES.has(actor.type)
       && !actor.inCompendium && !actor.isToken;
   }
 
@@ -112,8 +122,9 @@ export default class PartyModel extends foundry.abstract.TypeDataModel {
    */
   async removeMembers(actors = []) {
     const update = {};
+    const members = this.members;
     actors.forEach(actor => {
-      if (this.validMember(actor) && this.members.has(actor.id)) update[`-=${actor.id}`] = null;
+      if (members.has(actor.id)) update[`-=${actor.id}`] = null;
     });
     await this.parent.update({ "system.members": update });
     return this.parent;

--- a/src/module/data/actor/party.mjs
+++ b/src/module/data/actor/party.mjs
@@ -90,7 +90,7 @@ export default class PartyModel extends DrawSteelSystemModel {
    * @returns {boolean}
    */
   validMember(actor) {
-    return (actor instanceof foundry.documents.Actor) && this.constructor.ALLOWED_ACTOR_TYPES.has(actor.type)
+    return (actor instanceof foundry.documents.Actor) && PartyModel.ALLOWED_ACTOR_TYPES.has(actor.type)
       && !actor.inCompendium && !actor.isToken;
   }
 

--- a/src/module/data/effect/ability-modifier.mjs
+++ b/src/module/data/effect/ability-modifier.mjs
@@ -11,10 +11,10 @@ import { setOptions } from "../helpers.mjs";
 export default class AbilityModifier extends BaseEffectModel {
   /** @inheritdoc */
   static get metadata() {
-    return {
+    return foundry.utils.mergeObject(super.metadata, {
       type: "abilityModifier",
       icon: "fa-solid fa-hand-sparkles",
-    };
+    });
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/effect/base.mjs
+++ b/src/module/data/effect/base.mjs
@@ -15,6 +15,8 @@ export default class BaseEffectModel extends foundry.abstract.TypeDataModel {
     return {
       type: "base",
       icon: "fa-solid fa-person-rays",
+      invalidActorTypes: ["party"],
+      invalidItemTypes: [],
     };
   }
 
@@ -61,6 +63,18 @@ export default class BaseEffectModel extends foundry.abstract.TypeDataModel {
 
   /* -------------------------------------------------- */
 
+  /**
+   * Is this effect suppressed due to some system-specific behavior?
+   * @type {boolean}
+   */
+  get isSuppressed() {
+    const target = this.parent.target ?? {};
+    const invalidTypes = this.constructor.metadata[`invalid${target.documentName}Types`] ?? [];
+    return invalidTypes.includes(target.type);
+  }
+
+  /* -------------------------------------------------- */
+
   /** @import { ActiveEffectDuration, EffectDurationData } from "./_types" */
 
   /**
@@ -76,6 +90,17 @@ export default class BaseEffectModel extends foundry.abstract.TypeDataModel {
       remaining: null,
       label: this.durationLabel,
     };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preCreate(data, options, user) {
+    if ((await super._preCreate(data, options, user)) === false) return false;
+
+    const target = this.parent.parent ?? {};
+    const invalidTypes = this.constructor.metadata[`invalid${target.documentName}Types`] ?? [];
+    if (invalidTypes.includes(target.type)) return false;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/item/ancestry.mjs
+++ b/src/module/data/item/ancestry.mjs
@@ -9,7 +9,7 @@ export default class AncestryModel extends AdvancementModel {
     return {
       ...super.metadata,
       type: "ancestry",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
     };
   }
 

--- a/src/module/data/item/ancestryTrait.mjs
+++ b/src/module/data/item/ancestryTrait.mjs
@@ -10,7 +10,7 @@ export default class AncestryTraitModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "ancestryTrait",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       packOnly: true,
       detailsPartial: [systemPath("templates/sheets/item/partials/ancestryTrait.hbs")],
     };

--- a/src/module/data/item/career.mjs
+++ b/src/module/data/item/career.mjs
@@ -14,7 +14,7 @@ export default class CareerModel extends AdvancementModel {
     return {
       ...super.metadata,
       type: "career",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/career.hbs")],
     };
   }

--- a/src/module/data/item/class.mjs
+++ b/src/module/data/item/class.mjs
@@ -12,7 +12,7 @@ export default class ClassModel extends AdvancementModel {
     return {
       ...super.metadata,
       type: "class",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/class.hbs")],
     };
   }

--- a/src/module/data/item/complication.mjs
+++ b/src/module/data/item/complication.mjs
@@ -9,7 +9,7 @@ export default class ComplicationModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "complication",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: null,
     };
   }

--- a/src/module/data/item/culture.mjs
+++ b/src/module/data/item/culture.mjs
@@ -10,7 +10,7 @@ export default class CultureModel extends AdvancementModel {
       ...super.metadata,
       type: "culture",
       packOnly: false,
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
     };
   }
 

--- a/src/module/data/item/kit.mjs
+++ b/src/module/data/item/kit.mjs
@@ -16,7 +16,7 @@ export default class KitModel extends AdvancementModel {
     return {
       ...super.metadata,
       type: "kit",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/kit.hbs")],
     };
   }

--- a/src/module/data/item/perk.mjs
+++ b/src/module/data/item/perk.mjs
@@ -10,7 +10,7 @@ export default class PerkModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "perk",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/perk.hbs")],
     };
   }

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -22,7 +22,7 @@ export default class ProjectModel extends BaseItemModel {
     return {
       ...super.metadata,
       type: "project",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/project.hbs")],
     };
   }

--- a/src/module/data/item/subclass.mjs
+++ b/src/module/data/item/subclass.mjs
@@ -11,7 +11,7 @@ export default class SubclassModel extends AdvancementModel {
     return {
       ...super.metadata,
       type: "subclass",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/subclass.hbs")],
     };
   }

--- a/src/module/data/item/title.mjs
+++ b/src/module/data/item/title.mjs
@@ -16,7 +16,7 @@ export default class TitleModel extends FeatureModel {
     return {
       ...super.metadata,
       type: "title",
-      invalidActorTypes: ["npc", "object"],
+      invalidActorTypes: ["npc", "object", "party"],
       detailsPartial: [systemPath("templates/sheets/item/partials/title.hbs")],
     };
   }

--- a/src/module/data/settings/_module.mjs
+++ b/src/module/data/settings/_module.mjs
@@ -1,2 +1,3 @@
 export { HeroTokenModel } from "./hero-tokens.mjs";
 export { MaliceModel } from "./malice.mjs";
+export { default as PrimaryPartyModel } from "./primary-party.mjs";

--- a/src/module/data/settings/primary-party.mjs
+++ b/src/module/data/settings/primary-party.mjs
@@ -1,0 +1,12 @@
+export default class PrimaryPartyModel extends foundry.abstract.DataModel {
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      actor: new foundry.data.fields.ForeignDocumentField(foundry.documents.Actor, {
+        blank: true,
+        validate: id => !game.actors || (game.actors.get(id)?.type === "party"),
+        validationError: "This is not a valid id for a Party-type actor.",
+      }),
+    };
+  }
+}

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -1,5 +1,6 @@
 import BaseDocumentMixin from "./base-document-mixin.mjs";
 import DrawSteelActiveEffect from "./active-effect.mjs";
+import DrawSteelPartySheet from "../applications/sheets/party.mjs";
 
 /** @import ClassModel from "../data/item/class.mjs" */
 
@@ -54,6 +55,20 @@ export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.
     }
 
     Hooks.callAll("ds.prepareActorData", this);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDelete(options, userId) {
+    // Remove party sheets and re-render them.
+    Object.values(this.apps).forEach(app => {
+      if (!(app instanceof DrawSteelPartySheet)) return;
+      delete this.apps[app.id];
+      if (app.rendered) app.render();
+    });
+
+    super._onDelete(options, userId);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/collections/actors.mjs
+++ b/src/module/documents/collections/actors.mjs
@@ -1,6 +1,9 @@
 import { systemID } from "../../constants.mjs";
 
-/** @import { HeroTokenModel, MaliceModel } from "../../data/settings/_module.mjs" */
+/**
+ * @import { HeroTokenModel, MaliceModel } from "../../data/settings/_module.mjs";
+ * @import DrawSteelActor from "../actor.mjs";
+ */
 
 /**
  * An extension of the core Actors collection with extra convenience functions.
@@ -22,5 +25,50 @@ export default class DrawSteelActors extends foundry.documents.collections.Actor
    */
   get malice() {
     return game.settings.get(systemID, "malice");
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The primary party.
+   * @type {DrawSteelActor}
+   */
+  get party() {
+    return game.settings.get(systemID, "primaryParty")?.actor ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Unset the primary party.
+   * @returns {Promise<boolean>}    A promise that resolves to whether the modification was successful.
+   */
+  async unsetParty() {
+    if (!game.user.isGM) {
+      throw new Error("Only a GM can unassign the primary party!");
+    }
+
+    if (!this.party) return false;
+    await game.settings.set(systemID, "primaryParty", { actor: null });
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Set the primary party.
+   * @param {DrawSteelActor} actor    The actor to assign as the primary party.
+   * @returns {Promise<boolean>}      A promise that resolves to whether the modification was successful.
+   */
+  async setParty(actor) {
+    if (!game.user.isGM) {
+      throw new Error("Only a GM can assign the primary party!");
+    }
+
+    if (!actor || (actor.type !== "party")) return false;
+    if (actor === this.party) return false;
+
+    await game.settings.set(systemID, "primaryParty", { actor: actor.id });
+    return true;
   }
 }

--- a/src/module/helpers/settings.mjs
+++ b/src/module/helpers/settings.mjs
@@ -1,4 +1,4 @@
-import { HeroTokenModel, MaliceModel } from "../data/settings/_module.mjs";
+import { HeroTokenModel, MaliceModel, PrimaryPartyModel } from "../data/settings/_module.mjs";
 import DrawSteelHeroSheet from "../applications/sheets/hero-sheet.mjs";
 import { systemID } from "../constants.mjs";
 
@@ -51,6 +51,13 @@ export default class DrawSteelSettingsHandler {
         scope: "world",
         default: { value: 0 },
         onChange: MaliceModel.onChange,
+      },
+      primaryParty: {
+        type: PrimaryPartyModel,
+        scope: "world",
+        default: null,
+        config: false,
+        onChange: () => ui.actors.render(),
       },
       showPlayerMalice: {
         name: "DRAW_STEEL.Setting.ShowPlayerMalice.Label",

--- a/src/styles/system/applications/sheets/party.css
+++ b/src/styles/system/applications/sheets/party.css
@@ -1,0 +1,133 @@
+.draw-steel.application.sheet.actor.party {
+  --min-height: 300px;
+  --min-width: 600px;
+  --members-width: 250px;
+
+  &:not(.minimizing, .maximizing, .minimized) {
+    min-height: var(--min-height);
+    min-width: var(--min-width);
+  }
+
+  .window-content {
+    container-type: inline-size;
+  }
+
+  [data-application-part=header] {
+    display: grid;
+    grid-template-columns: min(30%, 15rem) min(25%, 10rem) min(30%, 15rem);
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+
+    @container (width < 800px) {
+      grid: "left avatar" "right avatar" / 15rem 10rem;
+
+      .left-controls { grid-area: left }
+      .right-controls { grid-area: right }
+      .middle-controls { grid-area: avatar }
+    }
+
+    .left-controls {
+      .title {
+        margin: 0;
+        margin-bottom: .5rem;
+        font-size: 30px;
+      }
+    }
+  }
+
+  [data-application-part=navigation] {
+    margin: 1rem 0;
+  }
+
+  [data-application-part=members] {
+    overflow: hidden;
+
+    .contents {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      gap: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+      align-content: start;
+      height: 100%;
+    }
+
+    .member {
+      display: grid;
+      grid-template-columns: 100px 1fr;
+      gap: .5rem;
+      padding: .5rem;
+      position: relative;
+      border-radius: .5rem;
+      background: rgb(58 55 55 / 0.336);
+
+      .avatar {
+        img {
+          width: 100%;
+          aspect-ratio: 1;
+          overflow: hidden;
+          object-position: top center;
+          object-fit: cover;
+        }
+      }
+
+      .details {
+        margin: 0 1.5rem 0 1rem;
+        overflow: hidden;
+
+        .title {
+          display: block;
+          font-size: 18px;
+          text-wrap: nowrap;
+          overflow: hidden visible;
+          text-overflow: ellipsis;
+          margin-bottom: .5rem;
+        }
+
+        .resources {
+          display: grid;
+        }
+      }
+
+      .controls {
+        position: absolute;
+        inset: 0 0 auto auto;
+        display: flex;
+        flex-direction: row-reverse;
+        text-align: center;
+
+        .control {
+          margin: .5rem;
+
+          .fa-solid {
+            margin: 0;
+          }
+        }
+      }
+    }
+  }
+
+  [data-application-part=details] {
+    overflow: hidden;
+    height: 100%;
+
+    .contents {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      gap: 1rem;
+      display: grid;
+      grid-template-rows: 0fr 1fr;
+      height: 100%;
+    }
+
+    .inputs {
+      display: grid;
+      gap: .5rem;
+    }
+
+    prose-mirror {
+      height: 100%;
+    }
+  }
+}

--- a/src/styles/system/applications/sidebar/tabs/actor.css
+++ b/src/styles/system/applications/sidebar/tabs/actor.css
@@ -1,0 +1,3 @@
+.directory-list .primary-party {
+  box-shadow: 0 0 1rem 0.2rem var(--draw-steel-c-primary-party) inset;
+}

--- a/src/styles/variables/colors.css
+++ b/src/styles/variables/colors.css
@@ -1,6 +1,5 @@
 /*:root,*/
-body.system-draw-steel.theme-light,
-.draw-steel.themed.theme-light {
+@scope (.theme-light) to (.themed) {
   --draw-steel-c-dark: #191813;
   --draw-steel-c-faint: #cdcdcd;
   --draw-steel-c-beige: #eeede0;
@@ -20,11 +19,10 @@ body.system-draw-steel.theme-light,
   --button-hover-background-color: var(--draw-steel-c-dark);
   --ability-default-border: url("/systems/draw-steel/assets/ui/abilityborderblack.svg");
   --ability-quick-border: url("/systems/draw-steel/assets/ui/abilityborderdark.svg");
-
+  --draw-steel-c-primary-party: #9F9175;
 }
 
-body.system-draw-steel.theme-dark,
-.draw-steel.themed.theme-dark {
+@scope (.theme-dark) to (.themed) {
   --draw-steel-c-dark: #c9c7b8;
   --draw-steel-c-faint: #191813;
   --draw-steel-c-beige: #444444;
@@ -42,22 +40,5 @@ body.system-draw-steel.theme-dark,
   --button-hover-background-color: var(--draw-steel-c-laserline);
   --ability-default-border: url("/systems/draw-steel/assets/ui/abilityborderwhite.svg");
   --ability-quick-border: url("/systems/draw-steel/assets/ui/abilityborderlight.svg");
-}
-
-/*inverse options*/
-body.system-draw-steel.theme-light .draw-steel.themed.theme-dark {
-  --draw-steel-c-dark: #c9c7b8;
-  --draw-steel-c-faint: #191813;
-  --draw-steel-c-beige: #444444;
-  --draw-steel-c-tan: #b5b3a4;
-  --draw-steel-c-white: #000000;
-  --draw-steel-c-black: whitesmoke;
-  --draw-steel-c-groove: #11121f;
-  --draw-steel-c-item-header-bg: #28232f;
-  --draw-steel-c-item-alternating-bg: rgba(255, 255, 255, .05);
-  --draw-steel-c-color-shadow: #ccccccaa;
-  --draw-steel-c-laserline: #856C4B;
-  --color-shadow-primary: #ccccccaa;
-  --button-focus-outline-color: var(--draw-steel-c-laserline);
-  --button-hover-background-color: var(--draw-steel-c-laserline);
+  --draw-steel-c-primary-party: #b9578c;
 }

--- a/system.json
+++ b/system.json
@@ -30,6 +30,9 @@
         "htmlFields": ["biography.value", "biography.director"],
         "gmOnlyFields": ["biography.director"]
       },
+      "party": {
+        "htmlFields": ["description.value"]
+      },
       "retainer": {
         "htmlFields": ["biography.value", "biography.director"],
         "gmOnlyFields": ["biography.director"]

--- a/templates/sheets/actor/party/details.hbs
+++ b/templates/sheets/actor/party/details.hbs
@@ -1,0 +1,18 @@
+<section data-tab="{{tabs.details.id}}" data-group="{{tabs.details.group}}" class="{{tabs.details.cssClass}}">
+  <div class="contents">
+    <section class="inputs {{#if (or (not details.isOwner) disabled)}} hidden {{/if}}">
+      {{#if (and details.isOwner isPlay)}}
+      {{formGroup fields.name value=source.name rootId=rootId}}
+      {{formGroup fields.img value=source.img rootId=rootId}}
+      {{/if}}
+    </section>
+
+    <section class="description">
+      {{#if isPlay}}
+      {{formInput systemFields.description.fields.value value=details.description.value}}
+      {{else}}
+      {{{details.description.enriched}}}
+      {{/if}}
+    </section>
+  </div>
+</section>

--- a/templates/sheets/actor/party/header.hbs
+++ b/templates/sheets/actor/party/header.hbs
@@ -1,0 +1,15 @@
+<section>
+  <section class="left-controls">
+    <h3 class="title">{{document.name}}</h3>
+    <a data-action="placeMembers" {{disabled (not header.canPlaceMembers)}}>
+      <i class="fa-solid fa-fw fa-bullseye" inert></i>
+      <span>{{localize "DRAW_STEEL.Actor.party.placeMembers"}}</span>
+    </a>
+  </section>
+
+  <section class="middle-controls">
+    <img src="{{document.img}}" alt="{{document.name}}">
+  </section>
+
+  <section class="right-controls"></section>
+</section>

--- a/templates/sheets/actor/party/members.hbs
+++ b/templates/sheets/actor/party/members.hbs
@@ -1,0 +1,31 @@
+<section data-tab="{{tabs.members.id}}" data-group="{{tabs.members.group}}" class="{{tabs.members.cssClass}}">
+  <div class="contents">
+    {{#each members}}
+    <section class="member" data-member-id="{{actor.id}}">
+      <section class="avatar">
+        <img src="{{actor.img}}" alt="{{actor.name}}">
+      </section>
+      <section class="details">
+        <span class="title">{{actor.name}}</span>
+
+        <section class="resources">
+          <span>{{localize "DRAW_STEEL.Actor.party.stamina"}}: {{stamina.value}} / {{stamina.max}}</span>
+          <span>{{localize "DRAW_STEEL.Actor.party.recoveries"}}: {{recoveries.value}} / {{recoveries.max}}</span>
+        </section>
+      </section>
+      <section class="controls">
+        {{#if @root.isPlay}}
+        <a class="control" data-action="removeMember">
+          <i class="fa-solid fa-fw fa-trash" inert></i>
+        </a>
+        {{/if}}
+        {{#if (and (not @root.isPlay) canView)}}
+        <a class="control" data-action="showMember">
+          <i class="fa-solid fa-fw fa-magnifying-glass" inert></i>
+        </a>
+        {{/if}}
+      </section>
+    </section>
+    {{/each}}
+  </div>
+</section>


### PR DESCRIPTION
- Adds `party` actor.
- ~~Deprecates `canvas.tokens.performTokenPlacement` in favor of `canvas.tokens.placeToken` to be in line with `canvas.regions.placeRegion`.~~
- Fixed issues with `canvas.tokens.#getTokenData` which threw errors when items or effect were empty.

### Notes

- I wasn't really able to find a good spot for using `canvas.tokens.#getTokenData` and don't think it's relevant for this anyhow. We are also not using it anywhere in the system at present.
- This is a proof of concept for now while we discuss whether we want to add it to 0.11.

### TODO
- [x] Implement basic party sheet.
- [x] Extend the Actor sidebar and implement `game.actors.party` as an easy access getter.
- [x] Add setting to assign "primary party" with context menu options in the sidebar.
- [x] Disallow creating (any?) items and effects on the party actor.

To test:

Create party actor and hero actor.

```js
const party = await Actor.implementation.create({ type: "party", name: "Party" });
const hero = await Actor.implementation.create({ type: "hero", name: "Hero" });
await party.system.addMembers([hero]);
await party.system.placeMembers();
```