### PR TITLE
[#1364] Move skills to top level of system data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 ### Changed
 
 - Moved skills from `system.hero.skills` to `system.skills.value`. (#1364)
-- Added "Share" button to item sheet header controls. (#1505)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 ### Changed
 
+- Moved skills from `system.hero.skills` to `system.skills.value`. (#1364)
+- Added "Share" button to item sheet header controls. (#1505)
+
 ### Fixed
 
 ## 0.10.2

--- a/lang/en.json
+++ b/lang/en.json
@@ -589,6 +589,11 @@
               },
               "format": "{type} Weakness"
             }
+          },
+          "skills": {
+            "value": {
+              "label": "Skills"
+            }
           }
         },
         "EVLabel": {
@@ -674,9 +679,6 @@
               "max": {
                 "label": "Max Followers"
               }
-            },
-            "skills": {
-              "label": "Skills"
             }
           }
         },

--- a/src/docs/Active-Effects.md
+++ b/src/docs/Active-Effects.md
@@ -143,15 +143,15 @@ Draw Steel also supports modifying the default roll formula for tests. `system.c
 
 |Purpose|Attribute Key|
 |:---:|---|
-|Edges for skills used in tests|`system.hero.skillModifiers.[skill].edges`|
-|Banes for skills used in tests|`system.hero.skillModifiers.[skill].banes`|
+|Edges for skills used in tests|`system.skills.modifiers.[skill].edges`|
+|Banes for skills used in tests|`system.skills.modifiers.[skill].banes`|
 
 > An example of applying a single edge to uses of the Jump skill would be:
-> |`system.hero.skillModifiers.jump.edges`|Add|`1`|
+> |`system.skills.modifiers.jump.edges`|Add|`1`|
 > |---|---|---|
 >
 > An example of applying two banes to uses of the Tailoring skill would be:
-> |`system.hero.skillModifiers.tailoring.banes`|Add|`2`|
+> |`system.skills.modifiers.tailoring.banes`|Add|`2`|
 > |---|---|---|
 
 #### Common bonus effect examples

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -19,6 +19,12 @@ The `[[lookup]]` enricher allows dynamic display of actor, item, and effect data
 - [&ZeroWidthSpace;[lookup formula=@A+3 evaluate=true]] The formula and evaluate parameters can be defined explicitly.
 - [&ZeroWidthSpace;[lookup formula="@A + 3" evaluate=true]] You must use quotes for formulas with spaces
 
+### Useful Roll Data
+These pieces of roll data return strings rather than numbers.
+
+- Name: `@name`
+- Skills: `@skills.list`
+
 ## Damage and Healing
 
 You can have inline damage enrichers by using `[[/damage]]`; this is the intended way to handle abilities that do damage as part of their effect, such as the Censor's Judgment. The damage is a formula that is evaluated when the text is rendered; closing and re-opening a sheet will recalculate the values. A roll does not have to include dice; Draw Steel frequently involves static damage values.

--- a/src/docs/Roll-Data.md
+++ b/src/docs/Roll-Data.md
@@ -12,134 +12,132 @@ Foundry's rolls support variable substitution through roll data, as explained in
 
 # Actor Roll Data
 
-## Characteristics
-+ Agility value -`@characteristics.agility.value`
-+ Intuition value - `@characteristics.intuition.value`
-+ Might value - `@characteristics.might.value`
-+ Presence value - `@characteristics.presence.value`
-+ Reason value - `@characteristics.reason.value`
+## General Info
+
+Most actors support the following roll attributes
+
+### Characteristics
++ Might value: `@characteristics.might.value` or `@M`
++ Agility value:`@characteristics.agility.value` or `@A`
++ Reason value: `@characteristics.reason.value` or `@R`
++ Intuition value: `@characteristics.intuition.value` or `@I`
++ Presence value: `@characteristics.presence.value` or `@P`
++ Highest characteristic: `@chr`
 
 ### Combat Data
-+ Save Bonus - `@combat.save.bonus`
-+ Save Threshold - `@combat.save.threshold`
++ Save Bonus: `@combat.save.bonus`
++ Save Threshold: `@combat.save.threshold`
 + Size (1/2/3/4) `@combat.size.value`
-+ Stability - `@combat.stability`
++ Stability: `@combat.stability`
 + Total amount of turns per round of specific actor (e.g. Solos would have 2) `@combat.turns`
-+ Initiative Threshold - `@combat.initiativeThreshold`
++ Initiative Threshold: `@combat.initiativeThreshold`
 
-## Potencies
-+ Strong Potency (= highest characteristic) - `@potency.strong`
-+ Average Potency (= highest characteristic -1) - `@potency.average`
-+ Weak Potency (= highest characteristic -2) - `@potency.weak`
-+ Bonus to Potency - `@potency.bonuses`
+### Potencies
++ Strong Potency: `@potency.strong`
++ Average Potency: `@potency.average`
++ Weak Potency: `@potency.weak`
++ Bonus to Potency: `@potency.bonuses`
 
-## Stamina
-+ Maximum Stamina - `@stamina.max`
-+ Temporary Stamina - `@stamina.temporary`
-+ Current Stamina value - `@stamina.value`
-+ Winded (<50%) Stamina Value - `@stamina.winded`
-+ Is currently winded? (1/yes, 0/no) - `@statuses.winded`
+### Stamina
++ Maximum Stamina: `@stamina.max`
++ Temporary Stamina: `@stamina.temporary`
++ Current Stamina value: `@stamina.value`
++ Winded (<50%) Stamina Value: `@stamina.winded`
++ Is currently winded? (1/yes, 0/no): `@statuses.winded`
 
 ### Recoveries
-+ Recovery value - `@recoveries.recoveryValue`
-+ Current recovery amount - `@recoveries.value`
-+ Maximum amount of recoveries - `@recoveries.max`
-+ Bonus to recovery value - `@recoveries.bonus`
++ Recovery value: `@recoveries.recoveryValue`
++ Current recovery amount: `@recoveries.value`
++ Maximum amount of recoveries: `@recoveries.max`
++ Bonus to recovery value: `@recoveries.bonus`
 
 ### Movement speeds
-+ Speed - `@movement.value`
-+ Teleport - `@movement.teleport` (Unaffected by most speed adjustments)
++ Speed: `@movement.value`
++ Teleport: `@movement.teleport` (Unaffected by most speed adjustments)
 
-## Echelon and Level
-+ Echelon - `@echelon`
-+ Level - `@level`
+### Echelon and Level
++ Echelon: `@echelon`
++ Level: `@level`
 
-## Biography
-+ Number of Languages: `@biography.languages.size`
+### Immunities and Weaknesses
+- Immunity: `@damage.immunities.[type]`, e.g. `@damage.immunities.fire`
+- Weakness: `@damage.weaknesses.[type]`, e.g. `@damage.immunities.fire`
+
+<details>
+<summary>The viable damage types for Immunities and Weaknesses are:</summary>
+|Damage Type|Active Effect Attribute Key|
+|:---:|---|
+|All damage (including untyped)|`all`
+|Acid damage|`acid`
+|Cold damage|`cold`
+|Corruption damage|`corruption`
+|Fire damage|`fire`
+|Holy damage|`holy`
+|Lightning damage|`lightning`
+|Poison damage|`poison`
+|Psychic Damage|`psychic`
+|Sonic Damage|`sonic`
+</details>
+
+### Statuses
+Value indicates if actor currently has status (1/yes, 0/no)
++ Asleep:`@statuses.sleep`
++ Bleeding: `@statuses.bleeding`
++ Burning: `@statuses.burning`
++ Dazed: `@statuses.dazed`
++ Dead: `@statuses.dead`
++ Deaf: `@statuses.deaf`
++ Dying: `@statuses.dying`
++ Frozen: `@statuses.frozen`
++ Frightened: `@statuses.frightened`
++ Grabbed: `@statuses.grabbed`
++ Invisible: `@statuses.invisible`
++ Marked: `@statuses.eye`
++ Prone: `@statuses.prone`
++ Restrained: `@statuses.restrained`
++ Slowed: `@statuses.slowed`
++ Targeted: `@statuses.target`
++ Taunted: `@statuses.taunted`
++ Weakened: `@statuses.weakened`
++ Winded: `@statuses.winded`
 
 ## Hero Roll Data
 
 ### Heroic Resource
-+ Heroic resource label - `@hero.primary.label`
-+ Heroic resource value - `@hero.primary.value`
++ Heroic resource label: `@hero.primary.label`
++ Heroic resource value: `@hero.primary.value`
 
 ### Other Hero values
-+ Renown - `@hero.renown`
-+ Skills - `@hero.skills`
-+ Current amount of Surges - `@hero.surges`
-+ Current Victory Points - `@hero.victories`
-+ Accumulated XP - `@hero.xp`
++ Renown: `@hero.renown`
++ Current amount of Surges: `@hero.surges`
++ Current Victory Points: `@hero.victories`
++ Accumulated XP: `@hero.xp`
 
-### Immunities and Weaknesses
-
-#### Immunities
-+ Acid damage -`@damage.immunities.acid`
-+ All damage (including untyped)- `@damage.immunities.all`
-+ Cold damage - `@damage.immunities.cold`
-+ Corruption damage - `@damage.immunities.corruption`
-+ Fire damage - `@damage.immunities.fire`
-+ Holy damage - `@damage.immunities.holy`
-+ Lightning damage - `@damage.immunities.lightning`
-+ Poison damage - `@damage.immunities.poison`
-+ Psychic Damage - `@damage.immunities.psychic`
-+ Sonic Damage - `@damage.immunities.sonic`
-
-#### Weaknesses
-+ Acid - `@damage.weaknesses.acid`
-+ All damage (including untyped) - `@damage.weaknesses.all`
-+ Cold damage -	`@damage.weaknesses.cold`
-+ Corruption damage - `@damage.weaknesses.corruption`
-+ Fire damage - `@damage.weaknesses.fire`
-+ Holy damage - `@damage.weaknesses.holy`
-+ Lightning damage - `@damage.weaknesses.lightning`
-+ Poison damage - `@damage.weaknesses.poison`
-+ Psychic Damage - `@damage.weaknesses.psychic`
-+ Sonic Damage - `@damage.weaknesses.sonic`
-
-### Statuses
-Value indicates if actor currently has status (1/yes, 0/no)
-+ Asleep -`@statuses.sleep`
-+ Bleeding - `@statuses.bleeding`
-+ Burning - `@statuses.burning`
-+ Dazed - `@statuses.dazed`
-+ Dead - `@statuses.dead`
-+ Deaf - `@statuses.deaf`
-+ Dying - `@statuses.dying`
-+ Frozen - `@statuses.frozen`
-+ Frightened - `@statuses.frightened`
-+ Grabbed - `@statuses.grabbed`
-+ Invisible - `@statuses.invisible`
-+ Marked - `@statuses.eye`
-+ Prone - `@statuses.prone`
-+ Restrained - `@statuses.restrained`
-+ Slowed - `@statuses.slowed`
-+ Targeted - `@statuses.target`
-+ Taunted - `@statuses.taunted`
-+ Weakened - `@statuses.weakened`
-+ Winded - `@statuses.winded`
+## Biography
++ Number of Languages: `@biography.languages.size`
 
 ## NPC Roll Data
 
 ### Monster Roll data
-+ Free Strike damage: - `@monster.freeStrike`
++ Free Strike damage:: `@monster.freeStrike`
 
 ### Monster Negotiation Roll Data
-+ Impression Score - `@negotiation.impression`
-+ Interest - `@negotiation.interest`
-+ Patience - `@negotiation.patience`
++ Impression Score: `@negotiation.impression`
++ Interest: `@negotiation.interest`
++ Patience: `@negotiation.patience`
 
 # Item Roll Data
 
 ## Downtime Project roll data
-+ Project Goal - `@item.project.goal`
++ Project Goal: `@item.project.goal`
 
 ## Abilities
 
-+ Ability primary distance  - `@item.distance.primary`
-+ Ability secondary distance - `@item.distance.secondary`
-+ Ability tertiary distance - `@item.distance.tertiary`
-+ Ability Power Roll Characteristic - `@item.powerRoll.characteristics`
-+ Ability Power Roll Characteristic formula - `@item.powerRoll.formula`
-+ Ability Heroic Resource/Malice Cost -`@item.resource`
-+ Ability Additional Heroic Resource/Malice Cost - `@item.spend.value`
-+ Number of targets - `@item.target.value`
++ Ability primary distance : `@item.distance.primary`
++ Ability secondary distance: `@item.distance.secondary`
++ Ability tertiary distance: `@item.distance.tertiary`
++ Ability Power Roll Characteristic: `@item.powerRoll.characteristics`
++ Ability Power Roll Characteristic formula: `@item.powerRoll.formula`
++ Ability Heroic Resource/Malice Cost:`@item.resource`
++ Ability Additional Heroic Resource/Malice Cost: `@item.spend.value`
++ Number of targets: `@item.target.value`

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -116,21 +116,14 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * @returns {string}
    */
   _getSkills() {
-    const list = this.actor.system.hero.skills.reduce((skills, skill) => {
-      skill = ds.CONFIG.skills.list[skill]?.label;
-      if (skill) skills.push(skill);
-      return skills;
-    }, []).sort((a, b) => a.localeCompare(b, game.i18n.lang));
-    const formatter = game.i18n.getListFormatter();
-
     const skillOptions = ds.CONFIG.skills.optgroups;
 
-    for (const skill of this.actor.system.hero.skills) {
+    for (const skill of this.actor.system.skills.value) {
       if (!(skill in ds.CONFIG.skills.list)) skillOptions.push({ value: skill });
     }
 
     return {
-      list: formatter.format(list),
+      list: this.actor.system.skills.list,
       options: skillOptions,
     };
   }

--- a/src/module/data/actor/_types.d.ts
+++ b/src/module/data/actor/_types.d.ts
@@ -1,5 +1,6 @@
 import DrawSteelActor from "../../documents/actor.mjs";
 import { ObjectSizeModel, SizeModel, SourceModel } from "../models/_module.mjs";
+import { PowerRollModifiers } from "../../_types";
 
 interface BarAttribute {
   value: number,
@@ -50,6 +51,12 @@ interface Combat {
     edges: number;
     banes: number;
   }
+}
+
+interface Skills {
+  value: Set<string>;
+  modifiers: Record<string, PowerRollModifiers>;
+  list: string;
 }
 
 declare module "./base-actor.mjs" {
@@ -132,9 +139,9 @@ declare module "./hero.mjs" {
       xp: number;
       renown: number;
       wealth: number;
-      skills: Set<string>;
       preferredKit: string;
     }
+    skills: Skills;
     biography: Biography & {
       languages: Set<string>;
       age: string;

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -135,7 +135,7 @@ export default class CreatureModel extends BaseActorModel {
     options.edges = (options.edges ?? 0) + chr.edges;
     options.banes = (options.banes ?? 0) + chr.banes;
 
-    const skills = this.hero?.skills ?? null;
+    const skills = this.skills?.value ?? null;
     const skillModifiers = this.skills?.modifiers ?? null;
 
     const evaluation = "evaluate";

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -136,7 +136,7 @@ export default class CreatureModel extends BaseActorModel {
     options.banes = (options.banes ?? 0) + chr.banes;
 
     const skills = this.hero?.skills ?? null;
-    const skillModifiers = this.hero?.skillModifiers ?? null;
+    const skillModifiers = this.skills?.modifiers ?? null;
 
     const evaluation = "evaluate";
     const baseFormula = chr.dice.number > 2 ? `${chr.dice.number}d10${chr.dice.mode}2` : "2d10";

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -143,6 +143,7 @@ export default class HeroModel extends CreatureModel {
   prepareBaseData() {
     super.prepareBaseData();
 
+    // Existing DrawSteelActiveEffect#_applyAdd override means this also shims active effects targeting hero.skills
     HeroModel.shimSkills(this);
 
     this.combat.initiativeThreshold = 6;

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -125,7 +125,7 @@ export default class HeroModel extends CreatureModel {
         warning += ` Issue occurred in Actor ${data.parent.uuid}`;
       }
 
-      foundry.abstract.Document._addDataFieldShim.call(this, data, oldPath, newPath, { warning, since: "0.11", until: "1.0" });
+      foundry.abstract.Document._addDataFieldShim(data, oldPath, newPath, { warning, since: "0.11", until: "1.0" });
     }
   }
 

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -104,8 +104,11 @@ export default class HeroModel extends CreatureModel {
 
   /* -------------------------------------------------- */
 
-  /** @inheritdoc */
-  static shimData(data, options) {
+  /**
+   * Shims both source and initialized hero data.
+   * @param {object | HeroModel} data
+   */
+  static shimSkills(data) {
     const shims = {
       "hero.skills": "skills.value",
       "hero.skillModifiers": "skills.modifiers",
@@ -114,13 +117,23 @@ export default class HeroModel extends CreatureModel {
       // v13 version of _addDataFieldShim fails to properly safeguard dot-split properties. Results in warning spam.
       const lastKey = oldPath.split(".").at(-1);
       if (Object.hasOwn(data.hero, lastKey)) continue;
-      // Not using the multi-helper because the message said it was from Document not HeroModel
-      foundry.abstract.Document._addDataFieldShim.call(this, data, oldPath, newPath, {
-        warning: `You are accessing ${this.name}#${oldPath}, which has been migrated to ${this.name}#${newPath}.`,
-        since: "0.11", until: "1.0",
-      });
-    }
+      // Not using the multi-helper to improve message
 
+      let warning = `You are accessing ${this.name}#${oldPath}, which has been migrated to ${this.name}#${newPath}.`;
+
+      if (data instanceof HeroModel) {
+        warning += ` Issue occurred in Actor ${data.parent.uuid}`;
+      }
+
+      foundry.abstract.Document._addDataFieldShim.call(this, data, oldPath, newPath, { warning, since: "0.11", until: "1.0" });
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static shimData(data, options) {
+    this.shimSkills(data);
     return super.shimData(data, options);
   }
 
@@ -129,6 +142,8 @@ export default class HeroModel extends CreatureModel {
   /** @inheritdoc */
   prepareBaseData() {
     super.prepareBaseData();
+
+    HeroModel.shimSkills(this);
 
     this.combat.initiativeThreshold = 6;
 

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -12,7 +12,6 @@ import CreatureModel from "./creature.mjs";
  * @import ActiveEffectData from "@common/documents/_types.mjs";
  * @import AdvancementChain from "../../utils/advancement-chain.mjs";
  * @import { ActorData, ItemData } from "@common/documents/_types.mjs";
- * @import { PowerRollModifiers } from "../../_types.js";
  */
 
 const fields = foundry.data.fields;
@@ -62,8 +61,11 @@ export default class HeroModel extends CreatureModel {
       victories: requiredInteger(),
       renown: requiredInteger(),
       wealth: requiredInteger({ initial: 1 }),
-      skills: new fields.SetField(setOptions()),
       preferredKit: new fields.DocumentIdField({ readonly: false }),
+    });
+
+    schema.skills = new fields.SchemaField({
+      value: new fields.SetField(setOptions()),
     });
 
     return schema;
@@ -88,6 +90,15 @@ export default class HeroModel extends CreatureModel {
     bio.age = new fields.StringField({ required: true });
 
     return bio;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static migrateData(data) {
+    foundry.abstract.Document._addDataFieldMigration(data, "hero.skills", "skills.value");
+
+    return super.migrateData(data);
   }
 
   /* -------------------------------------------------- */
@@ -165,8 +176,7 @@ export default class HeroModel extends CreatureModel {
       }
     }
 
-    /** @type {Record<string, PowerRollModifiers>} */
-    this.hero.skillModifiers = { };
+    this.skills.modifiers = {};
   }
 
   /* -------------------------------------------------- */
@@ -193,11 +203,21 @@ export default class HeroModel extends CreatureModel {
 
     // Handling for trait advancements
     for (const skill of this._traits.skill ?? []) {
-      if (skill in ds.CONFIG.skills.list) this.hero.skills.add(skill);
+      if (skill in ds.CONFIG.skills.list) this.skills.value.add(skill);
     }
     for (const lang of this._traits.language ?? []) {
       if (lang in ds.CONFIG.languages) this.biography.languages.add(lang);
     }
+
+    const list = this.skills.value.reduce((skills, skill) => {
+      skill = ds.CONFIG.skills.list[skill]?.label;
+      if (skill) skills.push(skill);
+      return skills;
+    }, []).sort((a, b) => a.localeCompare(b, game.i18n.lang));
+
+    const formatter = game.i18n.getListFormatter();
+
+    this.skills.list = formatter.format(list);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -104,6 +104,16 @@ export default class HeroModel extends CreatureModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  static shimData(data, options) {
+    foundry.abstract.Document._addDataFieldShim(data, "hero.skills", "skills.value", { since: "0.11", until: "1.0" });
+    foundry.abstract.Document._addDataFieldShim(data, "hero.skillModifiers", "skills.modifiers", { since: "0.11", until: "1.0" });
+
+    return super.shimData(data, options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   prepareBaseData() {
     super.prepareBaseData();
 

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -106,8 +106,20 @@ export default class HeroModel extends CreatureModel {
 
   /** @inheritdoc */
   static shimData(data, options) {
-    foundry.abstract.Document._addDataFieldShim(data, "hero.skills", "skills.value", { since: "0.11", until: "1.0" });
-    foundry.abstract.Document._addDataFieldShim(data, "hero.skillModifiers", "skills.modifiers", { since: "0.11", until: "1.0" });
+    const shims = {
+      "hero.skills": "skills.value",
+      "hero.skillModifiers": "skills.modifiers",
+    };
+    for (const [oldPath, newPath] of Object.entries(shims)) {
+      // v13 version of _addDataFieldShim fails to properly safeguard dot-split properties. Results in warning spam.
+      const lastKey = oldPath.split(".").at(-1);
+      if (Object.hasOwn(data.hero, lastKey)) continue;
+      // Not using the multi-helper because the message said it was from Document not HeroModel
+      foundry.abstract.Document._addDataFieldShim.call(this, data, oldPath, newPath, {
+        warning: `You are accessing ${this.name}#${oldPath}, which has been migrated to ${this.name}#${newPath}.`,
+        since: "0.11", until: "1.0",
+      });
+    }
 
     return super.shimData(data, options);
   }

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -251,7 +251,7 @@ export default class ProjectModel extends BaseItemModel {
       actor: this.actor,
       evaluation: "evaluate",
       data: rollData,
-      skillModifiers: this.actor?.system.hero?.skillModifiers ?? {},
+      skillModifiers: this.actor?.system.skills?.modifiers ?? {},
     });
 
     return promptValue;

--- a/src/module/data/migrations.mjs
+++ b/src/module/data/migrations.mjs
@@ -31,6 +31,10 @@ export async function migrateWorld() {
       await version_0_10_migration();
       updateVersion = true;
     }
+    if (foundry.utils.isNewerVersion("0.11.0", migrationVersion)) {
+      await version_0_11_migration();
+      updateVersion = true;
+    }
   }
   if (updateVersion) await game.settings.set(systemID, "migrationVersion", game.system.version);
 }
@@ -99,6 +103,45 @@ async function version_0_10_migration() {
 /* -------------------------------------------------- */
 
 /**
+ * Migrate active effect keys for version 0.10.0.
+ */
+async function version_0_11_migration() {
+  const warning = ui.notifications.warn("DRAW_STEEL.Setting.MigrationVersion.WorldWarning", { format: { version: "0.11.0" }, progress: true });
+
+  console.log("Migrating active effects inside actors");
+  for (const actor of game.actors) {
+    await migrateChanges(actor);
+  }
+  warning.update({ pct: 0.4 });
+  console.log("Migrating active effects inside items");
+  for (const item of game.items) {
+    await migrateChanges(item);
+  }
+  warning.update({ pct: 0.7 });
+
+  // Current migration does not search for effects created inside deltas
+  // if that is ever necessary, expand to loop through game.scenes => scene.tokens
+
+  const packsToMigrate = game.packs.filter(p => shouldMigrateCompendium(p));
+  for (const pack of packsToMigrate) {
+    console.log("Migrating document inside", pack.title);
+    const docs = await pack.getDocuments();
+    const wasLocked = pack.config.locked;
+    if (wasLocked) await pack.configure({ locked: false });
+    for (const doc of docs) await migrateChanges(doc);
+    if (wasLocked) await pack.configure({ locked: true });
+  }
+
+  warning.update({ pct: 1.00 });
+
+  ui.notifications.remove(warning);
+  ui.notifications.success("DRAW_STEEL.Setting.MigrationVersion.WorldSuccess", { format: { version: "0.11.0" }, permanent: true });
+  console.log("Migration complete");
+}
+
+/* -------------------------------------------------- */
+
+/**
  * @typedef {DocumentCollection<Document> | EmbeddedCollection<Document> | CompendiumCollection<Document>} AnyCollection
  */
 
@@ -122,6 +165,27 @@ export async function migrateType(collection, options = {}) {
     const updateData = toMigrate.slice(i * 100, (i + 1) * 100);
     await collection.documentClass.updateDocuments(updateData, { pack: options.pack, parent: options.parent, diff: false });
   }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Migrate all effects in an Actor or Item.
+ * @param {foundry.documents.Actor | foundry.documents.Item} parentDocument If this is an Actor, also migrate effects on items.
+ */
+export async function migrateChanges(parentDocument) {
+  const toMigrate = parentDocument.effects.filter(effect => effect.getFlag(systemID, "migrateChanges")).map(doc => ({
+    _id: doc.id,
+    "==changes": [...doc.changes],
+    "flags.draw-steel.-=migrateChanges": null,
+  }));
+
+  // TODO: Batch this in v14
+  await parentDocument.updateEmbeddedDocuments("ActiveEffect", toMigrate);
+  if (parentDocument.documentName === "Item") return;
+  const promises = [];
+  for (const item of parentDocument.items) promises.push(migrateChanges(item));
+  return Promise.allSettled(promises);
 }
 
 /* -------------------------------------------------- */

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -245,4 +245,36 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
     if (typeof this.system.apply === "function") return this.system.apply(actor, change);
     else return super.apply(actor, change);
   }
+
+  /* -------------------------------------------- */
+  /*  Deprecations and Compatibility              */
+  /* -------------------------------------------- */
+
+  /**
+   * Keys that need migration in active effects.
+   * @type {Record<string, string>}
+   */
+  static keyMigrations = {
+    // 0.11
+    "hero.skills": "skills.value",
+    "hero.skillModifiers": "skills.modifiers",
+    // 0.10
+    "monster.ev": "ev",
+  };
+
+  /** @inheritdoc */
+  static migrateData(data) {
+    let migrateChanges = false;
+    for (const change of data.changes ?? []) {
+      for (const [oldPath, newPath] of Object.entries(this.keyMigrations)) {
+        const oldKey = change.key;
+        change.key = change.key.replace(oldPath, newPath);
+        if (change.key !== oldKey) migrateChanges ||= true;
+      }
+    }
+
+    if (migrateChanges) foundry.utils.setProperty(data, "flags.draw-steel.migrateChanges", true);
+
+    return super.migrateData(data);
+  }
 }

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -92,7 +92,7 @@ export default class ProjectRoll extends DSRoll {
     options.modifiers.edges ??= 0;
     options.modifiers.banes ??= 0;
     options.modifiers.bonuses ??= 0;
-    options.skills ??= options.actor?.system.hero?.skills ?? null;
+    options.skills ??= options.actor?.system.skills?.value ?? null;
 
     const context = {
       modifiers: options.modifiers,

--- a/templates/apps/power-roll-dialog.hbs
+++ b/templates/apps/power-roll-dialog.hbs
@@ -48,7 +48,7 @@
   {{/each}}
   {{#if skillOptions}}
   <div class="form-group">
-    <label>{{localize "DRAW_STEEL.Actor.hero.FIELDS.hero.skills.label"}}</label>
+    <label>{{localize "DRAW_STEEL.Actor.base.FIELDS.skills.value.label"}}</label>
     <div class="form-fields">
       <select name="skill">
         {{selectOptions skillOptions blank=(localize "None") selected=skill}}

--- a/templates/sheets/actor/hero-sheet/stats.hbs
+++ b/templates/sheets/actor/hero-sheet/stats.hbs
@@ -130,7 +130,7 @@
   {{> "systems/draw-steel/templates/sheets/actor/shared/partials/stats/immunities-weaknesses.hbs"}}
   <fieldset class="skills">
     <legend>
-      {{systemFields.hero.fields.skills.label}}
+      {{systemFields.skills.fields.value.label}}
       {{#if unfilledSkill}}
       <button
         type="button"
@@ -147,7 +147,7 @@
     {{#if isPlay}}
     {{skills.list}}
     {{else}}
-    {{formInput systemFields.hero.fields.skills value=systemSource.hero.skills options=skills.options dataset=datasets.isSource}}
+    {{formInput systemFields.skills.fields.value value=systemSource.skills.value options=skills.options dataset=datasets.isSource}}
     {{/if}}
   </fieldset>
 </section>


### PR DESCRIPTION
1. We've got more general need to have it be `skills.value` so there can be the already-prepared `skills.list` and `skills.modifiers`
2. While normal NPCs don't have skills, there's enough other actor types like Companions that have skills. This also jives better with our expected Follower data.