### PR TITLE
Add party actor sheet

### DIFF
--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -29,6 +29,7 @@
 
 /* Sheet Imports*/
 @import url("../src/styles/system/applications/sheets/actor-sheet.css");
+@import url("../src/styles/system/applications/sheets/party.css");
 @import url("../src/styles/system/applications/sheets/combatant-group-config.css");
 @import url("../src/styles/system/applications/sheets/item-sheet.css");
 @import url("../src/styles/system/applications/sheets/journal-entry-page.css");

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -106,6 +106,11 @@ Hooks.once("init", function () {
     makeDefault: true,
     label: "DRAW_STEEL.SHEET.Labels.Object",
   });
+  Actors.registerSheet(DS_CONST.systemID, applications.sheets.DrawSteelPartySheet, {
+    types: ["party"],
+    makeDefault: true,
+    label: "DRAW_STEEL.SHEET.Labels.Party",
+  });
   Actors.registerSheet(DS_CONST.systemID, applications.sheets.DrawSteelRetainerSheet, {
     types: ["retainer"],
     makeDefault: true,

--- a/lang/en.json
+++ b/lang/en.json
@@ -829,7 +829,12 @@
         }
       },
       "party": {
-        "FIELDS": {}
+        "FIELDS": {},
+        "TABS": {
+          "details": "Details",
+          "members": "Members"
+        },
+        "placeMembers": "Place Members"
       },
       "retainer": {
         "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -835,7 +835,9 @@
           "details": "Details",
           "members": "Members"
         },
-        "placeMembers": "Place Members"
+        "placeMembers": "Place Members",
+        "stamina": "Stamina",
+        "recoveries": "Recoveries"
       },
       "retainer": {
         "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -304,6 +304,7 @@
         "Character": "Draw Steel Character Sheet",
         "NPC": "Draw Steel NPC Sheet",
         "Object": "Draw Steel Object Sheet",
+        "Party": "Draw Steel Party Sheet",
         "Retainer": "Draw Steel Retainer Sheet",
         "Item": "Draw Steel Item Sheet",
         "JournalEntry": "Draw Steel Journal Entry Sheet",

--- a/src/module/applications/sheets/_module.mjs
+++ b/src/module/applications/sheets/_module.mjs
@@ -6,6 +6,7 @@ export { default as DrawSteelItemSheet } from "./item-sheet.mjs";
 export { default as DrawSteelJournalEntrySheet } from "./journal-entry-sheet.mjs";
 export { default as DrawSteelNPCSheet } from "./npc-sheet.mjs";
 export { default as DrawSteelObjectSheet } from "./object-sheet.mjs";
+export { default as DrawSteelPartySheet } from "./party.mjs";
 export { default as DrawSteelRetainerSheet } from "./retainer-sheet.mjs";
 export { default as DrawSteelWallConfig } from "./wall-config.mjs";
 

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -10,6 +10,9 @@ import { systemPath } from "../../constants.mjs";
  * @import { ActorSheetItemContext, ActorSheetTreasureContext, ActorSheetComplicationsContext } from "./_types.js";
  */
 
+/**
+ * An implementation of an actor sheet for Hero actors.
+ */
 export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -1,6 +1,7 @@
 import { DocumentSourceInput, MonsterMetadataInput } from "../apps/_module.mjs";
 import { systemID, systemPath } from "../../constants.mjs";
 import DrawSteelActorSheet from "./actor-sheet.mjs";
+
 /**
  * @import { FormSelectOption } from "@client/applications/forms/fields.mjs";
  */

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -2,6 +2,9 @@ import { DocumentSourceInput, ObjectMetadataInput } from "../apps/_module.mjs";
 import DrawSteelActorSheet from "./actor-sheet.mjs";
 import { systemPath } from "../../constants.mjs";
 
+/**
+ * An implementation of an actor sheet for Object actors.
+ */
 export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/src/module/applications/sheets/party.mjs
+++ b/src/module/applications/sheets/party.mjs
@@ -1,0 +1,192 @@
+import DrawSteelActorSheet from "./actor-sheet.mjs";
+import enrichHTML from "../../utils/enrich-html.mjs";
+import { systemPath } from "../../constants.mjs";
+
+export default class DrawSteelPartySheet extends DrawSteelActorSheet {
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      placeMembers: DrawSteelPartySheet.#placeMembers,
+      removeMember: DrawSteelPartySheet.#removeMember,
+      showMember: DrawSteelPartySheet.#showMember,
+    },
+    classes: ["party"],
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    header: {
+      template: systemPath("templates/sheets/actor/party/header.hbs"),
+    },
+    navigation: {
+      template: "templates/generic/tab-navigation.hbs",
+    },
+    members: {
+      template: systemPath("templates/sheets/actor/party/members.hbs"),
+      classes: ["tab"],
+      scrollable: [".contents"],
+    },
+    details: {
+      template: systemPath("templates/sheets/actor/party/details.hbs"),
+      classes: ["tab"],
+      scrollable: [".contents"],
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  static TABS = {
+    primary: {
+      tabs: [
+        { id: "members" },
+        { id: "details" },
+      ],
+      initial: "members",
+      labelPrefix: "DRAW_STEEL.Actor.party.TABS",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /**
+   * External actors who re-render this application.
+   * @type {Set<RyuutamaActor>}
+   */
+  #appActors = new Set();
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+
+    context.header = await this.#prepareHeader();
+    context.members = await this.#prepareMembers();
+    context.details = await this.#prepareDetails();
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare details context.
+   * @returns {Promise<object>}
+   */
+  async #prepareDetails() {
+    const value = this.document.system._source.description.value;
+    const enriched = await enrichHTML(value, { relativeTo: this.document });
+    return {
+      isOwner: this.document.isOwner,
+      description: { value, enriched },
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare header context.
+   * @returns {Promise<object>}
+   */
+  async #prepareHeader() {
+    const members = this.document.system.members;
+    return {
+      canPlaceMembers: game.user.isGM && canvas?.ready && members.size,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare members context.
+   * @returns {Promise<object[]>}
+   */
+  async #prepareMembers() {
+    const members = [];
+    for (const member of this.document.system.members) {
+      const ctx = { ...member };
+      const { stamina } = member.actor.system;
+      Object.assign(ctx, {
+        stamina,
+        rootId: [this.id, member.actor.id].join("-"),
+        canView: member.actor.testUserPermission(game.user, "OBSERVER"),
+      });
+      members.push(ctx);
+    }
+    return members;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    for (const actor of this.#appActors) delete actor.apps[this.id];
+    this.#appActors.clear();
+    for (const { actor } of this.document.system.members) {
+      actor.apps[this.id] = this;
+      this.#appActors.add(actor);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onClose(options) {
+    for (const actor of this.#appActors) delete actor.apps[this.id];
+    this.#appActors.clear();
+    return super._onClose(options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @override */
+  async _onDropActor(event, actor) {
+    await this.document.system.addMembers([actor]);
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this DrawSteelPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static async #placeMembers(event, target) {
+    if (!this.document.system.members.size) return;
+    const isMaximized = this.rendered && !this.minimized;
+    if (isMaximized) await this.minimize();
+    await this.document.system.placeMembers();
+    if (isMaximized) this.maximize();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this DrawSteelPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #removeMember(event, target) {
+    const id = target.closest("[data-member-id]").dataset.memberId;
+    const actor = game.actors.get(id);
+    this.document.system.removeMembers([actor]);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * @this DrawSteelPartySheet
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing html element that defined the [data-action].
+   */
+  static #showMember(event, target) {
+    const id = target.closest("[data-member-id]").dataset.memberId;
+    const actor = game.actors.get(id);
+    actor.sheet.render({ force: true });
+  }
+}

--- a/src/module/applications/sheets/party.mjs
+++ b/src/module/applications/sheets/party.mjs
@@ -111,9 +111,9 @@ export default class DrawSteelPartySheet extends DrawSteelActorSheet {
     const members = [];
     for (const member of this.document.system.members) {
       const ctx = { ...member };
-      const { stamina } = member.actor.system;
+      const { recoveries, stamina } = member.actor.system;
       Object.assign(ctx, {
-        stamina,
+        recoveries, stamina,
         rootId: [this.id, member.actor.id].join("-"),
         canView: member.actor.testUserPermission(game.user, "OBSERVER"),
       });

--- a/src/module/applications/sheets/party.mjs
+++ b/src/module/applications/sheets/party.mjs
@@ -2,8 +2,11 @@ import DrawSteelActorSheet from "./actor-sheet.mjs";
 import enrichHTML from "../../utils/enrich-html.mjs";
 import { systemPath } from "../../constants.mjs";
 
+/**
+ * An implementation of an actor sheet for Party actors.
+ */
 export default class DrawSteelPartySheet extends DrawSteelActorSheet {
-  /** @override */
+  /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     actions: {
       placeMembers: DrawSteelPartySheet.#placeMembers,
@@ -15,7 +18,7 @@ export default class DrawSteelPartySheet extends DrawSteelActorSheet {
 
   /* -------------------------------------------------- */
 
-  /** @override */
+  /** @inheritdoc */
   static PARTS = {
     header: {
       template: systemPath("templates/sheets/actor/party/header.hbs"),
@@ -37,7 +40,7 @@ export default class DrawSteelPartySheet extends DrawSteelActorSheet {
 
   /* -------------------------------------------------- */
 
-  /** @override */
+  /** @inheritdoc */
   static TABS = {
     primary: {
       tabs: [
@@ -143,7 +146,7 @@ export default class DrawSteelPartySheet extends DrawSteelActorSheet {
 
   /* -------------------------------------------------- */
 
-  /** @override */
+  /** @inheritdoc */
   async _onDropActor(event, actor) {
     await this.document.system.addMembers([actor]);
     return true;

--- a/src/module/applications/sheets/party.mjs
+++ b/src/module/applications/sheets/party.mjs
@@ -3,6 +3,10 @@ import enrichHTML from "../../utils/enrich-html.mjs";
 import { systemPath } from "../../constants.mjs";
 
 /**
+ * @import DrawSteelActor from "../../documents/actor.mjs";
+ */
+
+/**
  * An implementation of an actor sheet for Party actors.
  */
 export default class DrawSteelPartySheet extends DrawSteelActorSheet {
@@ -56,7 +60,7 @@ export default class DrawSteelPartySheet extends DrawSteelActorSheet {
 
   /**
    * External actors who re-render this application.
-   * @type {Set<RyuutamaActor>}
+   * @type {Set<DrawSteelActor>}
    */
   #appActors = new Set();
 

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -2,6 +2,9 @@ import DrawSteelActorSheet from "./actor-sheet.mjs";
 import RetainerMetadataInput from "../apps/retainer-metadata-input.mjs";
 import { systemPath } from "../../constants.mjs";
 
+/**
+ * An implementation of an actor sheet for Retainer actors.
+ */
 export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/src/module/data/actor/party.mjs
+++ b/src/module/data/actor/party.mjs
@@ -90,7 +90,7 @@ export default class PartyModel extends DrawSteelSystemModel {
    * @returns {boolean}
    */
   validMember(actor) {
-    return (actor instanceof foundry.documents.Actor) && this.constructor.ALLOWED_ACTOR_TYPES.has(actor.type)
+    return (actor instanceof foundry.documents.Actor) && PartyModel.ALLOWED_ACTOR_TYPES.has(actor.type)
       && !actor.inCompendium && !actor.isToken;
   }
 

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -1,5 +1,6 @@
 import BaseDocumentMixin from "./base-document-mixin.mjs";
 import DrawSteelActiveEffect from "./active-effect.mjs";
+import DrawSteelPartySheet from "../applications/sheets/party.mjs";
 
 /** @import ClassModel from "../data/item/class.mjs" */
 
@@ -54,6 +55,20 @@ export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.
     }
 
     Hooks.callAll("ds.prepareActorData", this);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _onDelete(options, userId) {
+    // Remove party sheets and re-render them.
+    Object.values(this.apps).forEach(app => {
+      if (!(app instanceof DrawSteelPartySheet)) return;
+      delete this.apps[app.id];
+      if (app.rendered) app.render();
+    });
+
+    super._onDelete(options, userId);
   }
 
   /* -------------------------------------------------- */

--- a/src/styles/system/applications/sheets/party.css
+++ b/src/styles/system/applications/sheets/party.css
@@ -87,9 +87,7 @@
         }
 
         .resources {
-          .stamina {
-            margin-bottom: .5rem;
-          }
+          display: grid;
         }
       }
 

--- a/src/styles/system/applications/sheets/party.css
+++ b/src/styles/system/applications/sheets/party.css
@@ -82,7 +82,6 @@
           text-wrap: nowrap;
           overflow: hidden visible;
           text-overflow: ellipsis;
-          font-family: var(--ryuutama-font-gothic);
           margin-bottom: .5rem;
         }
 

--- a/src/styles/system/applications/sheets/party.css
+++ b/src/styles/system/applications/sheets/party.css
@@ -1,0 +1,136 @@
+.draw-steel.application.sheet.actor.party {
+  --min-height: 300px;
+  --min-width: 600px;
+  --members-width: 250px;
+
+  &:not(.minimizing, .maximizing, .minimized) {
+    min-height: var(--min-height);
+    min-width: var(--min-width);
+  }
+
+  .window-content {
+    container-type: inline-size;
+  }
+
+  [data-application-part=header] {
+    display: grid;
+    grid-template-columns: min(30%, 15rem) min(25%, 10rem) min(30%, 15rem);
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+
+    @container (width < 800px) {
+      grid: "left avatar" "right avatar" / 15rem 10rem;
+
+      .left-controls { grid-area: left }
+      .right-controls { grid-area: right }
+      .middle-controls { grid-area: avatar }
+    }
+
+    .left-controls {
+      .title {
+        margin: 0;
+        margin-bottom: .5rem;
+        font-size: 30px;
+      }
+    }
+  }
+
+  [data-application-part=navigation] {
+    margin: 1rem 0;
+  }
+
+  [data-application-part=members] {
+    overflow: hidden;
+
+    .contents {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      gap: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+      align-content: start;
+      height: 100%;
+    }
+
+    .member {
+      display: grid;
+      grid-template-columns: 100px 1fr;
+      gap: .5rem;
+      padding: .5rem;
+      position: relative;
+      border-radius: .5rem;
+      background: rgb(58 55 55 / 0.336);
+
+      .avatar {
+        img {
+          width: 100%;
+          aspect-ratio: 1;
+          overflow: hidden;
+          object-position: top center;
+          object-fit: cover;
+        }
+      }
+
+      .details {
+        margin: 0 1.5rem 0 1rem;
+        overflow: hidden;
+
+        .title {
+          display: block;
+          font-size: 18px;
+          text-wrap: nowrap;
+          overflow: hidden visible;
+          text-overflow: ellipsis;
+          font-family: var(--ryuutama-font-gothic);
+          margin-bottom: .5rem;
+        }
+
+        .resources {
+          .stamina {
+            margin-bottom: .5rem;
+          }
+        }
+      }
+
+      .controls {
+        position: absolute;
+        inset: 0 0 auto auto;
+        display: flex;
+        flex-direction: row-reverse;
+        text-align: center;
+
+        .control {
+          margin: .5rem;
+
+          .fa-solid {
+            margin: 0;
+          }
+        }
+      }
+    }
+  }
+
+  [data-application-part=details] {
+    overflow: hidden;
+    height: 100%;
+
+    .contents {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      gap: 1rem;
+      display: grid;
+      grid-template-rows: 0fr 1fr;
+      height: 100%;
+    }
+
+    .inputs {
+      display: grid;
+      gap: .5rem;
+    }
+
+    prose-mirror {
+      height: 100%;
+    }
+  }
+}

--- a/templates/sheets/actor/party/details.hbs
+++ b/templates/sheets/actor/party/details.hbs
@@ -1,0 +1,18 @@
+<section data-tab="{{tabs.details.id}}" data-group="{{tabs.details.group}}" class="{{tabs.details.cssClass}}">
+  <div class="contents">
+    <section class="inputs {{#if (or (not details.isOwner) disabled)}} hidden {{/if}}">
+      {{#if (and details.isOwner isPlay)}}
+      {{formGroup fields.name value=source.name rootId=rootId}}
+      {{formGroup fields.img value=source.img rootId=rootId}}
+      {{/if}}
+    </section>
+
+    <section class="description">
+      {{#if isPlay}}
+      {{formInput systemFields.description.fields.value value=details.description.value}}
+      {{else}}
+      {{{details.description.enriched}}}
+      {{/if}}
+    </section>
+  </div>
+</section>

--- a/templates/sheets/actor/party/header.hbs
+++ b/templates/sheets/actor/party/header.hbs
@@ -1,0 +1,15 @@
+<section>
+  <section class="left-controls">
+    <h3 class="title">{{document.name}}</h3>
+    <a data-action="placeMembers" {{disabled (not header.canPlaceMembers)}}>
+      <i class="fa-solid fa-fw fa-bullseye" inert></i>
+      <span>{{localize "DRAW_STEEL.Actor.party.placeMembers"}}</span>
+    </a>
+  </section>
+
+  <section class="middle-controls">
+    <img src="{{document.img}}" alt="{{document.name}}">
+  </section>
+
+  <section class="right-controls"></section>
+</section>

--- a/templates/sheets/actor/party/members.hbs
+++ b/templates/sheets/actor/party/members.hbs
@@ -9,7 +9,8 @@
         <span class="title">{{actor.name}}</span>
 
         <section class="resources">
-          <span>{{stamina.value}} / {{stamina.max}}</span>
+          <span>{{localize "DRAW_STEEL.Actor.party.stamina"}}: {{stamina.value}} / {{stamina.max}}</span>
+          <span>{{localize "DRAW_STEEL.Actor.party.recoveries"}}: {{recoveries.value}} / {{recoveries.max}}</span>
         </section>
       </section>
       <section class="controls">

--- a/templates/sheets/actor/party/members.hbs
+++ b/templates/sheets/actor/party/members.hbs
@@ -1,0 +1,30 @@
+<section data-tab="{{tabs.members.id}}" data-group="{{tabs.members.group}}" class="{{tabs.members.cssClass}}">
+  <div class="contents">
+    {{#each members}}
+    <section class="member" data-member-id="{{actor.id}}">
+      <section class="avatar">
+        <img src="{{actor.img}}" alt="{{actor.name}}">
+      </section>
+      <section class="details">
+        <span class="title">{{actor.name}}</span>
+
+        <section class="resources">
+          <span>{{stamina.value}} / {{stamina.max}}</span>
+        </section>
+      </section>
+      <section class="controls">
+        {{#if @root.isPlay}}
+        <a class="control" data-action="removeMember">
+          <i class="fa-solid fa-fw fa-trash" inert></i>
+        </a>
+        {{/if}}
+        {{#if (and (not @root.isPlay) canView)}}
+        <a class="control" data-action="showMember">
+          <i class="fa-solid fa-fw fa-magnifying-glass" inert></i>
+        </a>
+        {{/if}}
+      </section>
+    </section>
+    {{/each}}
+  </div>
+</section>


### PR DESCRIPTION
Adds a basic party sheet.

### Features
- Show a list of members (heroes) added to the party.
- Button on each member to render their sheet.
- Button on each member (in edit mode) to remove the member.
- Button to place members onto canvas.
- Displays stamina.
- Re-renders every time a hero is added, removed, deleted (without closing the party sheet).
- Re-renders every time a hero is updated (added to their `apps`).
- Depending on the width of the sheet, the left and right controls are grouped on the left or spread evenly beside the avatar of the party.

<img width="645" height="840" alt="image" src="https://github.com/user-attachments/assets/1c90ea38-306c-4554-938b-bcc7acef788d" />

<img width="640" height="826" alt="image" src="https://github.com/user-attachments/assets/ca08e2bb-576f-4e14-829e-458a5e215a7c" />

