### PR TITLE
[#1646] Add group member highlighting to combat tracker

### DIFF
--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -266,11 +266,16 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
           }
         });
       } else {
-        if (this.#highlightedTokens.length < 1) return;
         this.#highlightedTokens.forEach((token) => token._onHoverOut(event));
         this.#highlightedTokens.length = 0;
       }
     });
+
+    this.element.addEventListener("pointerout", (event) => {
+        this.#highlightedTokens.forEach((token) => token._onHoverOut(event));
+        this.#highlightedTokens.length = 0;
+    });
+
 
     new ux.DragDrop.implementation({
       dragSelector: ".combatant",

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -255,7 +255,7 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
 
       const { groupId } = event.target.closest(".combatant-group[data-group-id]")?.dataset ?? {};
 
-      const groupMembers = game.combat.groups.find((group) => group.id === groupId)?.members;
+      const groupMembers = game.combat.groups.get(groupId)?.members;
 
       if (groupMembers) {
         groupMembers.forEach((member, i) => {

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -49,6 +49,14 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
   };
 
   /* -------------------------------------------------- */
+
+  /**
+   * Array of currently highlighted tokens.
+   * @type {Array<DrawSteelToken>}
+   */
+  #highlightedTokens = [];
+
+  /* -------------------------------------------------- */
   /*   Application Life-Cycle Events                    */
   /* -------------------------------------------------- */
 
@@ -237,6 +245,32 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
         }
       }
     }
+
+    // Hover group targets
+    this.element.addEventListener("pointermove", (event) => {
+      if (!canvas.ready) return;
+
+      // Cancel if hovering target within group
+      if (event.target.closest(".combatant[data-combatant-id]")) return;
+
+      const { groupId } = event.target.closest(".combatant-group[data-group-id]")?.dataset ?? {};
+
+      const groupMembers = game.combat.groups.find((group) => group.id === groupId)?.members;
+
+      if (groupMembers) {
+        groupMembers.forEach((member, i) => {
+          const token = canvas.tokens.get(member?.tokenId);
+          if (token && token._canHover(game.user, event) && token.visible) {
+            token._onHoverIn(event, { hoverOutOthers: i === 0 });
+            this.#highlightedTokens.push(token);
+          }
+        });
+      } else {
+        if (this.#highlightedTokens.length < 1) return;
+        this.#highlightedTokens.forEach((token) => token._onHoverOut(event));
+        this.#highlightedTokens.length = 0;
+      }
+    });
 
     new ux.DragDrop.implementation({
       dragSelector: ".combatant",

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -52,9 +52,9 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
 
   /**
    * Array of currently highlighted tokens.
-   * @type {Array<DrawSteelToken>}
+   * @type {Set<DrawSteelToken>}
    */
-  #highlightedTokens = [];
+  #highlightedTokens = new Set();
 
   /* -------------------------------------------------- */
   /*   Application Life-Cycle Events                    */
@@ -262,20 +262,19 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
           const token = canvas.tokens.get(member?.tokenId);
           if (token && token._canHover(game.user, event) && token.visible) {
             token._onHoverIn(event, { hoverOutOthers: i === 0 });
-            this.#highlightedTokens.push(token);
+            this.#highlightedTokens.add(token);
           }
         });
       } else {
         this.#highlightedTokens.forEach((token) => token._onHoverOut(event));
-        this.#highlightedTokens.length = 0;
+        this.#highlightedTokens.clear();
       }
     });
 
     this.element.addEventListener("pointerout", (event) => {
-        this.#highlightedTokens.forEach((token) => token._onHoverOut(event));
-        this.#highlightedTokens.length = 0;
+      this.#highlightedTokens.forEach((token) => token._onHoverOut(event));
+      this.#highlightedTokens.clear();
     });
-
 
     new ux.DragDrop.implementation({
       dragSelector: ".combatant",

--- a/src/styles/system/applications/sidebar/tabs/combat.css
+++ b/src/styles/system/applications/sidebar/tabs/combat.css
@@ -8,6 +8,8 @@
   }
 
   .combat-tracker.ds-default {
+    padding-inline: var(--element-spacing);
+
     li.combatant, li.combatant-group {
       --combatantAlpha: 0.1;
       &.active {


### PR DESCRIPTION
Implements a pointermove event on combat tracker that handles group members.
Adjusts combat encounter padding so moving mouse off right side of popped out elements will properly trigger the _hoverOut effect.

Closes #1646