### PR TITLE
Add a defeated minion selection dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This version of the system does not support v13, it is exclusively for Foundry v
 - New Player-Facing Compendium Content:
 - New Director-Facing Compendium Content:
   - Added common effects like Burning, Marked, Petrified, and Wet. (#552, #1254)
+- Added a dialog for marking minions as defeated once a squads stamina thresholds have been met. (#662)
 - Created an "Effects and Imbues" compendium pack. (#1163)
 - Added Draw Steel inserts to the "Custom" section of prosemirror, allowing users to easily format their text with system-specific html. (#1267)
 - Updated formula fields to use the new core `HTMLFormulaInputElement`. (#1501)

--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -11,6 +11,7 @@
 @import url("../src/styles/system/applications/apps/advancement/item-grant-configuration-dialog.css");
 
 @import url("../src/styles/system/applications/apps/characteristic-input.css");
+@import url("../src/styles/system/applications/apps/defeated-minion-selection.css");
 @import url("../src/styles/system/applications/apps/monster-metadata.css");
 @import url("../src/styles/system/applications/apps/power-roll-dialog.css");
 @import url("../src/styles/system/applications/apps/saving-throw-dialog.css");

--- a/lang/en.json
+++ b/lang/en.json
@@ -911,6 +911,10 @@
         "ResetSurgeResources": {
           "label": "Reset Surges"
         }
+      },
+      "DefeatedMinionSelection": {
+        "Title": "Defeated Minion Selection",
+        "Header": "Choose {number} minion(s) to mark as defeated"
       }
     },
     "Combatant": {

--- a/src/module/applications/apps/_module.mjs
+++ b/src/module/applications/apps/_module.mjs
@@ -10,5 +10,6 @@ export { default as SavingThrowDialog } from "./saving-throw-dialog.mjs";
 export { default as SavingThrowManager } from "./saving-throw-manager.mjs";
 export { default as TargetedConditionPrompt } from "./targeted-condition-prompt.mjs";
 export { default as CompendiumTOCConfig } from "./toc-config.mjs";
+export { default as DefeatedMinionSelection } from "./defeated-minion-selection.mjs";
 
 export * as advancement from "./advancement/_module.mjs";

--- a/src/module/applications/apps/defeated-minion-selection.mjs
+++ b/src/module/applications/apps/defeated-minion-selection.mjs
@@ -1,0 +1,150 @@
+import DSApplication from "../api/application.mjs";
+import { systemPath } from "../../constants.mjs";
+
+/**
+ * @import DrawSteelToken from "../../canvas/placeables/token.mjs";
+ * @import ApplicationRenderContext from "@client/applications/_types.mjs";
+ */
+
+/**
+ * Prompt application for selecting defeated minions once a threshold has been reached.
+ */
+export default class DefeatedMinionSelection extends DSApplication {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["defeated-minion-selection"],
+    window: {
+      title: "DRAW_STEEL.Combat.DefeatedMinionSelection.Title",
+      icon: "fa-solid fa-skull",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    header: {
+      template: systemPath("templates/apps/defeated-minion-selection/header.hbs"),
+    },
+    minions: {
+      template: systemPath("templates/apps/defeated-minion-selection/minions.hbs"),
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _initializeApplicationOptions({ document, ...options }) {
+    options = super._initializeApplicationOptions(options);
+    options.uniqueId = `${this.constructor.name}-${options.context.squad.uuid.replaceAll(".", "-")}`;
+    return options;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The currently highlighted minion's token.
+   * @type {DrawSteelToken}
+   */
+  #highlighted = null;
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.needToDefeat = this.options.context.needToDefeat;
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+
+    switch (partId) {
+      case "minions":
+        await this._prepareMinionsContext(context);
+        break;
+      case "footer":
+        context.buttons = [{ type: "submit", label: "COMMON.Confirm", icon: "fa-solid fa-fw fa-check" }];
+        break;
+    }
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare the selected and disabled data for each minion.
+   * @param {ApplicationRenderContext} context       Shared context provided by _preparePartContext, will be mutated.
+   */
+  async _prepareMinionsContext(context) {
+    context.undefeatedMinions = [];
+    const ctx = this.options.context;
+    const selectedMinions = ctx.selected ?? [];
+    const maxedSelections = selectedMinions.length >= ctx.needToDefeat;
+    for (const minion of ctx.undefeated) {
+      const selected = selectedMinions.includes(minion.id) ?? false;
+      context.undefeatedMinions.push({
+        minion,
+        selected,
+        disabled: !selected && maxedSelections,
+      });
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _attachFrameListeners() {
+    super._attachFrameListeners();
+
+    // Hover In
+    this.element.addEventListener("pointerover", (event) => {
+      const { combatantId } = event.target.closest(".combatant[data-combatant-id]")?.dataset ?? {};
+      if (!canvas.ready || !combatantId) return;
+      const combatant = this.options.context.combat.combatants.get(combatantId);
+      const token = combatant.token?.object;
+      if (token && token._canHover(game.user, event) && token.visible) {
+        token._onHoverIn(event, { hoverOutOthers: true });
+        this.#highlighted = token;
+      }
+    }, { passive: true });
+
+    // Hover Out
+    this.element.addEventListener("pointerout", (event) => {
+      this.#highlighted?._onHoverOut(event);
+      this.#highlighted = null;
+    }, { passive: true });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Amend the currently selected minions based on form data.
+   * @inheritdoc
+   */
+  _onChangeForm(formConfig, event) {
+    super._onChangeForm(formConfig, event);
+
+    const formData = foundry.utils.expandObject(new foundry.applications.ux.FormDataExtended(this.element).object);
+    const selection = Array.isArray(formData["minion-selection"]) ? formData["minion-selection"] : [formData["minion-selection"]];
+    this.options.context.selected = selection.filter(_ => _);
+
+    this.render({ parts: ["minions"] });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _processFormData(event, form, formData, submitOptions) {
+    return { selectedMinions: this.options.context.selected ?? [] };
+  }
+}

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -90,7 +90,10 @@ export default class SquadModel extends BaseCombatantGroupModel {
   _onUpdate(changed, options, userId) {
     super._onUpdate(changed, options, userId);
 
-    if (changed.system && ("staminaValue" in changed.system)) this.refreshSquad();
+    if (changed.system && ("staminaValue" in changed.system)) {
+      this.refreshSquad();
+      this.checkDefeatedMinions();
+    }
     if (options.ds?.staminaDiff) this.displayMinionStaminaChange(options.ds.staminaDiff, options.ds.damageType);
   }
 
@@ -115,5 +118,32 @@ export default class SquadModel extends BaseCombatantGroupModel {
     super._onDelete(options, userId);
 
     this.refreshSquad();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Determine if any minions should be defeated based on stamina value and threshold and prompt the active owner to mark them as defeated.
+   */
+  async checkDefeatedMinions() {
+    const minions = this.minions;
+    if (!minions.size) return;
+
+    const activePlayerOwner = game.users.find(user => !user.isGM && user.active && this.parent.testUserPermission(user, "OWNER") && this.minions.every(minion => minion.testUserPermission(user, "OWNER")));
+    const promptedUser = activePlayerOwner ?? game.users.activeGM;
+    if (game.user !== promptedUser) return;
+
+    const { defeated = [], undefeated = [] } = Object.groupBy(minions, minion => minion.defeated ? "defeated" : "undefeated");
+    const staminaPerMinion = foundry.utils.getProperty(minions.first().actor, "system.stamina.max") ?? 0;
+    const shouldBeDefeated = Math.clamp(minions.size - Math.ceil(this.staminaValue / staminaPerMinion), 0, minions.size);
+    const needToDefeat = shouldBeDefeated - defeated.length;
+    // Only prompt if the number of minions that need to be defeated exceeds 0.
+    if (needToDefeat <= 0) return;
+
+    const fd = await ds.applications.apps.DefeatedMinionSelection.create({ context: { undefeated, needToDefeat, combat: this.combat, squad: this.parent } });
+    if (!fd || !fd.selectedMinions.length) return;
+
+    const selectedMinions = fd.selectedMinions.map(id => this.combat.combatants.get(id));
+    for (const minion of selectedMinions) ui.combat._onToggleDefeatedStatus(minion);
   }
 }

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -131,7 +131,7 @@ export default class SquadModel extends BaseCombatantGroupModel {
 
     const activePlayerOwner = game.users.find(user => !user.isGM && user.active && this.parent.testUserPermission(user, "OWNER") && minions.every(minion => minion.testUserPermission(user, "OWNER")));
     const promptedUser = activePlayerOwner ?? game.users.activeGM;
-    if (game.user !== promptedUser) return;
+    if (!promptedUser?.isSelf) return;
 
     const { defeated = [], undefeated = [] } = Object.groupBy(minions, minion => minion.defeated ? "defeated" : "undefeated");
     const staminaPerMinion = foundry.utils.getProperty(minions.first().actor, "system.stamina.max") ?? 0;

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -129,7 +129,7 @@ export default class SquadModel extends BaseCombatantGroupModel {
     const minions = this.minions;
     if (!minions.size) return;
 
-    const activePlayerOwner = game.users.find(user => !user.isGM && user.active && this.parent.testUserPermission(user, "OWNER") && this.minions.every(minion => minion.testUserPermission(user, "OWNER")));
+    const activePlayerOwner = game.users.find(user => !user.isGM && user.active && this.parent.testUserPermission(user, "OWNER") && minions.every(minion => minion.testUserPermission(user, "OWNER")));
     const promptedUser = activePlayerOwner ?? game.users.activeGM;
     if (game.user !== promptedUser) return;
 
@@ -144,6 +144,11 @@ export default class SquadModel extends BaseCombatantGroupModel {
     if (!fd || !fd.selectedMinions.length) return;
 
     const selectedMinions = fd.selectedMinions.map(id => this.combat.combatants.get(id));
-    for (const minion of selectedMinions) ui.combat._onToggleDefeatedStatus(minion);
+    const combatantUpdates = [];
+    for (const minion of selectedMinions) {
+      combatantUpdates.push({ _id: minion.id, defeated: true });
+      await minion.actor?.toggleStatusEffect(CONFIG.specialStatusEffects.DEFEATED, { overlay: true, active: true });
+    }
+    await this.combat.updateEmbeddedDocuments("Combatant", combatantUpdates);
   }
 }

--- a/src/styles/system/applications/apps/defeated-minion-selection.css
+++ b/src/styles/system/applications/apps/defeated-minion-selection.css
@@ -1,0 +1,11 @@
+.draw-steel.defeated-minion-selection {
+  h4 {
+    margin-bottom: 0;
+  }
+
+  .combatant {
+    display: grid;
+    grid-template-columns: 50px 1fr auto;
+    align-items: center;
+  }
+}

--- a/src/styles/system/applications/apps/defeated-minion-selection.css
+++ b/src/styles/system/applications/apps/defeated-minion-selection.css
@@ -5,7 +5,13 @@
 
   .combatant {
     display: grid;
-    grid-template-columns: 50px 1fr auto;
+    grid-template-columns: 1fr auto;
     align-items: center;
+
+    label {
+      display: grid;
+      grid-template-columns: 50px 1fr;
+      align-items: center;
+    }
   }
 }

--- a/templates/apps/defeated-minion-selection/header.hbs
+++ b/templates/apps/defeated-minion-selection/header.hbs
@@ -1,0 +1,3 @@
+<section>
+  <h4>{{localize "DRAW_STEEL.Combat.DefeatedMinionSelection.Header" number=needToDefeat}}</h4>
+</section>

--- a/templates/apps/defeated-minion-selection/minions.hbs
+++ b/templates/apps/defeated-minion-selection/minions.hbs
@@ -1,9 +1,11 @@
 <section>
   {{#each undefeatedMinions}}
   <div class="combatant" data-combatant-id="{{minion.id}}">
-    <img alt="{{minion.name}}" src="{{minion.img}}">
-    <span>{{minion.name}}</span>
-    <input type="checkbox" name="minion-selection" value="{{minion.id}}" {{checked selected}} {{disabled disabled}}>
+    <label for="{{minion.id}}">
+      <img alt="{{minion.name}}" src="{{minion.img}}">
+      <span>{{minion.name}}</span>
+    </label>
+    <input type="checkbox" name="minion-selection" id="{{minion.id}}" value="{{minion.id}}" {{checked selected}} {{disabled disabled}}>
   </div>
   {{/each}}
 </section>

--- a/templates/apps/defeated-minion-selection/minions.hbs
+++ b/templates/apps/defeated-minion-selection/minions.hbs
@@ -1,0 +1,9 @@
+<section>
+  {{#each undefeatedMinions}}
+  <div class="combatant" data-combatant-id="{{minion.id}}">
+    <img alt="{{minion.name}}" src="{{minion.img}}">
+    <span>{{minion.name}}</span>
+    <input type="checkbox" name="minion-selection" value="{{minion.id}}" {{checked selected}} {{disabled disabled}}>
+  </div>
+  {{/each}}
+</section>


### PR DESCRIPTION
I think this would be a good solution for #662. Forgetting to mark minions as defeated is a problem I've consistently had, so a reminder/prompt would be a big boon in my games.

When a minion squad is damaged, if the threshold to kill a minion is reached, a dialog will spawn for the active owner (prioritizing player if applicable). It will have a list of non-defeated minions to select, limiting to the number of minions that need to be defeated. Possible improvement to this would be indicated which of the minions are currently controlled to easily indicate which ones were selected when damaged.


Demo:
https://github.com/user-attachments/assets/68d61435-1aed-4279-91be-fe951d1eb2ae

