### PR TITLE
Release process tweaks

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -2,9 +2,8 @@ name: Publish wiki
 on:
   workflow_dispatch:
     inputs: {}
-  push:
-    tags:
-      - 'release-*'
+  release:
+    types: [published]
 concurrency:
   group: publish-wiki
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,12 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          name: ${{ github.event.release.name }}
+          omitNameDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: "./system.json, ./system.zip"
           tag: ${{ github.event.release.tag_name }}
+          makeLatest: false
+          prerelease: true
           body: |
             ${{ github.event.release.body }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 
 ### Fixed
 
+- Player-Facing Compendium Data Fixes:
+  - Added "Performance" keyword to the Blocking ability. (#1709)
+  - Removed extraneous characters from "Thunder Mother" story text.
 - Fixed an issue where guaranteed items like the Tactician's "Field Arsenal" did not offer their advancements.
 
 ## 0.10.2


### PR DESCRIPTION
- Changelog updates
- Ensures wiki action runs
- All new releases are automatically flagged to be prereleases / not latest. That status is expected to be a manual switch when we're actually ready for public consumption.