### PR TITLE
Added mentor property to Retainer model

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -850,6 +850,9 @@
             },
             "role": {
               "label": "Creature Role"
+            },
+            "mentor": {
+              "label": "Mentor"
             }
           }
         },

--- a/src/module/applications/apps/retainer-metadata-input.mjs
+++ b/src/module/applications/apps/retainer-metadata-input.mjs
@@ -34,6 +34,10 @@ export default class RetainerMetadataInput extends DocumentInput {
     );
     context.monsterRoles = Object.entries(monsterConfig.roles).map(([value, { label }]) => ({ value, label }));
     context.retainerFields = this.document.system.schema.getField("retainer").fields;
+
+    context.mentorOptions = game.actors.filter(a => (a.type === "hero") && (a.isOwner || (a === this.document.system.retainer.mentor)))
+      .map(a => ({ value: a.id, label: a.name }));
+
     return context;
   }
 }

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -63,6 +63,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
     switch (partId) {
       case "header":
         context.retainerKeywords = this._getRetainerKeywords();
+        context.mentorLink = this.document.system.retainer.mentor?.toAnchor();
         break;
       case "stats":
         context.characteristics = this._getCharacteristics(true);

--- a/src/module/data/actor/party.mjs
+++ b/src/module/data/actor/party.mjs
@@ -21,7 +21,7 @@ export default class PartyModel extends DrawSteelSystemModel {
    * The Actor subtypes allowed as members of a party.
    * @type {Set<string>}
    */
-  static ALLOWED_ACTOR_TYPES = new Set(["hero"]);
+  static ALLOWED_ACTOR_TYPES = new Set(["hero", "retainer"]);
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/actor/retainer.mjs
+++ b/src/module/data/actor/retainer.mjs
@@ -33,6 +33,7 @@ export default class RetainerModel extends CreatureModel {
       freeStrike: requiredInteger({ initial: 0 }),
       keywords: new fields.SetField(setOptions()),
       role: new fields.StringField({ required: true }),
+      mentor: new fields.ForeignDocumentField(foundry.documents.Actor),
     });
 
     schema.recoveries = new fields.SchemaField({

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -54,6 +54,7 @@
     }
     .header-right {
       flex: 0 0 160px;
+      max-width: 160px;
       .actor-source {
         margin-top: 5px;
         font-family: var(--font-h4);
@@ -61,6 +62,17 @@
         flex-grow: 1;
         align-items: start;
         text-align: center;
+      }
+      dd.mentor {
+        /* Padding ensures top of content link is visible */
+        padding-top: 0.2rem;
+        overflow-x: hidden;
+        a.content-link {
+          display: inline-block;
+          max-width: 100%;
+          text-overflow: clip;
+          overflow-x: hidden;
+        }
       }
       div.actor-data > div,
       .malice {

--- a/templates/apps/document-input/retainer-metadata-input.hbs
+++ b/templates/apps/document-input/retainer-metadata-input.hbs
@@ -1,4 +1,5 @@
 <section class="standard-form">
   {{formGroup retainerFields.keywords value=systemSource.retainer.keywords options=monsterKeywords}}
   {{formGroup retainerFields.role value=systemSource.retainer.role options=monsterRoles}}
+  {{formGroup retainerFields.mentor value=systemSource.retainer.mentor options=mentorOptions}}
 </section>

--- a/templates/sheets/actor/retainer-sheet/header.hbs
+++ b/templates/sheets/actor/retainer-sheet/header.hbs
@@ -38,5 +38,11 @@
     <div class="actor-source">
       {{system.source.label}}
     </div>
+    <dl>
+      {{#if mentorLink}}
+      <dt class="level">{{systemFields.retainer.fields.mentor.label}}</dt>
+      <dd class="level">{{{mentorLink.outerHTML}}}</dd>
+      {{/if}}
+    </dl>
   </div>
 </header>

--- a/templates/sheets/actor/retainer-sheet/header.hbs
+++ b/templates/sheets/actor/retainer-sheet/header.hbs
@@ -40,8 +40,8 @@
     </div>
     <dl>
       {{#if mentorLink}}
-      <dt class="level">{{systemFields.retainer.fields.mentor.label}}</dt>
-      <dd class="level">{{{mentorLink.outerHTML}}}</dd>
+      <dt class="mentor">{{systemFields.retainer.fields.mentor.label}}</dt>
+      <dd class="mentor">{{{mentorLink.outerHTML}}}</dd>
       {{/if}}
     </dl>
   </div>


### PR DESCRIPTION
- Added Mentor as a FDF; mentors must be non-synthetic and not inside of a pack, which allows us to use it as `idOnly: false`
- Added retainers as valid party members

<img width="698" height="552" alt="image" src="https://github.com/user-attachments/assets/2c42e978-b6ae-4f25-bd29-7080a9b67e25" />

Styling problem: What to do with characters that have long names? Ellipsis, clip?
<img width="696" height="220" alt="image" src="https://github.com/user-attachments/assets/620d2230-2160-4d6c-b5f8-07400624d169" />
<img width="691" height="242" alt="image" src="https://github.com/user-attachments/assets/85ae1b27-00cf-4dce-92b5-2423a196014a" />

