### PR TITLE
Primary Party initialization

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -837,8 +837,7 @@
         },
         "placeMembers": "Place Members",
         "stamina": "Stamina",
-        "recoveries": "Recoveries",
-        "primary": "Primary Party"
+        "recoveries": "Recoveries"
       },
       "retainer": {
         "FIELDS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -837,7 +837,8 @@
         },
         "placeMembers": "Place Members",
         "stamina": "Stamina",
-        "recoveries": "Recoveries"
+        "recoveries": "Recoveries",
+        "primary": "Primary Party"
       },
       "retainer": {
         "FIELDS": {

--- a/src/module/data/actor/party.mjs
+++ b/src/module/data/actor/party.mjs
@@ -67,6 +67,15 @@ export default class PartyModel extends DrawSteelSystemModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+
+    if (game.user.isActiveGM && !game.actors.party) game.actors.setParty(this.parent);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   prepareBaseData() {
     super.prepareBaseData();
 

--- a/src/module/data/migrations.mjs
+++ b/src/module/data/migrations.mjs
@@ -19,7 +19,8 @@ export async function migrateWorld() {
   let updateVersion = false;
   if (!migrationVersion) {
     // New world - initialize the migration version and rename Gamemaster to Director
-    await game.users.activeGM.update({ name: game.i18n.localize("USER.RoleGamemaster") });
+    if (game.user.name === "Gamemaster") await game.user.update({ name: game.i18n.localize("USER.RoleGamemaster") });
+    await createPrimaryParty();
     updateVersion = true;
   }
   else {
@@ -132,6 +133,10 @@ async function version_0_11_migration() {
     if (wasLocked) await pack.configure({ locked: true });
   }
 
+  warning.update({ pct: 0.95 });
+
+  await createPrimaryParty();
+
   warning.update({ pct: 1.00 });
 
   ui.notifications.remove(warning);
@@ -206,4 +211,19 @@ function shouldMigrateCompendium(pack) {
   // Module compendiums should only be migrated if they don't have a download or manifest URL
   const module = game.modules.get(pack.metadata.packageName);
   return !module.download && !module.manifest;
+}
+
+/**
+ * Create a party actor and mark it as the primary actor.
+ */
+export async function createPrimaryParty() {
+  const party = await getDocumentClass("Actor").create({
+    name: game.i18n.localize("DRAW_STEEL.Actor.party.primary"),
+    type: "party",
+    img: "icons/magic/symbols/chevron-elipse-circle-blue.webp",
+  });
+
+  await party.system.addMembers(game.actors.filter(a => a.type === "hero"));
+
+  return game.actors.setParty(party);
 }

--- a/src/module/data/migrations.mjs
+++ b/src/module/data/migrations.mjs
@@ -20,7 +20,6 @@ export async function migrateWorld() {
   if (!migrationVersion) {
     // New world - initialize the migration version and rename Gamemaster to Director
     if (game.user.name === "Gamemaster") await game.user.update({ name: game.i18n.localize("USER.RoleGamemaster") });
-    await createPrimaryParty();
     updateVersion = true;
   }
   else {
@@ -133,10 +132,6 @@ async function version_0_11_migration() {
     if (wasLocked) await pack.configure({ locked: true });
   }
 
-  warning.update({ pct: 0.95 });
-
-  await createPrimaryParty();
-
   warning.update({ pct: 1.00 });
 
   ui.notifications.remove(warning);
@@ -211,19 +206,4 @@ function shouldMigrateCompendium(pack) {
   // Module compendiums should only be migrated if they don't have a download or manifest URL
   const module = game.modules.get(pack.metadata.packageName);
   return !module.download && !module.manifest;
-}
-
-/**
- * Create a party actor and mark it as the primary actor.
- */
-export async function createPrimaryParty() {
-  const party = await getDocumentClass("Actor").create({
-    name: game.i18n.localize("DRAW_STEEL.Actor.party.primary"),
-    type: "party",
-    img: "icons/magic/symbols/chevron-elipse-circle-blue.webp",
-  });
-
-  await party.system.addMembers(game.actors.filter(a => a.type === "hero"));
-
-  return game.actors.setParty(party);
 }


### PR DESCRIPTION
- Added check for renaming logic on Gamemaster => Director, in anticipation of v14 start screen changes
- Migration now creates a primary party in new games and with 0.11 migration