### PR TITLE
[#1446] Implement `toMessage` to leverage message parts

### DIFF
--- a/src/module/rolls/base.mjs
+++ b/src/module/rolls/base.mjs
@@ -7,7 +7,7 @@ export default class DSRoll extends foundry.dice.Roll {
    * The type used for the `part` of a standard message.
    * @type {string}
    */
-  static PART_TYPE = "";
+  static PART_TYPE = "roll";
 
   /* -------------------------------------------------- */
 
@@ -20,6 +20,7 @@ export default class DSRoll extends foundry.dice.Roll {
 
     if (!this._evaluated) await this.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
 
+    const id = foundry.utils.randomID();
     messageData = foundry.utils.mergeObject({
       type: "standard",
       system: {},
@@ -27,7 +28,8 @@ export default class DSRoll extends foundry.dice.Roll {
       sound: CONFIG.sounds.dice,
     }, messageData);
     messageData.system.parts = {
-      [foundry.utils.randomID()]: {
+      [id]: {
+        _id: id,
         flavor: messageData.flavor,
         rolls: [this],
         type: this.constructor.PART_TYPE,

--- a/src/module/rolls/base.mjs
+++ b/src/module/rolls/base.mjs
@@ -36,7 +36,6 @@ export default class DSRoll extends foundry.dice.Roll {
       },
     };
     delete messageData.flavor;
-    delete messageData.rolls;
 
     const Cls = getDocumentClass("ChatMessage");
     const msg = new Cls(messageData);

--- a/src/module/rolls/base.mjs
+++ b/src/module/rolls/base.mjs
@@ -2,4 +2,45 @@
 /**
  * Base roll class for Draw Steel.
  */
-export default class DSRoll extends foundry.dice.Roll { }
+export default class DSRoll extends foundry.dice.Roll {
+  /**
+   * The type used for the `part` of a standard message.
+   * @type {string}
+   */
+  static PART_TYPE = "";
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async toMessage(messageData = {}, { rollMode, create = true } = {}) {
+    if (!this.constructor.PART_TYPE) return super.toMessage(messageData, { rollMode, create });
+
+    if (rollMode === "roll") rollMode = undefined;
+    rollMode ||= game.settings.get("core", "rollMode");
+
+    if (!this._evaluated) await this.evaluate({ allowInteractive: rollMode !== CONST.DICE_ROLL_MODES.BLIND });
+
+    messageData = foundry.utils.mergeObject({
+      type: "standard",
+      system: {},
+      author: game.user.id,
+      sound: CONFIG.sounds.dice,
+    }, messageData);
+    messageData.system.parts = {
+      [foundry.utils.randomID()]: {
+        flavor: messageData.flavor,
+        rolls: [this],
+        type: this.constructor.PART_TYPE,
+      },
+    };
+    delete messageData.flavor;
+    delete messageData.rolls;
+
+    const Cls = getDocumentClass("ChatMessage");
+    const msg = new Cls(messageData);
+    msg.applyRollMode(rollMode);
+
+    if (create) return Cls.create(msg);
+    return msg.toObject();
+  }
+}


### PR DESCRIPTION
Implements `toMessage` on the base `DSRoll` class. Subclasses should define `PART_TYPE`.

Closes #1446.