### PR TITLE
Follower roll API

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1426,6 +1426,10 @@
         "Types": {
           "artisan": "Artisan",
           "sage": "Sage"
+        },
+        "ProjectChoice": {
+          "Title": "Project Choice: {name}",
+          "NoProjects": "No projects of an appropriate type were found to work on."
         }
       },
       "kit": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1429,7 +1429,7 @@
         },
         "ProjectChoice": {
           "Title": "Project Choice: {name}",
-          "NoProjects": "No projects of an appropriate type were found to work on."
+          "NoProjects": "No projects were found to work on."
         }
       },
       "kit": {

--- a/src/module/_types.d.ts
+++ b/src/module/_types.d.ts
@@ -7,7 +7,10 @@ import "./utils/advancement/_types";
 import {
   DrawSteelActor,
   DrawSteelChatMessage,
+  DrawSteelItem,
 } from "./documents/_module.mjs";
+
+import FollowerModel from "./data/item/follower.mjs";
 
 import {
   PowerRoll,
@@ -18,6 +21,10 @@ export interface PowerRollModifiers {
   edges: number;
   banes: number;
   bonuses: number;
+}
+
+export interface ProjectRollOptions extends PowerRollModifiers {
+  follower?: Omit<DrawSteelItem, "system"> & { system: FollowerModel }
 }
 
 export interface PowerRollTargets {
@@ -45,6 +52,10 @@ export interface PowerRollPrompt {
   rollMode: keyof typeof CONFIG["Dice"]["rollModes"];
   baseRoll: PowerRoll;
   rolls: Array <PowerRoll | DrawSteelChatMessage | object>;
+}
+
+export interface ProjectRollPromptOptions extends RollPromptOptions {
+  follower?: Omit<DrawSteelItem, "system"> & { system: FollowerModel }
 }
 
 export interface ProjectRollPrompt {

--- a/src/module/constants.mjs
+++ b/src/module/constants.mjs
@@ -138,14 +138,22 @@ export const potencyStrengths = Object.freeze({
 /* -------------------------------------------------- */
 
 /**
+ * @typedef FollowerType
+ * @property {string} label
+ * @property {Set<string>} projectTypes
+ */
+
+/**
  * Valid follower types for Follower items (excludes Retainer, which is an Actor subtype).
- * @type {Record<string, { label: string }>}
+ * @type {Record<string, FollowerType>}
  */
 export const followerTypes = Object.freeze({
   artisan: {
     label: "DRAW_STEEL.Item.follower.Types.artisan",
+    projectTypes: new Set(["crafting"]),
   },
   sage: {
     label: "DRAW_STEEL.Item.follower.Types.sage",
+    projectTypes: new Set(["research"]),
   },
 });

--- a/src/module/constants.mjs
+++ b/src/module/constants.mjs
@@ -140,7 +140,6 @@ export const potencyStrengths = Object.freeze({
 /**
  * @typedef FollowerType
  * @property {string} label
- * @property {Set<string>} projectTypes
  */
 
 /**
@@ -150,10 +149,8 @@ export const potencyStrengths = Object.freeze({
 export const followerTypes = Object.freeze({
   artisan: {
     label: "DRAW_STEEL.Item.follower.Types.artisan",
-    projectTypes: new Set(["crafting"]),
   },
   sage: {
     label: "DRAW_STEEL.Item.follower.Types.sage",
-    projectTypes: new Set(["research"]),
   },
 });

--- a/src/module/data/item/follower.mjs
+++ b/src/module/data/item/follower.mjs
@@ -191,9 +191,11 @@ export default class FollowerModel extends BaseItemModel {
   async roll(options = {}) {
     if (!this.actor) throw new Error("Only followers with a hero can ");
     if (!options.project) {
-      const projectOptions = this.actor.itemTypes.project
-        .filter(p => ds.CONST.followerTypes[this.type].projectTypes.has(p.system.type))
-        .map(p => ({ value: p.id, label: p.name }));
+      const projectOptions = this.actor.itemTypes.project.map(p => ({
+        value: p.id,
+        label: p.name,
+        group: ds.CONFIG.projects.types[p.system.type]?.label,
+      }));
 
       if (!projectOptions.length) {
         ui.notifications.error("DRAW_STEEL.Item.follower.ProjectChoice.NoProjects", { localize: true });

--- a/src/module/data/item/follower.mjs
+++ b/src/module/data/item/follower.mjs
@@ -3,6 +3,10 @@ import enrichHTML from "../../utils/enrich-html.mjs";
 import { setOptions } from "../helpers.mjs";
 import { systemPath } from "../../constants.mjs";
 
+/**
+ * @import DrawSteelItem from "../../documents/item.mjs";
+ */
+
 const fields = foundry.data.fields;
 
 /**
@@ -175,5 +179,55 @@ export default class FollowerModel extends BaseItemModel {
       return v.value;
     });
     rollData.item.chr = Math.max(...chars);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform a characteristic roll to assist a project.
+   * @param {object} options
+   * @param {DrawSteelItem} [options.project] A specific project to roll for.
+   */
+  async roll(options = {}) {
+    if (!this.actor) throw new Error("Only followers with a hero can ");
+    if (!options.project) {
+      const projectOptions = this.actor.itemTypes.project
+        .filter(p => ds.CONST.followerTypes[this.type].projectTypes.has(p.system.type))
+        .map(p => ({ value: p.id, label: p.name }));
+
+      if (!projectOptions.length) {
+        ui.notifications.error("DRAW_STEEL.Item.follower.ProjectChoice.NoProjects", { localize: true });
+        return;
+      }
+
+      const content = document.createElement("div");
+
+      const { createFormGroup, createSelectInput } = foundry.applications.fields;
+
+      const projectInput = createFormGroup({
+        label: "TYPES.Item.project",
+        input: createSelectInput({
+          name: "project",
+          options: projectOptions,
+        }),
+        localize: true,
+      });
+
+      content.append(projectInput);
+
+      const fd = await ds.applications.api.DSDialog.input({
+        content,
+        window: {
+          title: game.i18n.format("DRAW_STEEL.Item.follower.ProjectChoice.Title", { name: this.parent.name }),
+          icon: "fa-solid fa-diagram-project",
+        },
+      });
+
+      if (!fd) return;
+
+      options.project = this.actor.items.get(fd.project);
+    }
+
+    return options.project.system.roll({ follower: this.parent });
   }
 }

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -8,7 +8,7 @@ import { setOptions } from "../helpers.mjs";
 
 /**
  * @import { DocumentHTMLEmbedConfig, EnrichmentOptions } from "@client/applications/ux/text-editor.mjs";
- * @import { PowerRollModifiers } from  "../../_types.js"
+ * @import { ProjectRollOptions } from  "../../_types.js"
  */
 
 const fields = foundry.data.fields;
@@ -63,22 +63,6 @@ export default class ProjectModel extends BaseItemModel {
     this.points ??= 0;
 
     this.projectType = game.i18n.localize(ds.CONFIG.projects.types[this.type]?.label ?? "");
-  }
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  preparePostActorPrepData() {
-    super.preparePostActorPrepData();
-
-    // Set the highest characteristic amongst the roll characteristics
-    this.characteristic = null;
-    for (const characteristic of this.rollCharacteristic) {
-      if (this.characteristic === null) this.characteristic = characteristic;
-
-      const actorCharacteristics = this.actor.system.characteristics;
-      if (actorCharacteristics[characteristic].value > actorCharacteristics[this.characteristic].value) this.characteristic = characteristic;
-    }
   }
 
   /* -------------------------------------------------- */
@@ -192,7 +176,7 @@ export default class ProjectModel extends BaseItemModel {
 
   /**
    * Make a project roll for this project and update the project points progress.
-   * @param {Partial<PowerRollModifiers>} [options={}]
+   * @param {Partial<ProjectRollOptions>} [options={}]
    * @returns {Promise<DrawSteelChatMessage | null>}
    */
   async roll(options = {}) {
@@ -249,20 +233,30 @@ export default class ProjectModel extends BaseItemModel {
 
   /**
    * Prompt the player to roll this project.
-   * @param {Partial<PowerRollModifiers>} [options={}]
+   * @param {Partial<ProjectRollOptions>} [options={}]
    * @returns {ProjectRollPrompt}
    */
   async rollPrompt(options = {}) {
-    const rollData = this.parent.getRollData();
-    const rollKey = ds.CONFIG.characteristics[this.characteristic]?.rollKey ?? "";
+    const rollData = options.follower ? options.follower.getRollData() : this.parent.getRollData();
+
+    // Pick the highest characteristic amongst the roll characteristics
+    let chr = null;
+    const characteristicData = options.follower?.system.characteristics ?? this.actor.system.characteristics;
+    for (const characteristic of this.rollCharacteristic) {
+      if (chr === null) chr = characteristic;
+      else if (characteristicData[characteristic].value > characteristicData[chr].value) chr = characteristic;
+    }
+
+    const rollKey = ds.CONFIG.characteristics[chr]?.rollKey ?? "";
+    const rollFormula = rollKey && options.follower ? `item.${rollKey}` : rollKey;
 
     const promptValue = await ProjectRoll.prompt({
-      formula: rollKey ? `2d10 + @${rollKey}` : "2d10",
+      follower: options.follower,
+      formula: rollKey ? `2d10 + @${rollFormula}` : "2d10",
       modifiers: options.modifiers ?? {},
       actor: this.actor,
       evaluation: "evaluate",
       data: rollData,
-      skillModifiers: this.actor?.system.skills?.modifiers ?? {},
     });
 
     return promptValue;

--- a/src/module/helpers/macros.mjs
+++ b/src/module/helpers/macros.mjs
@@ -18,6 +18,7 @@ export async function createDocMacro(data, slot) {
   let name;
   switch (item.type) {
     case "ability":
+    case "follower":
     case "project":
       command = `ds.helpers.macros.rollItemMacro("${data.uuid}");`;
       name = item.name;

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -3,7 +3,7 @@ import DrawSteelChatMessage from "../documents/chat-message.mjs";
 import PowerRollDialog from "../applications/apps/power-roll-dialog.mjs";
 import { systemPath } from "../constants.mjs";
 
-/** @import { RollPromptOptions, ProjectRollPrompt } from "../_types.js" */
+/** @import { ProjectRollPromptOptions, ProjectRollPrompt } from "../_types.js" */
 
 /**
  * A special test a hero makes while working on a downtime project during a respite.
@@ -78,7 +78,7 @@ export default class ProjectRoll extends DSRoll {
 
   /**
    * Prompt the user with a roll configuration dialog.
-   * @param {Partial<RollPromptOptions>} [options]
+   * @param {Partial<ProjectRollPromptOptions>} [options]
    * @returns {Promise<ProjectRollPrompt | null>}
    */
   static async prompt(options = {}) {
@@ -87,12 +87,13 @@ export default class ProjectRoll extends DSRoll {
     if (!["none", "evaluate", "message"].includes(evaluation)) {
       throw new Error("The `evaluation` parameter must be 'none', 'evaluate', or 'message'");
     }
-    const flavor = options.flavor ?? game.i18n.localize("DRAW_STEEL.ROLL.Project.Label");
+    const flavor = options.flavor ?? options.follower ? options.follower.name : game.i18n.localize("DRAW_STEEL.ROLL.Project.Label");
     options.modifiers ??= {};
     options.modifiers.edges ??= 0;
     options.modifiers.banes ??= 0;
     options.modifiers.bonuses ??= 0;
-    options.skills ??= options.actor?.system.skills?.value ?? null;
+    options.skills ??= (options.follower ?? options.actor)?.system.skills?.value ?? null;
+    options.skillModifiers ??= (options.follower ?? options.actor)?.system.skills?.modifiers ?? {};
 
     const context = {
       modifiers: options.modifiers,


### PR DESCRIPTION
Basic implementation of a follower roll API. We may want to break it up a bit if we want to enable non-project rolls from followers, but the primary purpose of Artisans and Sages is they make project rolls when the hero is away from home.

> An artisan can contribute one project roll per day to a downtime project you choose, whether you spend those days in respite, adventuring, or other activities. They must remain at your stronghold or at the site where the project is undertaken, and must have access to the necessary materials.