### PR TITLE
Fix blink not being properly deleted. Add DataFieldOperator types.

### DIFF
--- a/draw-steel.d.ts
+++ b/draw-steel.d.ts
@@ -24,4 +24,12 @@ declare global {
    * The singleton game canvas.
    */
   const canvas: Canvas;
+  /**
+   * A singleton ForcedDeletion operator instance that can be reused.
+   */
+  const _del: foundry.data.operators.ForcedDeletion;
+  /**
+   * A reference for ForcedReplacement.create that can be easily referenced.
+   */
+  const _replace = foundry.data.operators.ForcedReplacement.create;
 }

--- a/draw-steel.d.ts
+++ b/draw-steel.d.ts
@@ -1,5 +1,6 @@
 import "./src/module/_types";
 import "@client/global.mjs";
+import "@common/global.mjs";
 import "@common/primitives/global.mjs";
 import Canvas from "@client/canvas/board.mjs";
 
@@ -24,12 +25,4 @@ declare global {
    * The singleton game canvas.
    */
   const canvas: Canvas;
-  /**
-   * A singleton ForcedDeletion operator instance that can be reused.
-   */
-  const _del: foundry.data.operators.ForcedDeletion;
-  /**
-   * A reference for ForcedReplacement.create that can be easily referenced.
-   */
-  const _replace = foundry.data.operators.ForcedReplacement.create;
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,8 @@ export default defineConfig([
         fromUuid: "readonly",
         fromUuidSync: "readonly",
         getDocumentClass: "readonly",
+        _del: "readonly",
+        _replace: "readonly",
       },
 
       ecmaVersion: "latest",

--- a/src/module/canvas/placeables/tokens/token-ruler.mjs
+++ b/src/module/canvas/placeables/tokens/token-ruler.mjs
@@ -24,7 +24,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
     const teleport = { ...CONFIG.Token.movement.actions.blink, label: "TOKEN.MOVEMENT.ACTIONS.teleport.label" };
     // Optional chaining on canSelect until https://github.com/foundryvtt/foundryvtt/issues/12603 is resolved
     foundry.utils.mergeObject(CONFIG.Token.movement.actions, {
-      "-=blink": null,
+      blink: _del,
       teleport,
       /** @type {TokenMovementActionConfig} */
       climb: {
@@ -60,7 +60,7 @@ export default class DrawSteelTokenRuler extends foundry.canvas.placeables.token
       walk: {
         canSelect: (token) => !(token instanceof foundry.documents.TokenDocument) || !token.hasStatusEffect("prone"),
       },
-    }, { performDeletions: true });
+    }, { applyOperators: true });
   }
 
   /* -------------------------------------------------- */


### PR DESCRIPTION
Blink wasn't properly being deleted from the movement actions, so it was erroring out. This prevented loading in V14.

Added the typings for the `DataFieldOperator` shorthands, `_del` and `_replace`. Pretty that's correct.