### PR TITLE
Formula editor autocomplete context

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -280,6 +280,11 @@ Hooks.once("i18nInit", () => {
 
   localizePseudos(data.pseudoDocuments.powerRollEffects.BasePowerRollEffect.TYPES);
   localizePseudos(data.pseudoDocuments.advancements.BaseAdvancement.TYPES);
+
+  // Register formula editor autocomplete contexts after ds.CONFIG localization so labels show localized.
+  CONFIG.formulaEditor.contexts.default = {
+    labels: Object.fromEntries(Object.entries(ds.CONFIG.formulaEditorContexts.default).map(([key, value]) => [key, value.label])),
+  };
 });
 
 /* -------------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -2245,6 +2245,7 @@
       }
     },
     "FormulaEditor": {
+      "Echelon": "Echelon",
       "Level": "Level",
       "Potency": {
         "Weak": "Weak Potency",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2243,6 +2243,15 @@
         "contextMenuAssignPrimaryParty": "Assign Primary Party",
         "contextMenuRemovePrimaryParty": "Remove Primary Party"
       }
+    },
+    "FormulaEditor": {
+      "Level": "Level",
+      "Potency": {
+        "Weak": "Weak Potency",
+        "Average": "Average Potency",
+        "Strong": "Strong Potency"
+      },
+      "Chr": "Highest Characteristic"
     }
   },
   "TYPES": {

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2607,6 +2607,9 @@ export const formulaEditorContexts = {
     level: {
       label: "DRAW_STEEL.FormulaEditor.Level",
     },
+    echelon: {
+      label: "DRAW_STEEL.FormulaEditor.Echelon",
+    },
     "potency.weak": {
       label: "DRAW_STEEL.FormulaEditor.Potency.Weak",
     },

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2577,3 +2577,45 @@ export const references = {
   wealth: "Compendium.draw-steel.journals.JournalEntry.f8eNK5Pte4CSdex0.JournalEntryPage.I38Puf98ti2zZbiz",
   winded: "Compendium.draw-steel.journals.JournalEntry.f8eNK5Pte4CSdex0.JournalEntryPage.3yd9XsnxkDbR7Ywd",
 };
+
+/* -------------------------------------------------- */
+
+/**
+ * Default formula editor context for autocompletion.
+ * @type {Record<string, { label: string }>}    A record of roll data paths to labels.
+ */
+export const formulaEditorContexts = {
+  default: {
+    M: {
+      label: "DRAW_STEEL.Actor.characteristics.might.full",
+    },
+    A: {
+      label: "DRAW_STEEL.Actor.characteristics.agility.full",
+    },
+    R: {
+      label: "DRAW_STEEL.Actor.characteristics.reason.full",
+    },
+    I: {
+      label: "DRAW_STEEL.Actor.characteristics.intuition.full",
+    },
+    P: {
+      label: "DRAW_STEEL.Actor.characteristics.presence.full",
+    },
+    chr: {
+      label: "DRAW_STEEL.FormulaEditor.Chr",
+    },
+    level: {
+      label: "DRAW_STEEL.FormulaEditor.Level",
+    },
+    "potency.weak": {
+      label: "DRAW_STEEL.FormulaEditor.Potency.Weak",
+    },
+    "potency.average": {
+      label: "DRAW_STEEL.FormulaEditor.Potency.Average",
+    },
+    "potency.strong": {
+      label: "DRAW_STEEL.FormulaEditor.Potency.Strong",
+    },
+  },
+};
+preLocalize("formulaEditorContexts.default", { key: "label" });

--- a/src/module/data/fields/formula-field.mjs
+++ b/src/module/data/fields/formula-field.mjs
@@ -48,6 +48,16 @@ export default class FormulaField extends foundry.data.fields.StringField {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _applyChangeSubtract(value, delta, model, change) {
+    const operator = delta.startsWith("-") ? "+" : "-";
+    delta = delta.replace(/^[+-]/, "").trim();
+    if (!value) return (operator === "-") ? `-${delta}` : delta;
+    return `${value} ${operator} ${delta}`;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   _applyChangeMultiply(value, delta, model, change) {
     if (!value) return delta;
     const terms = new foundry.dice.Roll(value).terms;
@@ -75,7 +85,9 @@ export default class FormulaField extends foundry.data.fields.StringField {
     return `min(${value}, ${delta})`;
   }
 
-  /** @override*/
+  /* -------------------------------------------------- */
+
+  /** @override */
   _toInput(config) {
     config.value ??= this.getInitialValue({}) ?? "";
     return foundry.applications.elements.HTMLFormulaInputElement.create(config);

--- a/src/module/data/fields/formula-field.mjs
+++ b/src/module/data/fields/formula-field.mjs
@@ -49,10 +49,8 @@ export default class FormulaField extends foundry.data.fields.StringField {
 
   /** @inheritdoc */
   _applyChangeSubtract(value, delta, model, change) {
-    const operator = delta.startsWith("-") ? "+" : "-";
-    delta = delta.replace(/^[+-]/, "").trim();
-    if (!value) return (operator === "-") ? `-${delta}` : delta;
-    return `${value} ${operator} ${delta}`;
+    if (!value) return `-(${delta})`;
+    return `${value} - (${delta})`;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/fields/formula-field.mjs
+++ b/src/module/data/fields/formula-field.mjs
@@ -87,7 +87,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
 
   /* -------------------------------------------------- */
 
-  /** @override */
+  /** @inheritdoc */
   _toInput(config) {
     config.value ??= this.getInitialValue({}) ?? "";
     return foundry.applications.elements.HTMLFormulaInputElement.create(config);


### PR DESCRIPTION
Adds the formula field autocomplete contexts for a few of the most important roll data paths. I used existing localization keys for the characteristics, but for the other made new ones. I could have used the potency localization form the ability stuff, but without the context "Weak"/"Strong"/"Average" felt too vague, so wanted to include "Potency" in it.

It should be easy enough now to add additional entries if we decide there should be more.


Also added the `_applyChangeSubtract` to `FormulaField`. Adjusted when we check for `!value` to account for double negatives.