### PR TITLE
[#637] Added surge option to Modify Damage dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Added new "Retainer" actor type. (#155)
   - Added "Encounter" keyword. (This does not yet include tracking the usage)
+- Added surge expenditure to the "Modify Damage Roll" chat context option for ability results.
 - Added new "Follower" item type for Artisans and Sages. (#679)
 - Added a "Share Item" button to the item sheet header controls. (#1505)
 - Added a "Party" actor which can be designated as the primary party.

--- a/lang/en.json
+++ b/lang/en.json
@@ -2179,6 +2179,10 @@
           },
           "DamageModificationDialog": {
             "Title": "Modify Damage Roll",
+            "Surges": {
+              "label": "Surges",
+              "hint": "Each surge adds {damage} damage."
+            },
             "AdditionalTerms": {
               "label": "Additional Terms",
               "hint": "Additional roll terms to add to the damage roll. (e.g. 1d3)"

--- a/src/module/data/pseudo-documents/message-parts/ability-result.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-result.mjs
@@ -226,6 +226,7 @@ export default class AbilityResultPart extends RollPart {
         hint: game.i18n.format("DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Surges.hint", { damage: surgeDamage }),
         input: createNumberInput({ name: "surges", step: 1, min: 0, max: surgeMax }),
         localize: true,
+        classes: ["slim"],
       });
 
       content.append(surges);

--- a/src/module/data/pseudo-documents/message-parts/ability-result.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-result.mjs
@@ -10,7 +10,7 @@ import { systemPath } from "../../../constants.mjs";
  */
 
 const { DocumentUUIDField, NumberField } = foundry.data.fields;
-const { createFormGroup, createSelectInput, createTextInput } = foundry.applications.fields;
+const { createFormGroup, createNumberInput, createSelectInput, createTextInput } = foundry.applications.fields;
 
 /**
  * A part that displays the result of an ability power roll and its consequences.
@@ -211,6 +211,26 @@ export default class AbilityResultPart extends RollPart {
   async modifyDamageDialog(roll) {
     const content = document.createElement("div");
 
+    let sourceActor = this.ability?.actor;
+
+    // Retainers use their mentor's surges and surge value
+    if (sourceActor.type === "retainer") sourceActor = sourceActor.system.retainer.mentor;
+
+    const surgeDamage = sourceActor.getRollData()?.chr;
+
+    if (sourceActor.type === "hero") {
+      const surgeMax = Math.min(3, sourceActor.system.hero.surges);
+
+      const surges = createFormGroup({
+        label: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Surges.label",
+        hint: game.i18n.format("DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Surges.hint", { damage: surgeDamage }),
+        input: createNumberInput({ name: "surges", step: 1, min: 0, max: surgeMax }),
+        localize: true,
+      });
+
+      content.append(surges);
+    }
+
     const additionalTermGroup = createFormGroup({
       label: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.AdditionalTerms.label",
       hint: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.AdditionalTerms.hint",
@@ -245,8 +265,16 @@ export default class AbilityResultPart extends RollPart {
 
     // If the dialog is closed or submitted without modifications, don't create a new roll.
     if (!modifications) return;
-    if ((modifications.additionalTerms === "") && (modifications.damageType === roll.options.type)) return;
 
-    this.createModifiedDamageRoll(roll, modifications);
+    if (modifications.surges) {
+      await sourceActor.modifyTokenAttribute("hero.surges", -1 * modifications.surges, true, false);
+      if (modifications.additionalTerms) modifications.additionalTerms += `+ ${modifications.surges} * ${surgeDamage}`;
+      else modifications.additionalTerms = `${modifications.surges} * ${surgeDamage}`;
+      delete modifications.surges;
+    }
+
+    if ((!modifications.additionalTerms) && (modifications.damageType === roll.options.type)) return;
+
+    return this.createModifiedDamageRoll(roll, modifications);
   }
 }


### PR DESCRIPTION
Previous API and UI work made this a very simple thing to add in.

<img width="408" height="344" alt="image" src="https://github.com/user-attachments/assets/6fe252f6-94b2-4de6-8041-187146753995" />

Closes #637