### PR TITLE
Implemented ability registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This version of the system does not support v13, it is exclusively for Foundry v
 ### Changed
 
 - Refactored CONFIG.statusEffects usage from array to record, in accordance with core migration. (#1166)
+- Compendium abilities now use the name of the associated class's heroic resource instead of a generic "Heroic Resource" if possible. (#1419)
 - Migrated roll modes to the new core message modes. (#1681)
 
 ### Deprecated

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -64,7 +64,14 @@ Hooks.once("init", function () {
   }
 
   // Indexing DSID, class primary name, subclass associated classes, and perk types
-  CONFIG.Item.compendiumIndexFields.push("system._dsid", "system.primary", "system.classLink", "system.perkType");
+  CONFIG.Item.compendiumIndexFields.push(
+    "system._dsid",
+    "system.primary",
+    "system.classLink",
+    "system.perkType",
+    "system.prerequisites",
+    "system.resource",
+  );
   // Need to be able to find "configuration" type pages
   CONFIG.JournalEntry.compendiumIndexFields.push("pages.type");
 

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -71,6 +71,7 @@ Hooks.once("init", function () {
     "system.perkType",
     "system.prerequisites",
     "system.resource",
+    "system.category",
   );
   // Need to be able to find "configuration" type pages
   CONFIG.JournalEntry.compendiumIndexFields.push("pages.type");

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -63,14 +63,20 @@ Hooks.once("init", function () {
     }
   }
 
-  // Indexing DSID, class primary name, subclass associated classes, and perk types
   CONFIG.Item.compendiumIndexFields.push(
+    // DSID
     "system._dsid",
+    // Class heroic resource name
     "system.primary",
+    // Subclass associated class
     "system.classLink",
+    // Perk type
     "system.perkType",
+    // prerequisites object
     "system.prerequisites",
+    // Heroic resource cost
     "system.resource",
+    // Ability category (e.g. signature)
     "system.category",
   );
   // Need to be able to find "configuration" type pages

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -336,7 +336,19 @@ export default class AbilityModel extends BaseItemModel {
     const config = ds.CONFIG.abilities;
     const formattedLabels = this.formattedLabels;
 
-    const resourceName = this.actor?.system.coreResource?.name ?? _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label");
+    let resourceName = this.actor?.system.coreResource?.name;
+
+    if (!resourceName && (this.prerequisites.dsid.size === 1)) {
+      const dsid = this.prerequisites.dsid.first();
+      let classEntry = ds.registry.class.filter(e => e.dsid === dsid).at(-1);
+      if (!classEntry) {
+        const subclass = ds.registry.subclass.filter(e => e.dsid === dsid).at(-1);
+        if (subclass) classEntry = ds.registry.class.filter(e => e.dsid === subclass.dsid).at(-1);
+      }
+      if (classEntry) resourceName = classEntry.primary;
+    }
+
+    resourceName ??= _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label");
 
     context.resourceName = resourceName;
 

--- a/src/module/helpers/_types.d.ts
+++ b/src/module/helpers/_types.d.ts
@@ -13,4 +13,27 @@ export interface RegistryEntry {
   classLink?: string;
   /** Perk type for perks. */
   perkType?: string;
+  /** Abilities for a class or subclass */
+  abilities?: Readonly<AbilityRegistryEntry>;
+}
+
+// Abilities are organized by resource cost and *not* by level
+// This is because the Elementalist shows that if the second set of options is *not* organized by subclass, then you can pick from a prior level
+// The strict hierarchy is only based on ability cost and class or subclass affiliation
+
+export interface AbilityRegistryEntry {
+  /** The Key used for the entry. */
+  key: string;
+  /** Abilities without a heroic resource cost are signature abilities */
+  signature: Set<string>;
+  /** 3 cost abilities are usually available at levels 1 and 2 */
+  heroic3: Set<string>;
+  /** 5 cost abilities are usually available at levels 1 and 3 */
+  heroic5: Set<string>;
+  /** 7 cost abilities are usually available at levels 5 and 6 */
+  heroic7: Set<string>;
+  /** 9 cost abilities are usually available at levels 8 and 9 */
+  heroic9: Set<string>;
+  /** 11 cost abilities are usually available at level 10 */
+  heroic11: Set<string>;
 }

--- a/src/module/helpers/registry.mjs
+++ b/src/module/helpers/registry.mjs
@@ -1,7 +1,7 @@
 import DrawSteelItem from "../documents/item.mjs";
 
 /**
- * @import { RegistryEntry } from "./_types";
+ * @import { AbilityRegistryEntry, RegistryEntry } from "./_types";
  */
 
 /**
@@ -11,6 +11,7 @@ import DrawSteelItem from "../documents/item.mjs";
 export default class DrawSteelRegistry {
   constructor() {
     Object.defineProperties(this, {
+      abilities: { value: new foundry.utils.Collection(), writable: false, configurable: false },
       class: { value: new DSRegistryCollection(), writable: false, configurable: false },
       subclass: { value: new DSRegistryCollection(), writable: false, configurable: false },
       perk: { value: new DSRegistryCollection(), writable: false, configurable: false },
@@ -35,7 +36,7 @@ export default class DrawSteelRegistry {
       return typeMap[a.metadata.packageType] - typeMap[b.metadata.packageType];
     });
 
-    const registryTypes = new Set(["class", "subclass", "perk", "kit"]);
+    const registryTypes = new Set(["ability", "class", "subclass", "perk", "kit"]);
 
     for (const pack of itemPacks) {
       // Need to re-call `getIndex` for `system._dsid` to be populated
@@ -60,12 +61,26 @@ export default class DrawSteelRegistry {
         };
 
         switch (idx.type) {
+          case "ability":
+            if (idx.system.prerequisites?.dsid?.length) this.#registerAbility(idx, registryEntry);
+            break;
           case "class":
             registryEntry.primary = idx.system.primary;
+            Object.defineProperties(registryEntry, {
+              abilities: {
+                get: () => this.abilities.get(dsid),
+              },
+              subclasses: {
+                get: () => this.subclass.filter(e => e.classLink === dsid),
+              },
+            });
             this.class.set(key, registryEntry);
             break;
           case "subclass":
             registryEntry.classLink = idx.system.classLink;
+            Object.defineProperty(registryEntry, "abilities", {
+              get: () => this.abilities.get(dsid),
+            });
             this.subclass.set(key, registryEntry);
             break;
           case "perk":
@@ -83,6 +98,30 @@ export default class DrawSteelRegistry {
   }
 
   /* -------------------------------------------------- */
+
+  /**
+   * Handle registering an ability. Only register abilities that have associated classes or subclasses.
+   * @param {object} index
+   */
+  #registerAbility(index) {
+    // This will be length 1 for all known classes and subclasses
+    for (const dsid of index.system.prerequisites.dsid) {
+      let entry = this.abilities.get(dsid);
+      if (!entry) {
+        entry = {
+          key: dsid,
+          signature: new Set(),
+          heroic3: new Set(),
+          heroic5: new Set(),
+          heroic7: new Set(),
+          heroic9: new Set(),
+          heroic11: new Set(),
+        };
+        this.abilities.set(dsid, entry);
+      }
+      index.system.resource ? entry[`heroic${index.system.resource}`]?.add(index.uuid) : entry.signature.add(index.uuid);
+    }
+  }
 
   /**
    * Called once in `ready` after migrations.
@@ -130,6 +169,12 @@ export default class DrawSteelRegistry {
 
   /**
    * A registry of classes mapping DSID to registry entries.
+   * @type {DSAbilityRegistry}
+   */
+  abilities;
+
+  /**
+   * A registry of classes mapping DSID to registry entries.
    * @type {DSRegistryCollection}
    */
   class;
@@ -157,6 +202,22 @@ export default class DrawSteelRegistry {
    * @type {DSRegistryCollection}
    */
   kit;
+
+  /* -------------------------------------------------- */
+  /*  Methods                                           */
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetch all entry info for a given class.
+   * @param {string} dsid
+   * @returns {{ entry: RegistryEntry, subclasses: RegistryEntry[] }}
+   */
+  getClassInfo(dsid) {
+    const entry = this.class.filter(e => e.dsid === dsid);
+    const subclasses = this.subclass.filter(e => e.classLink === dsid);
+
+    return { entry, subclasses };
+  }
 }
 
 /* -------------------------------------------------- */
@@ -166,3 +227,9 @@ export default class DrawSteelRegistry {
  * @extends {foundry.utils.Collection<string, RegistryEntry>}
  */
 class DSRegistryCollection extends foundry.utils.Collection {}
+
+/**
+ * A collection subclass for the registries. The keys are expected to be the DSID of registry entries.
+ * @extends {foundry.utils.Collection<string, AbilityRegistryEntry>}
+ */
+class DSAbilityRegistry extends foundry.utils.Collection {}

--- a/src/module/helpers/registry.mjs
+++ b/src/module/helpers/registry.mjs
@@ -119,7 +119,9 @@ export default class DrawSteelRegistry {
         };
         this.abilities.set(dsid, entry);
       }
-      index.system.resource ? entry[`heroic${index.system.resource}`]?.add(index.uuid) : entry.signature.add(index.uuid);
+      if (index.system.resource) entry[`heroic${index.system.resource}`]?.add(index.uuid);
+      else if (index.system.category === "signature") entry.signature.add(index.uuid);
+      // abilities without a resource cost or signature category don't need to be registered
     }
   }
 


### PR DESCRIPTION
- Added registration of abilities
- Abilities are organized by resource cost rather than level because when the two are *not* in sync, resource cost is the primary determinant (setup for #1420)
- Leveraged ability registry to improve intelligence of Heroic Resource labels for compendium abilities

<img width="577" height="433" alt="image" src="https://github.com/user-attachments/assets/e970104d-1cf5-4470-b824-2ba189f598ea" />

Note: Testing must be done on the Conduit because that's the only class we've structured with the appropriate prerequisites data. Fortunately, doing updates will be relatively simple because our foldering corresponds to the necessary data values.

Not labeling this as closing the ticket because a follow-up issue should tackle feature prerequisites (relevant for properly genericizing the Conduit subclass feature choices)