### PR TITLE
[#1757] Remove unneeded uses of fa-fw

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -39,28 +39,28 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       controls: [
         {
           action: "configureToken",
-          icon: "fa-regular fa-fw fa-circle-user",
+          icon: "fa-regular fa-circle-user",
           label: "DOCUMENT.Token",
           visible: this.#canConfigureToken,
           ownership: "OWNER",
         },
         {
           action: "configurePrototypeToken",
-          icon: "fa-solid fa-fw fa-circle-user",
+          icon: "fa-solid fa-circle-user",
           label: "TOKEN.TitlePrototype",
           visible: this.#canConfigurePrototype,
           ownership: "OWNER",
         },
         {
           action: "showPortraitArtwork",
-          icon: "fa-solid fa-fw fa-image",
+          icon: "fa-solid fa-image",
           label: "SIDEBAR.CharArt",
           visible: this.#canViewCharacterArt,
           ownership: "OWNER",
         },
         {
           action: "showTokenArtwork",
-          icon: "fa-solid fa-fw fa-image",
+          icon: "fa-solid fa-image",
           label: "SIDEBAR.TokenArt",
           visible: this.#canViewTokenArt,
           ownership: "OWNER",
@@ -595,7 +595,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       // Kit specific options
       {
         label: "DRAW_STEEL.Item.kit.PreferredKit.MakePreferred",
-        icon: "fa-solid fa-fw fa-star",
+        icon: "fa-solid fa-star",
         visible: (target) => this._getEmbeddedDocument(target)?.type === "kit",
         onClick: async (event, target) => {
           const item = this._getEmbeddedDocument(target);
@@ -606,7 +606,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       // Equipment specific options
       {
         label: "DRAW_STEEL.Item.project.Craft.FromTreasure.Label",
-        icon: "fa-solid fa-fw fa-hammer",
+        icon: "fa-solid fa-hammer",
         visible: (target) => this._getEmbeddedDocument(target)?.type === "treasure",
         onClick: async (event, target) => {
           const item = this._getEmbeddedDocument(target);
@@ -617,7 +617,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       // Project specific options
       {
         label: "DRAW_STEEL.Item.project.SpendCareerPoints.Title",
-        icon: "fa-solid fa-fw fa-hammer",
+        icon: "fa-solid fa-hammer",
         visible: (target) => {
           const item = this._getEmbeddedDocument(target);
           if (item.type !== "project") return false;
@@ -635,7 +635,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.Item.project.Events.DrawEvent",
-        icon: "fa-solid fa-fw fa-table-list",
+        icon: "fa-solid fa-table-list",
         visible: (target) => {
           const item = this._getEmbeddedDocument(target);
           return item.type === "project";
@@ -648,7 +648,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       //Ability specific options
       {
         label: "DRAW_STEEL.Item.ability.SwapUsage.ToMelee",
-        icon: "fa-solid fa-fw fa-sword",
+        icon: "fa-solid fa-sword",
         visible: (target) => {
           const item = this._getEmbeddedDocument(target);
           return (item?.type === "ability") && (item?.system.distance.type === "meleeRanged") && (item?.system.damageDisplay === "ranged");
@@ -660,7 +660,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.Item.ability.SwapUsage.ToRanged",
-        icon: "fa-solid fa-fw fa-bow-arrow",
+        icon: "fa-solid fa-bow-arrow",
         visible: (target) => {
           const item = this._getEmbeddedDocument(target);
           return (item?.type === "ability") && (item?.system.distance.type === "meleeRanged") && (item?.system.damageDisplay === "melee");
@@ -673,7 +673,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       // Active Effect options
       {
         label: "DRAW_STEEL.ActiveEffect.RollSave",
-        icon: "fa-solid fa-fw fa-dice-d10",
+        icon: "fa-solid fa-dice-d10",
         visible: (target) => {
           const effect = this._getEmbeddedDocument(target);
           return (effect.documentName === "ActiveEffect") && (effect.system.end?.type === "save");
@@ -685,7 +685,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.ActiveEffect.Toggle",
-        icon: "fa-solid fa-fw fa-check",
+        icon: "fa-solid fa-check",
         visible: (target) => {
           const effect = this._getEmbeddedDocument(target);
           return (effect.documentName === "ActiveEffect") && !effect.active;
@@ -701,7 +701,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.ActiveEffect.Toggle",
-        icon: "fa-solid fa-fw fa-times",
+        icon: "fa-solid fa-times",
         visible: (target) => {
           const effect = this._getEmbeddedDocument(target);
           return (effect.documentName === "ActiveEffect") && effect.active;
@@ -714,7 +714,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       // All applicable options
       {
         label: "DRAW_STEEL.SHEET.View",
-        icon: "fa-solid fa-fw fa-eye",
+        icon: "fa-solid fa-eye",
         visible: () => this.isPlayMode,
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
@@ -723,7 +723,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.Edit",
-        icon: "fa-solid fa-fw fa-edit",
+        icon: "fa-solid fa-edit",
         visible: () => this.isEditMode,
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
@@ -732,7 +732,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.Share",
-        icon: "fa-solid fa-fw fa-share-from-square",
+        icon: "fa-solid fa-share-from-square",
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
           await DrawSteelChatMessage.create({
@@ -747,7 +747,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.Delete",
-        icon: "fa-solid fa-fw fa-trash",
+        icon: "fa-solid fa-trash",
         visible: () => this.actor.isOwner,
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
@@ -768,7 +768,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
     return [
       {
         label: _loc("DOCUMENT.Create", { type: _loc("DOCUMENT.ActiveEffect") }),
-        icon: `${CONFIG.ActiveEffect.typeIcons.base} fa-fw`,
+        icon: CONFIG.ActiveEffect.typeIcons.base,
         visible: () => this.isEditable,
         onClick: (event, target) => {
           const effectClass = getDocumentClass("ActiveEffect");
@@ -788,7 +788,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       },
       {
         label: _loc("DOCUMENT.Create", { type: _loc("TYPES.ActiveEffect.abilityModifier") }),
-        icon: `${CONFIG.ActiveEffect.typeIcons.abilityModifier} fa-fw`,
+        icon: CONFIG.ActiveEffect.typeIcons.abilityModifier,
         visible: () => this.isEditable,
         onClick: (event, target) => {
           const effectClass = getDocumentClass("ActiveEffect");

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -38,12 +38,12 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
     },
     window: {
       controls: [{
-        icon: "fa-solid fa-fw fa-file-arrow-down",
+        icon: "fa-solid fa-file-arrow-down",
         label: "DRAW_STEEL.SOURCE.CompendiumSource.UpdateFrom.Label",
         action: "updateFromCompendium",
         visible: DrawSteelItemSheet.#canUpdateFromCompendium,
       }, {
-        icon: "fa-solid fa-fw fa-share-from-square",
+        icon: "fa-solid fa-share-from-square",
         label: "DRAW_STEEL.SHEET.Share",
         action: "shareDoc",
         visible: DrawSteelItemSheet.#canEmbed,
@@ -357,7 +357,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
     return [
       {
         label: "DRAW_STEEL.ActiveEffect.RollSave",
-        icon: "fa-solid fa-fw fa-dice-d10",
+        icon: "fa-solid fa-dice-d10",
         visible: (target) => {
           const effect = this._getEmbeddedDocument(target);
           return effect.system.end?.type === "save";
@@ -369,7 +369,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.ActiveEffect.Toggle",
-        icon: "fa-solid fa-fw fa-check",
+        icon: "fa-solid fa-check",
         visible: (target) => {
           const effect = this._getEmbeddedDocument(target);
           return !effect.active;
@@ -377,15 +377,13 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         onClick: async (event, target) => {
           const effect = this._getEmbeddedDocument(target);
           const updateData = DrawSteelActiveEffect.getInitialDuration();
-
           updateData.disabled = false;
-
           await effect.update(updateData);
         },
       },
       {
         label: "DRAW_STEEL.ActiveEffect.Toggle",
-        icon: "fa-solid fa-fw fa-times",
+        icon: "fa-solid fa-times",
         visible: (target) => {
           const effect = this._getEmbeddedDocument(target);
           return effect.active;
@@ -397,7 +395,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.View",
-        icon: "fa-solid fa-fw fa-eye",
+        icon: "fa-solid fa-eye",
         visible: () => this.isPlayMode,
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
@@ -406,7 +404,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.Edit",
-        icon: "fa-solid fa-fw fa-edit",
+        icon: "fa-solid fa-edit",
         visible: () => this.isEditMode,
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
@@ -415,7 +413,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.Share",
-        icon: "fa-solid fa-fw fa-share-from-square",
+        icon: "fa-solid fa-share-from-square",
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
           await DrawSteelChatMessage.create({
@@ -430,7 +428,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       },
       {
         label: "DRAW_STEEL.SHEET.Delete",
-        icon: "fa-solid fa-fw fa-trash",
+        icon: "fa-solid fa-trash",
         visible: () => this.item.isOwner,
         onClick: async (event, target) => {
           const document = this._getEmbeddedDocument(target);
@@ -448,7 +446,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
     return [
       {
         label: _loc("DOCUMENT.Create", { type: _loc("DOCUMENT.ActiveEffect") }),
-        icon: `${CONFIG.ActiveEffect.typeIcons.base} fa-fw`,
+        icon: CONFIG.ActiveEffect.typeIcons.base,
         visible: () => this.isEditable,
         onClick: (event, target) => {
           const effectClass = getDocumentClass("ActiveEffect");
@@ -470,7 +468,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       },
       {
         label: _loc("DOCUMENT.Create", { type: _loc("TYPES.ActiveEffect.abilityModifier") }),
-        icon: `${CONFIG.ActiveEffect.typeIcons.abilityModifier} fa-fw`,
+        icon: CONFIG.ActiveEffect.typeIcons.abilityModifier,
         visible: () => this.isEditable,
         onClick: (event, target) => {
           const effectClass = getDocumentClass("ActiveEffect");

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -17,7 +17,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
     },
     window: {
       controls: [{
-        icon: "fa-solid fa-fw fa-file-arrow-down",
+        icon: "fa-solid fa-file-arrow-down",
         label: "DRAW_STEEL.SOURCE.CompendiumSource.UpdateFrom.Label",
         action: "updateFromCompendium",
         visible: DrawSteelNPCSheet.#canUpdateFromCompendium,

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -15,7 +15,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
     },
     window: {
       controls: [{
-        icon: "fa-solid fa-fw fa-file-arrow-down",
+        icon: "fa-solid fa-file-arrow-down",
         label: "DRAW_STEEL.SOURCE.CompendiumSource.UpdateFrom.Label",
         action: "updateFromCompendium",
         visible: DrawSteelObjectSheet.#canUpdateFromCompendium,

--- a/src/module/applications/sidebar/tabs/actors.mjs
+++ b/src/module/applications/sidebar/tabs/actors.mjs
@@ -5,7 +5,7 @@ export default class DrawSteelActorDirectory extends foundry.applications.sideba
 
     const options = [{
       label: "DRAW_STEEL.SIDEBAR.ACTORS.contextMenuAssignPrimaryParty",
-      icon: "fa-solid fa-fw fa-medal",
+      icon: "fa-solid fa-medal",
       visible: (target) => {
         const actor = getActor(target);
         return game.user.isGM && (actor.type === "party") && (actor !== game.actors.party);
@@ -14,7 +14,7 @@ export default class DrawSteelActorDirectory extends foundry.applications.sideba
       group: "system",
     }, {
       label: "DRAW_STEEL.SIDEBAR.ACTORS.contextMenuRemovePrimaryParty",
-      icon: "fa-solid fa-fw fa-times",
+      icon: "fa-solid fa-times",
       visible: (target) => game.user.isGM && (getActor(target) === game.actors.party),
       onClick: (event, target) => game.actors.unsetParty(),
       group: "system",

--- a/src/module/applications/sidebar/tabs/combat-tracker.mjs
+++ b/src/module/applications/sidebar/tabs/combat-tracker.mjs
@@ -393,7 +393,7 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
     const getCombatant = target => this.viewed.combatants.get(target.dataset.combatantId);
     entryOptions.push({
       label: "DRAW_STEEL.Combatant.ToggleCaptain",
-      icon: "fa-solid fa-fw fa-helmet-battle",
+      icon: "fa-solid fa-helmet-battle",
       visible: (target) => {
         const combatant = getCombatant(target);
         return game.user.isGM && !combatant.actor?.isMinion && (combatant.group?.type === "squad");
@@ -416,15 +416,15 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
     const entryOptions = [
       {
         label: _loc("DOCUMENT.Create", { type: _loc("DOCUMENT.CombatantGroup") }),
-        icon: "fa-solid fa-fw fa-users-rectangle",
+        icon: "fa-solid fa-users-rectangle",
         onClick: () => DrawSteelCombatantGroup.createDialog({}, { parent: this.viewed }),
       }, {
         label: "DRAW_STEEL.CombatantGroup.GroupSelected",
-        icon: "fa-solid fa-fw fa-users-viewfinder",
+        icon: "fa-solid fa-users-viewfinder",
         onClick: async () => DrawSteelCombatantGroup.createFromTokens(this.viewed),
       }, {
         label: "COMBAT.InitiativeRoll",
-        icon: "fa-solid fa-fw fa-dice-d10",
+        icon: "fa-solid fa-dice-d10",
         visible: () => game.combats.isDefaultInitiativeMode,
         onClick: () => this.viewed.rollFirst(),
       },
@@ -446,7 +446,7 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
     return [
       {
         label: _loc("DOCUMENT.Update", { type: _loc("DOCUMENT.CombatantGroup") }),
-        icon: "fa-solid fa-fw fa-edit",
+        icon: "fa-solid fa-edit",
         visible: (target) => getCombatantGroup(target).isOwner,
         onClick: (event, target) => getCombatantGroup(target)?.sheet.render({
           force: true,
@@ -458,7 +458,7 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
       },
       {
         label: "DRAW_STEEL.CombatantGroup.ResetSquadHP",
-        icon: "fa-solid fa-fw fa-rotate",
+        icon: "fa-solid fa-rotate",
         visible: (target) => {
           const group = getCombatantGroup(target);
           return ((group.type === "squad") && group.isOwner);
@@ -470,13 +470,13 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
       },
       {
         label: "COMBAT.ClearMovementHistories",
-        icon: "fa-solid fa-fw fa-shoe-prints",
+        icon: "fa-solid fa-shoe-prints",
         visible: () => game.user.isGM,
         onClick: (event, target) => getCombatantGroup(target).clearMovementHistories(),
       },
       {
         label: "DRAW_STEEL.CombatantGroup.ColorTokens.Label",
-        icon: "fa-solid fa-fw fa-palette",
+        icon: "fa-solid fa-palette",
         visible: (target) => getCombatantGroup(target).members.every(c => c.isOwner),
         onClick: async (event, target) => {
           await getCombatantGroup(target).colorTokensDialog();
@@ -484,13 +484,13 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
       },
       {
         label: _loc("DOCUMENT.Delete", { type: _loc("DOCUMENT.CombatantGroup") }),
-        icon: "fa-solid fa-fw fa-trash",
+        icon: "fa-solid fa-trash",
         visible: () => game.user.isGM,
         onClick: (event, target) => getCombatantGroup(target).delete(),
       },
       {
         label: "OWNERSHIP.Configure",
-        icon: "fa-solid fa-fw fa-lock",
+        icon: "fa-solid fa-lock",
         visible: () => game.user.isGM,
         onClick: (event, target) => new foundry.applications.apps.DocumentOwnershipConfig({
           document: getCombatantGroup(target),
@@ -502,7 +502,7 @@ export default class DrawSteelCombatTracker extends sidebar.tabs.CombatTracker {
       },
       {
         label: "DRAW_STEEL.CombatantGroup.ToggleVisibility",
-        icon: "fa-solid fa-fw fa-eye-slash",
+        icon: "fa-solid fa-eye-slash",
         visible: (target) => game.user.isGM && getCombatantGroup(target).members.size,
         onClick: (event, target) => {
           const combatantGroup = getCombatantGroup(target);

--- a/src/module/applications/ui/players.mjs
+++ b/src/module/applications/ui/players.mjs
@@ -49,7 +49,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
     return [
       {
         label: "DRAW_STEEL.Setting.HeroTokens.GiveToken",
-        icon: "fa-solid fa-fw fa-plus",
+        icon: "fa-solid fa-plus",
         visible: () => game.user.isGM,
         onClick: async (event, target) => {
           /** @type {HeroTokenModel} */
@@ -59,7 +59,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
       },
       {
         label: "DRAW_STEEL.Setting.HeroTokens.SpendToken",
-        icon: "fa-solid fa-fw fa-minus",
+        icon: "fa-solid fa-minus",
         onClick: async (event, target) => {
           /** @type {HeroTokenModel} */
           const heroTokens = game.actors.heroTokens;
@@ -68,7 +68,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
       },
       {
         label: "DRAW_STEEL.Setting.HeroTokens.ResetToken",
-        icon: "fa-solid fa-fw fa-rotate",
+        icon: "fa-solid fa-rotate",
         visible: () => game.user.isGM,
         onClick: async (event, target) => {
           /** @type {HeroTokenModel} */
@@ -78,7 +78,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
       },
       {
         label: "DRAW_STEEL.Setting.Malice.AdjustMalice.label",
-        icon: "fa-solid fa-fw fa-plus-minus",
+        icon: "fa-solid fa-plus-minus",
         visible: () => game.user.isGM && game.combat,
         onClick: async (event, target) => {
           /** @type {MaliceModel} */
@@ -88,7 +88,7 @@ export default class DrawSteelPlayers extends foundry.applications.ui.Players {
       },
       {
         label: "DRAW_STEEL.Setting.Malice.ResetMalice",
-        icon: "fa-solid fa-fw fa-rotate",
+        icon: "fa-solid fa-rotate",
         visible: () => game.user.isGM && game.combat,
         onClick: async (event, target) => {
           /** @type {MaliceModel} */

--- a/src/module/data/pseudo-documents/message-parts/ability-result.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-result.mjs
@@ -195,7 +195,7 @@ export default class AbilityResultPart extends RollPart {
       });
       return {
         label,
-        icon: "fa-fw fa-solid fa-gear",
+        icon: "fa-solid fa-gear",
         visible: () => this.message.isOwner,
         onClick: () => this.modifyDamageDialog(roll),
       };

--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -39,7 +39,7 @@
       <label> {{name}} </label>
       <div class="form-fields">
         <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
-        <button type="button" data-action="deletePseudoDocument" class="icon fa-solid fa-fw fa-trash" {{disabled @root.isPlay}}></button>
+        <button type="button" data-action="deletePseudoDocument" class="icon fa-fw fa-solid fa-trash" {{disabled @root.isPlay}}></button>
       </div>
     </div>
     {{/each}}


### PR DESCRIPTION
Closes #1757.

Unsurprisingly, fa-fw is applied automatically in both context menus and header menus.