### PR TITLE
Refactored release system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,163 +4,70 @@ name: Release Creation
 env:
   NODE_VERSION: 22
 
-
 on:
-  push:
-    tags:
-      - 'release-*'
-
+  release:
+    types: [published]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Load system manifest
-      id: manifest
-      uses: ActionsTools/read-json-action@main
-      with:
-        file_path: "./system.json"
+      # Get part of the tag after the `v`.
+      - name: Extract tag version number
+        id: get_version
+        uses: battila7/get-version-action@v2
 
+      # Modify manifest version, download, esmodules, styles, remove hotreload.
+      - name: Modify Manifest to remove HotReload
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: "system.json"
+        env:
+          flags.hotReload: false
+          version: ${{steps.get_version.outputs.version-without-v}}
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.zip
 
-    # Set up our some variables for future use
-    # Adapted from https://github.community/t/how-to-get-just-the-tag-name/16241/7
-    # Tag name: ${{ env.TAG_NAME }}
-    # Zip name: ${{ env.ZIP_NAME }}
-    # Expected Release Download URL: ${{ env.RELEASE_DOWNLOAD_URL }}
-    # Expected Release system.json URL: ${{ env.RELEASE_INSTALL_URL }}
-    - name: Set up variables
-      id: get_vars
-      run: |
-        TAG=${GITHUB_REF/refs\/tags\//}
-        PACKAGE_ID=${{ steps.manifest.outputs.id }}
-        PACKAGE_TYPE="system"
-        echo "TAG_NAME=$TAG" >> $GITHUB_ENV
-        echo "PACKAGE_ID=$PACKAGE_ID" >> $GITHUB_ENV
-        echo "PACKAGE_TYPE=$PACKAGE_TYPE" >> $GITHUB_ENV
-        echo "ZIP_NAME=$PACKAGE_ID-$TAG.zip" >> $GITHUB_ENV
-        echo "RELEASE_DOWNLOAD_URL=https://github.com/${{ github.repository }}/releases/download/$TAG/$PACKAGE_ID-$TAG.zip" >> $GITHUB_ENV
-        echo "RELEASE_INSTALL_URL=https://github.com/${{ github.repository }}/releases/download/$TAG/$PACKAGE_TYPE.json" >> $GITHUB_ENV
+      # Set up Node
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
 
-    # Run some tests to make sure our `system.json` is correct
-    # Exit before setting up node if not
-    - name: Verify correct naming
-      env:
-        TAG_NAME: ${{ env.TAG_NAME }}
-        RELEASE_DOWNLOAD: ${{ env.RELEASE_DOWNLOAD_URL }}
-        PACKAGE_TYPE: ${{ env.PACKAGE_TYPE }}
-        PACKAGE_VERSION: ${{ steps.manifest.outputs.version }}
-        PACKAGE_DOWNLOAD: ${{ steps.manifest.outputs.download }}
-      run: |
-        # Validate that the tag being released matches the package version.
-        if [[ ! $TAG_NAME == release-$PACKAGE_VERSION ]]; then
-          echo "The $PACKAGE_TYPE.json version does not match tag name."
-          echo "$PACKAGE_TYPE.json: $PACKAGE_VERSION"
-          echo "tag name: $TAG_NAME"
-          echo "Please fix this and push the tag again."
-          exit 1
-        fi
+      # `npm ci` is recommended:
+      # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+      - name: Install Dependencies
+        run: npm ci
 
-        # Validate that the package download url matches the release asset that will be created.
-        if [[ ! $RELEASE_DOWNLOAD == $PACKAGE_DOWNLOAD ]]; then
-          echo "The $PACKAGE_TYPE.json download url does not match the created release asset url."
-          echo "$PACKAGE_TYPE.json: $PACKAGE_DOWNLOAD"
-          echo "release asset url: $RELEASE_DOWNLOAD"
-          echo "Please fix this and push the tag again."
-          exit 1
-        fi
+      # Run build script, leaving out CSS because that's handled by the postInstall script
+      - name: Build All
+        run: |
+          npm run prepareRelease
+          mv --force public/draw-steel.mjs draw-steel.mjs
+          mv --force public/draw-steel.mjs.map draw-steel.mjs.map
+          mv --force public/css/draw-steel-system.css css/draw-steel-system.css
+          mv --force public/css/draw-steel-elements.css css/draw-steel-elements.css
+          mv --force public/css/draw-steel-variables.css css/draw-steel-variables.css
 
+      # Create zip file.
+      - name: Create ZIP archive
+        run: zip -r ./system.zip system.json draw-steel.mjs draw-steel.mjs.map CHANGELOG.md LICENSE.md assets/ css/ lang/ packs/ templates/
 
-    - name: Adjust manifest
-      uses: TomaszKandula/variable-substitution@v1.0.2
-      with:
-        files: "system.json"
-      env:
-        flags.hotReload: false
+      # Create a release for this specific version.
+      - name: Update Release with Files
+        id: create_version_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          name: ${{ github.event.release.name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "./system.json, ./system.zip"
+          tag: ${{ github.event.release.tag_name }}
+          body: |
+            ${{ github.event.release.body }}
 
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
-
-
-    # `npm ci` is recommended:
-    # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-    - name: Install Dependencies
-      run: npm ci
-
-    # Run build script, leaving out CSS because that's handled by the postInstall script
-    - name: Build All
-      run: |
-        npm run prepareRelease
-        mv --force public/draw-steel.mjs draw-steel.mjs
-        mv --force public/draw-steel.mjs.map draw-steel.mjs.map
-        mv --force public/css/draw-steel-system.css css/draw-steel-system.css
-        mv --force public/css/draw-steel-elements.css css/draw-steel-elements.css
-        mv --force public/css/draw-steel-variables.css css/draw-steel-variables.css
-
-
-    - name: Determine archive contents
-      id: archive
-      uses: actions/github-script@v6
-      env:
-        ESMODULES: ${{ steps.manifest.outputs.esmodules }}
-        LANGUAGES: ${{ steps.manifest.outputs.languages }}
-        PACKS: ${{ steps.manifest.outputs.packs }}
-        STYLES: ${{ steps.manifest.outputs.styles }}
-      with:
-        result-encoding: string
-        script: |
-          const manifest = {
-            includes: ["assets/", "templates/", "packs/", "CHANGELOG.md", "LICENSE.md"]
-          };
-          if ( process.env.ESMODULES ) manifest.esmodules = JSON.parse(process.env.ESMODULES);
-          if ( process.env.LANGUAGES ) manifest.languages = JSON.parse(process.env.LANGUAGES);
-          if ( process.env.PACKS ) manifest.packs = JSON.parse(process.env.PACKS);
-          if ( process.env.STYLES ) manifest.styles = JSON.parse(process.env.STYLES);
-          const includes = [
-            "${{ env.PACKAGE_TYPE }}.json",
-            ...(manifest.esmodules ?? []),
-            ...(manifest.esmodules?.map(s => `${s}.map`) ?? []),
-            ...(manifest.styles?.map(s => s.src) ?? []),
-            ...(manifest.languages?.map(l => l.path) ?? []),
-            ...(manifest.includes ?? [])
-          ];
-          return includes.join(" ");
-
-
-    - name: Zip package
-      run: zip ${{ env.ZIP_NAME }} -r ${{ steps.archive.outputs.result }}
-
-
-    - name: Fetch Release Body
-      id: release
-      uses: cardinalby/git-get-release-action@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        tag: ${{ env.TAG_NAME }}
-        doNotFailIfNotFound: true
-
-
-    - name: Update Release with Files
-      id: create_version_release
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: true # Set this to false if you want to prevent updating existing releases
-        name: ${{ env.TAG_NAME }}
-        draft: false
-        prerelease: true
-        omitDraftDuringUpdate: true
-        omitPrereleaseDuringUpdate: true
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './${{ env.PACKAGE_TYPE }}.json, ./${{ env.ZIP_NAME }}'
-        tag: ${{ env.TAG_NAME }}
-        body: |
-          ${{ steps.release.outputs.body }}
-
-          **Installation:** To manually install this release, please use the following manifest URL: ${{ env.RELEASE_INSTALL_URL }}
+            **Installation:** To manually install this release, please use the following manifest URL: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.zip

--- a/system.json
+++ b/system.json
@@ -251,8 +251,8 @@
     }
   ],
   "socket": true,
-  "manifest": "https://raw.githubusercontent.com/MetaMorphic-Digital/draw-steel/refs/heads/main/system.json",
-  "download": "https://github.com/MetaMorphic-Digital/draw-steel/releases/download/release-0.11.0/draw-steel-release-0.11.0.zip",
+  "manifest": "https://github.com/MetaMorphic-Digital/draw-steel/releases/latest/system.json",
+  "download": "",
   "background": "systems/draw-steel/assets/anvil-impact.png",
   "grid": {
     "type": 1,


### PR DESCRIPTION
Refactored our release system
- Manifest now points to releases/latest
- No more "main" branch
- We can now just have a rotating primary branch with archival benefits (keeping 0.11.x after we switch to the 1.0.x branch)