### PR TITLE
[#1665] Advancement Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,26 @@
 
 ## 0.10.2
 
+### Added
+
+- Hovering a combatant group now highlights all associated tokens. (#1646)
+
 ### Changed
 
+- Using an ability with a power roll only consumes associated resources *after* the power roll dialog is completed.
+- Increased margin above `div.ability-bordered`.
+- Blocked programmatic creation of certain item types on Object actors. (e.g. ancestries, ancestry traits, classes, titles)
 - Item grant advancements now defer sub-node generation until after they are selected.
 
 ### Fixed
 
-- Fixed the Berserker subclass not granting its kit signature ability (#1665)
 - Player-Facing Compendium Data Fixes:
   - Fixed the formatting of Judgment, added a description to the effect.
   - Added an applied effect to Behold a Shield of Faith!
   - Added an applied effect to Vengeance Mark.
   - Updated many complications, including descriptions in effects and using the /test enricher where relevant.
+- Fixed the Berserker subclass not granting its kit signature ability during the advancement dialog. (#1665)
+- Fixed heroes not defaulting to their primary resource as the secondary resource bar.
 
 ## 0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@
 
 ## 0.10.2
 
+### Changed
+
+- Item grant advancements now defer sub-node generation until after they are selected.
+
 ### Fixed
 
+- Fixed the Berserker subclass not granting its kit signature ability (#1665)
 - Player-Facing Compendium Data Fixes:
   - Fixed the formatting of Judgment, added a description to the effect.
   - Added an applied effect to Behold a Shield of Faith!

--- a/src/module/applications/apps/advancement/item-grant-configuration-dialog.mjs
+++ b/src/module/applications/apps/advancement/item-grant-configuration-dialog.mjs
@@ -339,8 +339,7 @@ export default class ItemGrantConfigurationDialog extends DSApplication {
     }
     if (allowed && !this.items.has(item)) {
       this.items.add(item);
-      const leaf = this.node.choices[item.uuid] = new AdvancementLeaf(this.node, item.uuid, item.toAnchor().outerHTML, { item });
-      await Promise.allSettled(this.node.chain.createNodes(item, { parentLeaf: leaf }));
+      this.node.choices[item.uuid] = new AdvancementLeaf(this.node, item.uuid, item.toAnchor().outerHTML, { item });
       this.chosen.add(item.uuid);
       this.element.querySelector(".item-choices").insertAdjacentHTML("beforeend", `<div class="form-group">
         <label>${item.toAnchor().outerHTML}</label>

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -153,10 +153,7 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
       /** @type {DrawSteelItem} */
       const item = await fromUuid(uuid);
       if (!item) continue;
-      const leaf = node.choices[item.uuid] = new AdvancementLeaf(node, item.uuid, item.toAnchor().outerHTML, { item });
-      if (!item.supportsAdvancements) continue;
-
-      promises.push(...node.chain.createNodes(item, { parentLeaf: leaf }));
+      node.choices[item.uuid] = new AdvancementLeaf(node, item.uuid, item.toAnchor().outerHTML, { item });
     }
     return Promise.allSettled(promises);
   }
@@ -169,12 +166,18 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
 
     if (!selection) return null;
 
+    const promises = [];
+
     if (node) {
       node.selected = selection.choices.reduce((selected, uuid) => {
-        selected[uuid] = this.pointBuy ? node.choices[uuid].item.system.points : true;
+        const leaf = node.choices[uuid];
+        selected[uuid] = this.pointBuy ? leaf.item.system.points : true;
+        promises.push(...node.chain.createNodes(leaf.item, { parentLeaf: leaf }));
         return selected;
       }, {});
     }
+
+    await Promise.allSettled(promises);
 
     return { [`flags.draw-steel.advancement.${this.id}.selected`]: selection.choices };
   }

--- a/src/module/utils/advancement/chain.mjs
+++ b/src/module/utils/advancement/chain.mjs
@@ -224,9 +224,8 @@ export default class AdvancementChain {
    * @param {AdvancementNode} node
    */
   addNode(node) {
-    if (this.nodes.has(node.id)) {
-      console.log(this.nodes.get(node.id), node);
-    }
+    const existing = this.nodes.get(node.id);
+    if (existing) this.removeNode(existing);
     this.nodes.set(node.id, node);
   }
 
@@ -237,6 +236,7 @@ export default class AdvancementChain {
    * @param {AdvancementNode} node
    */
   removeNode(node) {
+    for (const n of node.children) this.removeNode(n);
     this.nodes.delete(node.id);
   }
 }

--- a/src/module/utils/advancement/chain.mjs
+++ b/src/module/utils/advancement/chain.mjs
@@ -224,6 +224,9 @@ export default class AdvancementChain {
    * @param {AdvancementNode} node
    */
   addNode(node) {
+    if (this.nodes.has(node.id)) {
+      console.log(this.nodes.get(node.id), node);
+    }
     this.nodes.set(node.id, node);
   }
 


### PR DESCRIPTION
**The problem:** Fury subclasses are responsible for kit selection, which meant that both the Berserker and Reaver subclasses were generating nodes for the kit options. Those would *then* generate nodes for the signature abilities, which have UUID collisions because they literally come from the same item and advancement.

- Berserker => Panther Kit => Devastating Rush
- Reaver => Panther Kit => Devastating Rush

The Reaver would override the relevant nodes in the chain in `addNode` to add a new one with a different parent.

**The solution** proposed in this PR is to delay node generation until after item selection. Not only does this have performance benefits, but also ensures that nodes are freshly generated based on current information. This probably has positive impacts on #1607