### PR TITLE
[#1161] Define custom elements in detached windows; swap uses of `document` to `HTMLElement#ownerDocument`

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -10,29 +10,35 @@ import * as rolls from "./src/module/rolls/_module.mjs";
 import * as utils from "./src/module/utils/_module.mjs";
 
 globalThis.ds = {
+  applications,
   canvas,
   compatibility,
+  data,
   documents,
-  applications,
   helpers,
   rolls,
-  data,
   utils,
-  CONST: DS_CONST,
   CONFIG: DS_CONFIG,
+  CONST: DS_CONST,
   registry: new helpers.DrawSteelRegistry(),
 };
 
-// Register custom elements.
-for (const element of Object.values(applications.elements)) {
-  window.customElements.define(element.tagName, element);
-}
+/* -------------------------------------------------- */
+/*   Init Hook                                        */
+/* -------------------------------------------------- */
 
 Hooks.once("init", function () {
   CONFIG.DRAW_STEEL = DS_CONFIG;
   game.system.socketHandler = new helpers.DrawSteelSocketHandler();
   helpers.DrawSteelSettingsHandler.registerSettings();
   applications.apps.DocumentSourceInput.addModuleSources();
+
+  // Define custom elements.
+  const defineElements = window => {
+    window.customElements.define(applications.elements.DSIconElement.tagName, applications.elements.DSIconElement);
+  };
+  defineElements(window);
+  Hooks.on("openDetachedWindow", (id, window) => defineElements(window));
 
   // Assign document classes
   for (const docCls of Object.values(documents)) {
@@ -224,10 +230,12 @@ Hooks.once("init", function () {
   helpers.registerHandlebars();
 });
 
-/**
- * Perform one-time pre-localization and sorting of some configuration objects.
- */
+/* -------------------------------------------------- */
+/*   I18n Hook                                        */
+/* -------------------------------------------------- */
+
 Hooks.once("i18nInit", () => {
+  // Perform one-time pre-localization and sorting of some configuration objects.
   helpers.localization.performPreLocalization(CONFIG.DRAW_STEEL);
 
   // These fields are not auto-localized due to having a different location in en.json
@@ -274,6 +282,10 @@ Hooks.once("i18nInit", () => {
   localizePseudos(data.pseudoDocuments.advancements.BaseAdvancement.TYPES);
 });
 
+/* -------------------------------------------------- */
+/*   Setup Hook                                       */
+/* -------------------------------------------------- */
+
 Hooks.once("setup", () => {
   applications.sidebar.apps.DrawSteelCompendiumTOC.applyToPacks();
 
@@ -307,9 +319,9 @@ Hooks.once("setup", () => {
   }
 });
 
-/* -------------------------------------------- */
-/*  Ready Hook                                  */
-/* -------------------------------------------- */
+/* -------------------------------------------------- */
+/*   Ready Hook                                       */
+/* -------------------------------------------------- */
 
 Hooks.once("ready", async function () {
   game.tooltip.observe();
@@ -328,15 +340,17 @@ Hooks.once("ready", async function () {
   console.log(DS_CONST.ASCII);
 });
 
-/**
- * Render hooks.
- */
+/* -------------------------------------------------- */
+/*   Render Hooks                                     */
+/* -------------------------------------------------- */
+
 Hooks.on("renderChatMessageHTML", applications.hooks.renderChatMessageHTML);
 Hooks.on("renderCombatantConfig", applications.hooks.renderCombatantConfig);
 Hooks.on("renderTokenApplication", applications.hooks.renderTokenApplication);
 
-/**
- * Other hooks.
- */
+/* -------------------------------------------------- */
+/*   Other Hooks                                      */
+/* -------------------------------------------------- */
+
 Hooks.on("applyCompendiumArt", helpers.applyCompendiumArt);
 Hooks.on("hotReload", helpers.hotReload);

--- a/src/module/applications/hooks/tokenApplication.mjs
+++ b/src/module/applications/hooks/tokenApplication.mjs
@@ -37,7 +37,7 @@ export function renderTokenApplication(app, html, context, options) {
             groups[ancestor.name].appendChild(opt);
           }
           else {
-            const g = document.createElement("optgroup");
+            const g = html.ownerDocument.createElement("optgroup");
             g.label = ancestor.label;
             bar.appendChild(g);
             groups[ancestor.name] = g;

--- a/src/module/applications/sheets/journal-entry-sheet.mjs
+++ b/src/module/applications/sheets/journal-entry-sheet.mjs
@@ -34,9 +34,9 @@ export default class DrawSteelJournalEntrySheet extends foundry.applications.she
     const previous = nav.previous ? await getDocument(nav.previous) : null;
     const up = nav.up ? await getDocument(nav.up) : null;
     const next = nav.next ? await getDocument(nav.next) : null;
-    const element = document.createElement("nav");
+    const element = this.element.ownerDocument.createElement("nav");
     element.classList.add("book-navigation");
-    const list = document.createElement("ul");
+    const list = this.element.ownerDocument.createElement("ul");
     element.append(list);
     list.append(this.#makeNavigation(previous, "prev"));
     list.append(this.#makeNavigation(up, "up"));
@@ -53,9 +53,9 @@ export default class DrawSteelJournalEntrySheet extends foundry.applications.she
    * @returns {HTMLLIElement}
    */
   #makeNavigation(doc, dir) {
-    const li = document.createElement("li");
+    const li = this.element.ownerDocument.createElement("li");
     if (!doc?.testUserPermission(game.user, "OBSERVER")) return li;
-    const anchor = document.createElement("a");
+    const anchor = this.element.ownerDocument.createElement("a");
     anchor.classList.add("content-link");
     if (dir === "up") anchor.classList.add("parent");
     else {

--- a/src/module/applications/sheets/wall-config.mjs
+++ b/src/module/applications/sheets/wall-config.mjs
@@ -8,8 +8,8 @@ export default class DrawSteelWallConfig extends foundry.applications.sheets.Wal
   async _onRender(context, options) {
     await super._onRender(context, options);
 
-    const fieldset = document.createElement("fieldset");
-    const legend = document.createElement("legend");
+    const fieldset = this.element.ownerDocument.createElement("fieldset");
+    const legend = this.element.ownerDocument.createElement("legend");
     legend.textContent = _loc("DRAW_STEEL.Wall.Config.Legend");
 
     const checkbox = foundry.applications.fields.createCheckboxInput({

--- a/src/module/applications/ux/enrichers/lookup.mjs
+++ b/src/module/applications/ux/enrichers/lookup.mjs
@@ -43,7 +43,7 @@ export async function enricher(match, options) {
   /** @type {string | number} */
   let value;
   if (parsedConfig.evaluate) {
-    const replacedFormula = Roll.replaceFormulaData(parsedConfig.formula, data);
+    const replacedFormula = foundry.dice.Roll.defaultImplementation.replaceFormulaData(parsedConfig.formula, data);
     value = (replacedFormula.includes("@")) ? fallback : ds.utils.evaluateFormula(replacedFormula, data, { contextName: "lookup" });
   } else {
     value = foundry.utils.getProperty(data, parsedConfig.formula.substring(1)) ?? fallback;

--- a/src/module/applications/ux/enrichers/roll.mjs
+++ b/src/module/applications/ux/enrichers/roll.mjs
@@ -252,7 +252,7 @@ async function rollDamageHeal(link, event) {
 
   if (typeOptions.length || scaling) {
 
-    const content = document.createElement("div");
+    const content = link.ownerDocument.createElement("div");
 
     const typeInputs = typeOptions.map(choices => {
       const options = choices.types.map((type) => ({
@@ -537,7 +537,7 @@ async function rollTest(link, event) {
   if (characteristic.includes("|")) {
     const chrOptions = characteristic.split("|").map(chr => ({ value: chr, label: ds.CONFIG.characteristics[chr].label }));
 
-    const content = document.createElement("div");
+    const content = link.ownerDocument.createElement("div");
     const { createFormGroup, createSelectInput } = foundry.applications.fields;
 
     content.append(createFormGroup({

--- a/src/module/data/message/base.mjs
+++ b/src/module/data/message/base.mjs
@@ -66,7 +66,7 @@ export default class BaseMessageModel extends DrawSteelSystemModel {
   async alterMessageHTML(html) {
     const footerButtons = await this._constructFooterButtons();
     if (footerButtons.length) {
-      const footer = document.createElement("footer");
+      const footer = html.ownerDocument.createElement("footer");
       footer.append(...footerButtons);
       html.insertAdjacentElement("beforeend", footer);
     }

--- a/src/module/data/pseudo-documents/message-parts/test.mjs
+++ b/src/module/data/pseudo-documents/message-parts/test.mjs
@@ -202,7 +202,7 @@ export default class TestPart extends RollPart {
     let damageSelection;
 
     if (damageInfo.types.size > 1) {
-      const content = document.createElement("div");
+      const content = target.ownerDocument.createElement("div");
 
       const { createFormGroup, createSelectInput } = foundry.applications.fields;
 

--- a/src/module/documents/combatant-group.mjs
+++ b/src/module/documents/combatant-group.mjs
@@ -95,7 +95,7 @@ export default class DrawSteelCombatantGroup extends foundry.documents.Combatant
           nameInput.placeholder = cls.defaultName({ type: e.target.value, parent, pack });
         });
         // On-render addition to avoid having to use a new template
-        const hint = document.createElement("p");
+        const hint = dialog.element.ownerDocument.createElement("p");
         hint.className = "hint";
         hint.innerText = _loc("DRAW_STEEL.CombatantGroup.TypeHint");
         const group = typeInput.closest(".form-group");

--- a/src/module/documents/item.mjs
+++ b/src/module/documents/item.mjs
@@ -131,7 +131,7 @@ export default class DrawSteelItem extends BaseDocumentMixin(foundry.documents.I
   /**
    * An alternative to the document delete method, this deletes the item as well as any items that were
    * added as a result of this item's creation via advancements.
-   * @param {Object} options
+   * @param {object} options
    * @param {boolean} [options.replacement=false]   Should the window title indicate that this is a replacement?
    * @param {boolean} [options.skipDialog=false]    Whether to skip the confirmation dialog, e.g., if there's already been another.
    * @returns {Promise<foundry.documents.Item[]|null>}   A promise that resolves to the deleted items.

--- a/src/module/utils/construct-html-button.mjs
+++ b/src/module/utils/construct-html-button.mjs
@@ -10,7 +10,9 @@
  * @param {boolean} [config.disabled=false]                   Whether to disable the button.
  * @returns {HTMLButtonElement}
  */
-export default function constructHTMLButton({ label = "", dataset = {}, classes = [], icon = "", img = "", type = "button", disabled = false }) {
+export default function constructHTMLButton({
+  label = "", dataset = {}, classes = [], icon = "", img = "", type = "button", disabled = false,
+}) {
   const button = document.createElement("button");
   button.type = type;
 

--- a/src/module/utils/update-from-compendium.mjs
+++ b/src/module/utils/update-from-compendium.mjs
@@ -82,11 +82,11 @@ function compendiumUpdateData(doc) {
   switch (doc.documentName) {
     case "Actor":
     case "Item":
-      return { _id: doc.id, "==system": documentData.system };
+      return { _id: doc.id, system: _replace(documentData.system) };
     case "ActiveEffect":
       return {
         _id: doc.id,
-        "==system": documentData.system,
+        system: _replace(documentData.system),
         duration: documentData.duration,
         description: documentData.description,
       };


### PR DESCRIPTION
Closes #1161.

Cleaned up the main file a bit as well. Unlike mentioned in 1161, we do register the element(s) but arent using them anywhere yet.

I applied a liberal use of `HTMLElement#ownerDocument` where an element could be found, and probably much more than needed.