### PR TITLE
Implemented batch operations for effect application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This version of the system does not support v13, it is exclusively for Foundry v
 - ActiveEffect changes for v14
   - Migrated `system.end.type` to `duration.expiry` to leverage the new built-in duration tracking. (#1166)
   - Refactored CONFIG.statusEffects usage from array to record. (#1166)
+  - Applying a new copy of a status effect always removes the old one if it's not a stacking effect.
 - Implemented field placeholders where possible. (#1326)
 - Refactored data preparation pipeline to use non-persisted effects. (#1521)
 - Migrated roll modes to the new core message modes. (#1681)

--- a/src/module/applications/ux/enrichers/apply-effect.mjs
+++ b/src/module/applications/ux/enrichers/apply-effect.mjs
@@ -3,6 +3,7 @@ import DrawSteelActiveEffect from "../../../documents/active-effect.mjs";
 
 /**
  * @import { ActiveEffectData } from "@common/documents/_types.mjs";
+ * @import { DatabaseWriteOperation } from "@common/abstract/_types.mjs";
  * @import { TextEditorEnricher, TextEditorEnricherConfig } from "@client/config.mjs";
  * @import HTMLEnrichedContentElement from "@client/applications/elements/enriched-content.mjs";
  * @import { ParsedConfig } from "../helpers.mjs";
@@ -133,16 +134,20 @@ async function onClickAnchor() {
   const updates = {
     transfer: true,
     origin: this.dataset.origin,
-    system: {},
   };
-
-  if (this.dataset.end) updates.system.end = { type: this.dataset.end };
-  tempEffect.updateSource(updates);
+  if (this.dataset.end) updates.duration = { expiry: ds.CONFIG.effectEnds[this.dataset.end].expiryEvent };
+  // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
+  const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
 
   /** @type {Set<DrawSteelActor>} */
   const actors = new Set();
 
-  // TODO: Update when https://github.com/foundryvtt/foundryvtt/issues/11898 is implemented
+  // Need separate operations because all deletions must be done before creations to avoid id collisions
+  /** @type {DatabaseWriteOperation[]} */
+  const toDelete = [];
+  /** @type {DatabaseWriteOperation[]} */
+  const toCreate = [];
+
   for (const token of tokens) {
     const actor = token.actor;
     if (!actor) continue;
@@ -152,25 +157,22 @@ async function onClickAnchor() {
     // reusing the ID will block creation if it's already on the actor
     const existing = actor.effects.get(tempEffect.id);
     // deleting instead of updating because there may be variances between the old copy and new
-    if (existing?.disabled || existing?.duration.expired) await existing.delete();
-
-    // not awaited to allow parallel processing
-    actor.createEmbeddedDocuments("ActiveEffect", [tempEffect.toObject()], { keepId: noStack });
+    if (existing) toDelete.push({ action: "delete", parent: actor, documentName: "ActiveEffect", ids: [tempEffect.id] });
+    toCreate.push({ action: "create", parent: actor, documentName: "ActiveEffect", data: [createData], keepId: noStack });
 
     // statuses automatically create scrolling text themselves
-    if (this.dataset.type !== "status") {
-      const scrollingTextArgs = [
-        token.center,
+    if (this.dataset.type === "custom") {
+      canvas.interface.createScrollingText(token.center,
         _loc("DRAW_STEEL.EDITOR.Enrichers.ApplyEffect.CreateText", { name: tempEffect.name }),
         {
           fill: "white",
           fontSize: 32,
           stroke: 0x000000,
           strokeThickness: 4,
-        },
-      ];
-
-      canvas.interface.createScrollingText(...scrollingTextArgs);
+        });
     }
   }
+
+  await foundry.documents.modifyBatch(toDelete);
+  await foundry.documents.modifyBatch(toCreate);
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -180,6 +180,7 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
    * @param {string} effectId   A status effect or AE id.
    * @param {object} [options]
    * @param {Iterable<DrawSteelActor>} [options.targets] Defaults to all selected actors.
+   * @returns {Promise<DrawSteelActiveEffect[][]>} The batched operation of created effects.
    */
   async applyEffect(tierKey, effectId, options = {}) {
     if (Array.from(options.targets ?? []).some(a => !a.isOwner)) {

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -3,9 +3,11 @@ import DrawSteelActiveEffect from "../../../documents/active-effect.mjs";
 import { setOptions } from "../../helpers.mjs";
 
 /**
+ * @import { ActiveEffectData } from "@common/documents/_types.mjs";
+ * @import { DatabaseWriteOperation } from "@common/abstract/_types.mjs";
+ * @import { StatusEffectConfig } from "@client/config.mjs";
  * @import { AppliedEffectSchema } from "./_types";
  * @import { DrawSteelActor } from "../../../documents/_module.mjs";
- * @import { StatusEffectConfig } from "@client/config.mjs";
  */
 
 const { SchemaField, SetField, StringField, TypedObjectField } = foundry.data.fields;
@@ -198,24 +200,30 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
     /** @type {ActiveEffectData} */
     const updates = {
       transfer: true,
-      // v14 is turning this into a DocumentUUID field so needs to be a real document
       origin: this.item.uuid,
-      system: {},
     };
-    if (config.end) updates.system.end = { type: config.end };
-    tempEffect.updateSource(updates);
+    if (config.end) updates.duration = { expiry: ds.CONFIG.effectEnds[config.end].expiryEvent };
+    // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
+    const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
 
     const targetActors = options.targets ?? ds.utils.tokensToActors();
 
-    // TODO: Update when https://github.com/foundryvtt/foundryvtt/issues/11898 is implemented
+    // Need separate operations because all deletions must be done before creations to avoid id collisions
+    /** @type {DatabaseWriteOperation[]} */
+    const toDelete = [];
+    /** @type {DatabaseWriteOperation[]} */
+    const toCreate = [];
+
     for (const actor of targetActors) {
       // reusing the ID will block creation if it's already on the actor
       const existing = actor.effects.get(tempEffect.id);
       // deleting instead of updating because there may be variances between the old copy and new
-      if (existing?.disabled || existing?.duration.expired) await existing.delete();
-      // not awaited to allow parallel processing
-      actor.createEmbeddedDocuments("ActiveEffect", [tempEffect.toObject()], { keepId: noStack });
+      if (existing) toDelete.push({ action: "delete", parent: actor, documentName: "ActiveEffect", ids: [tempEffect.id] });
+      toCreate.push({ action: "create", parent: actor, documentName: "ActiveEffect", data: [createData], keepId: noStack });
     }
+
+    await foundry.documents.modifyBatch(toDelete);
+    return foundry.documents.modifyBatch(toCreate);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -206,7 +206,7 @@ export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.
 
     // Create a new effect unless the status effect is forced inactive
     if (!active && (active !== undefined)) return;
-    const effect = await DrawSteelActiveEffect.fromStatusEffect(statusId);
+    const effect = await DrawSteelActiveEffect.fromStatusEffect(statusId, { parent: this });
     if (overlay) effect.updateSource({ "flags.core.overlay": true });
     if (effectEnd) {
       const expiry = ds.CONFIG.effectEnds[effectEnd].expiryEvent;


### PR DESCRIPTION
- Implemented `foundry.documents.modifyBatch` for our two effect application routes
- Addressed warning created by `ActiveEffect#origin` checking for relative UUIDs
- Caught  and fixed old expiry data (was being handled by the migration)