### PR TITLE
Add share button to item sheet header controls (#1505)

### DIFF
--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -543,22 +543,22 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
   /* -------------------------------------------------- */
 
   /**
-   * Whether this item can be updated from a compendium source.
+   * Whether item has been configured for embeds.
    *
    * @this DrawSteelItemSheet
    */
   static #canEmbed() {
-    return "toEmbed" in this.document;
+    return this.document.system.toEmbed !== foundry.abstract.TypeDataModel.prototype.toEmbed;
   }
 
   /* -------------------------------------------------- */
 
   /**
-   * Renders an embedded document's sheet in play or edit mode based on the document sheet view mode.
+   * Sends item as embed in chat.
    *
    * @this DrawSteelItemSheet
    * @param {PointerEvent} event   The originating click event.
-   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   * @param {HTMLElement} target   The capturing HTML element.
    * @protected
    */
   static async #shareDoc(event, target) {

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -548,6 +548,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    * DrawSteel items extend toEmbed, returning data for use with enricher.
    *
    * @this DrawSteelItemSheet
+   * @returns {boolean}
    */
   static #canEmbed() {
     return this.document.system.toEmbed !== foundry.abstract.TypeDataModel.prototype.toEmbed;

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -543,7 +543,9 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
   /* -------------------------------------------------- */
 
   /**
-   * Whether item has been configured for embeds.
+   * Whether item has been configured for use with Draw Steel embed enricher.
+   * All Foundry documents have toEmbed by default, but return null (preventing enricher embed).
+   * DrawSteel items extend toEmbed, returning data for use with enricher.
    *
    * @this DrawSteelItemSheet
    */
@@ -554,7 +556,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
   /* -------------------------------------------------- */
 
   /**
-   * Sends item as embed in chat.
+   * Sends item with embed enricher in chat.
    *
    * @this DrawSteelItemSheet
    * @param {PointerEvent} event   The originating click event.

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -34,6 +34,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       toggleEffect: this.#toggleEffect,
       createCultureAdvancement: this.#createCultureAdvancement,
       reconfigureAdvancement: this.#reconfigureAdvancement,
+      shareDoc: this.#shareDoc,
     },
     window: {
       controls: [{
@@ -41,6 +42,11 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         label: "DRAW_STEEL.SOURCE.CompendiumSource.UpdateFrom.Label",
         action: "updateFromCompendium",
         visible: DrawSteelItemSheet.#canUpdateFromCompendium,
+      }, {
+        icon: "fa-solid fa-fw fa-share-from-square",
+        label: "DRAW_STEEL.SHEET.Share",
+        action: "shareDoc",
+        visible: DrawSteelItemSheet.#canEmbed,
       }],
     },
   };
@@ -534,6 +540,39 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
 
   /* -------------------------------------------------- */
   /*   Actions                                          */
+  /* -------------------------------------------------- */
+
+  /**
+   * Whether this item can be updated from a compendium source.
+   *
+   * @this DrawSteelItemSheet
+   */
+  static #canEmbed() {
+    return "toEmbed" in this.document;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Renders an embedded document's sheet in play or edit mode based on the document sheet view mode.
+   *
+   * @this DrawSteelItemSheet
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   * @protected
+   */
+  static async #shareDoc(event, target) {
+    const document = this.document;
+    await DrawSteelChatMessage.create({
+      content: `@Embed[${document.uuid} caption=false]`,
+      type: "standard",
+      "system.parts": [{ type: "content" }],
+      title: document.name,
+      author: game.user,
+      flags: { core: { canPopout: true } },
+    });
+  }
+
   /* -------------------------------------------------- */
 
   /**


### PR DESCRIPTION
Adds share button to item sheet controls.
Checks for toEmbed method for future proofing against other items that may not embed. Not sure if any plans for that, so maybe unnecessary.
Closes #1505
