### PR TITLE
[#1711] Object Helpers

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -287,7 +287,9 @@ Hooks.once("i18nInit", () => {
 
   // Register formula editor autocomplete contexts after ds.CONFIG localization so labels show localized.
   CONFIG.formulaEditor.contexts.default = {
-    labels: Object.fromEntries(Object.entries(ds.CONFIG.formulaEditorContexts.default).map(([key, value]) => [key, value.label])),
+    labels: Object.fromEntries(
+      Object.entries(ds.CONFIG.formulaEditorContexts.default).map(([key, value]) => [key, value.label]),
+    ),
   };
 });
 

--- a/src/module/applications/apps/monster-metadata-input.mjs
+++ b/src/module/applications/apps/monster-metadata-input.mjs
@@ -29,12 +29,10 @@ export default class MonsterMetadataInput extends DocumentInput {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const monsterConfig = ds.CONFIG.monsters;
-    context.monsterKeywords = Object.entries(monsterConfig.keywords).map(([value, { label, group }]) =>
-      ({ value, label, group }),
-    );
-    context.monsterOrganizations = Object.entries(monsterConfig.organizations).map(([value, { label }]) =>
-      ({ value, label }),
-    );
+    context.monsterKeywords = Object.entries(monsterConfig.keywords)
+      .map(([value, { label, group }]) => ({ value, label, group }));
+    context.monsterOrganizations = Object.entries(monsterConfig.organizations)
+      .map(([value, { label }]) => ({ value, label }));
     context.monsterRoles = Object.entries(monsterConfig.roles).map(([value, { label }]) => ({ value, label }));
     context.monsterFields = this.document.system.schema.getField("monster").fields;
     return context;

--- a/src/module/applications/apps/object-metadata-input.mjs
+++ b/src/module/applications/apps/object-metadata-input.mjs
@@ -29,9 +29,8 @@ export default class ObjectMetadataInput extends DocumentInput {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const objectConfig = ds.CONFIG.objects;
-    context.objectCategories = Object.entries(objectConfig.categories).map(([value, { label }]) =>
-      ({ value, label }),
-    );
+    context.objectCategories = Object.entries(objectConfig.categories)
+      .map(([value, { label }]) => ({ value, label }));
     context.objectRoles = Object.entries(objectConfig.roles).map(([value, { label }]) => ({ value, label }));
     context.objectFields = this.document.system.schema.getField("object").fields;
     return context;

--- a/src/module/applications/apps/retainer-metadata-input.mjs
+++ b/src/module/applications/apps/retainer-metadata-input.mjs
@@ -29,13 +29,13 @@ export default class RetainerMetadataInput extends DocumentInput {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const monsterConfig = ds.CONFIG.monsters;
-    context.monsterKeywords = Object.entries(monsterConfig.keywords).map(([value, { label, group }]) =>
-      ({ value, label, group }),
-    );
+    context.monsterKeywords = Object.entries(monsterConfig.keywords)
+      .map(([value, { label, group }]) => ({ value, label, group }));
     context.monsterRoles = Object.entries(monsterConfig.roles).map(([value, { label }]) => ({ value, label }));
     context.retainerFields = this.document.system.schema.getField("retainer").fields;
 
-    context.mentorOptions = game.actors.filter(a => (a.type === "hero") && (a.isOwner || (a === this.document.system.retainer.mentor)))
+    context.mentorOptions = game.actors
+      .filter(a => (a.type === "hero") && (a.isOwner || (a === this.document.system.retainer.mentor)))
       .map(a => ({ value: a.id, label: a.name }));
 
     return context;

--- a/src/module/applications/apps/saving-throw-manager.mjs
+++ b/src/module/applications/apps/saving-throw-manager.mjs
@@ -31,7 +31,7 @@ export default class SavingThrowManager extends RollManager {
     else {
       const activeOwners = game.users.filter(u => effect.testUserPermission(u, "OWNER") && u.active);
       const queryResult = await this.create({ users: activeOwners, effect });
-      return Object.values(queryResult).filter(r => typeof r === "boolean")[0];
+      return foundry.utils.objectValues(queryResult).find(r => typeof r === "boolean");
     }
   }
 

--- a/src/module/applications/apps/toc-config.mjs
+++ b/src/module/applications/apps/toc-config.mjs
@@ -93,7 +93,8 @@ export default class CompendiumTOCConfig extends HandlebarsApplicationMixin(Appl
 
     context.chapterOptions = context.entries.filter(e => e.type === "chapter").map(e => ({ value: e.document.id, label: e.document.name }));
 
-    context.entryTypes = Object.entries(ds.applications.sidebar.apps.DrawSteelCompendiumTOC.ENTRY_TYPES).map(([value, { label }]) => ({ value, label }));
+    context.entryTypes = Object.entries(ds.applications.sidebar.apps.DrawSteelCompendiumTOC.ENTRY_TYPES)
+      .map(([value, { label }]) => ({ value, label }));
 
     return context;
   }
@@ -118,13 +119,7 @@ export default class CompendiumTOCConfig extends HandlebarsApplicationMixin(Appl
    */
   static async #submitHandler(event, form, formData, submitOptions = {}) {
     const fd = foundry.utils.expandObject(formData.object);
-
-    const updateData = [];
-
-    for (const [_id, data] of Object.entries(fd)) {
-      updateData.push({ _id, [CompendiumTOCConfig.flagPath]: data });
-    }
-
+    const updateData = Object.entries(fd).map(([_id, data]) => ({ _id, [CompendiumTOCConfig.flagPath]: data }));
     await getDocumentClass("JournalEntry").updateDocuments(updateData, { pack: this.compendium.collection });
 
     // Also includes this application

--- a/src/module/applications/hooks/combatantConfig.mjs
+++ b/src/module/applications/hooks/combatantConfig.mjs
@@ -19,7 +19,8 @@ export function renderCombatantConfig(app, html, context, options) {
 
   if (combatant.type !== "base") return;
 
-  const dispositions = Object.entries(CONST.TOKEN_DISPOSITIONS).map(([key, value]) => ({ value, label: _loc(`TOKEN.DISPOSITION.${key}`) }));
+  const dispositions = Object.entries(CONST.TOKEN_DISPOSITIONS)
+    .map(([key, value]) => ({ value, label: _loc(`TOKEN.DISPOSITION.${key}`) }));
 
   const dispositionInput = combatant.system.schema.getField("disposition")?.toFormGroup(
     {},

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -308,8 +308,12 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       }, {}),
     };
 
-    const immunities = Object.entries(this.actor.system.damage.immunities).filter(([damageType, value]) => value > 0).map(([damageType, value]) => `<span class="immunity">${labels[damageType]} ${value}</span>`);
-    const weaknesses = Object.entries(this.actor.system.damage.weaknesses).filter(([damageType, value]) => value > 0).map(([damageType, value]) => `<span class="weakness">${labels[damageType]} ${value}</span>`);
+    const immunities = Object.entries(this.actor.system.damage.immunities)
+      .filter(([damageType, value]) => value > 0)
+      .map(([damageType, value]) => `<span class="immunity">${labels[damageType]} ${value}</span>`);
+    const weaknesses = Object.entries(this.actor.system.damage.weaknesses)
+      .filter(([damageType, value]) => value > 0)
+      .map(([damageType, value]) => `<span class="weakness">${labels[damageType]} ${value}</span>`);
 
     const formatter = game.i18n.getListFormatter({ type: "unit" });
     return {

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -488,7 +488,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       for (const id of effect.statuses) {
         if (!(id in statusInfo)) continue;
         statusInfo[id].active = "active";
-        if (!Object.values(statusInfo).some(s => s._id === effect._id)) statusInfo[id].disabled = true;
+        if (!foundry.utils.objectValues(statusInfo).some(s => s._id === effect._id)) statusInfo[id].disabled = true;
       }
     }
 

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -262,12 +262,18 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * @returns {{ heightUnit: string; heightOptions: FormSelectOption[]; weightUnit: string; weightOptions: FormSelectOption[] }}
    */
   _getMeasurements() {
-    const heightOptions = Object.entries(ds.CONFIG.measurements.height).map(([value, config]) => ({
-      value, label: config.label, group: ds.CONFIG.measurements.groups[config.group]?.label,
-    }));
-    const weightOptions = Object.entries(ds.CONFIG.measurements.weight).map(([value, config]) => ({
-      value, label: config.label, group: ds.CONFIG.measurements.groups[config.group]?.label,
-    }));
+    const heightOptions = Object.entries(ds.CONFIG.measurements.height)
+      .map(([value, config]) => ({
+        value,
+        label: config.label,
+        group: ds.CONFIG.measurements.groups[config.group]?.label,
+      }));
+    const weightOptions = Object.entries(ds.CONFIG.measurements.weight)
+      .map(([value, config]) => ({
+        value,
+        label: config.label,
+        group: ds.CONFIG.measurements.groups[config.group]?.label,
+      }));
 
     return {
       heightUnit: ds.CONFIG.measurements.height[this.actor.system.biography.height.units]?.label ?? this.actor.system.biography.height.units,

--- a/src/module/applications/ux/enrichers/potency.mjs
+++ b/src/module/applications/ux/enrichers/potency.mjs
@@ -40,8 +40,8 @@ export async function enricher(match, options) {
   const characteristics = ds.CONFIG.characteristics;
   const potencyStrengths = ds.CONST.potencyStrengths;
   // Caching the rollKeys this way as ds.CONFIG is not available at the time rollKeys is initially set.
-  if (rollKeys.size === 0) {
-    for (const characteristic of Object.values(characteristics)) rollKeys.add(characteristic.rollKey.toLocaleLowerCase());
+  if (!rollKeys.size) {
+    foundry.utils.objectValues(characteristics).forEach(char => rollKeys.add(char.rollKey.toLocaleLowerCase()));
   }
 
   for (const val of parsedConfig.values) {

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -915,7 +915,8 @@ export const hero = {
   get xpTrack() {
     const xpSetting = game.settings.get(systemID, "xpAdvancement");
     // In case a module added track is removed.
-    const fallbackTrack = ds.CONFIG.hero.xpTracks.normal?.track ?? Object.values(ds.CONFIG.hero.xpTracks)[0].track;
+    const fallbackTrack = ds.CONFIG.hero.xpTracks.normal?.track
+      ?? foundry.utils.objectValues(ds.CONFIG.hero.xpTracks).next().value.track;
 
     return ds.CONFIG.hero.xpTracks[xpSetting]?.track ?? fallbackTrack;
   },

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2311,7 +2311,9 @@ export const perks = {
    */
   get typeOptions() {
     const skillGroups = Object.entries(ds.CONFIG.skills.groups).map(([value, entry]) => ({ value, label: entry.label }));
-    return skillGroups.concat(Object.entries(ds.CONFIG.perks.types).map(([value, entry]) => ({ value, label: entry.label })));
+    return skillGroups.concat(
+      Object.entries(ds.CONFIG.perks.types).map(([value, entry]) => ({ value, label: entry.label })),
+    );
   },
 };
 preLocalize("perks.types", { key: "label" });

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -79,7 +79,10 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     for (const status of Object.values(CONFIG.statusEffects)) {
       if (status.targeted) {
         const existing = schema.statuses.getField(status.id);
-        const sources = new fields.SetField(new fields.DocumentUUIDField({ type: "Actor" }), { persisted: false, max: status.maxSources });
+        const sources = new fields.SetField(
+          new fields.DocumentUUIDField({ type: "Actor" }),
+          { persisted: false, max: status.maxSources },
+        );
         if (existing instanceof fields.SchemaField) existing.extendFields({ sources });
         else schema.statuses.extendFields({
           [status.id]: new fields.SchemaField({ sources }, { persisted: false }),

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -190,18 +190,15 @@ export default class HeroModel extends CreatureModel {
     for (const keyword of ["melee", "ranged"]) {
       const bonuses = foundry.utils.flattenObject(kitAbilityBonuses[keyword]);
       for (const [key, value] of Object.entries(bonuses)) {
-        if (value) {
-          this._abilityBonuses.push({
-            key,
-            value,
-            type: "add",
-            priority: 0,
-            filters: {
-              keywords: new Set([keyword, "weapon"]),
-            },
-          });
-        }
-
+        if (!value) continue;
+        this._abilityBonuses.push({
+          key, value,
+          type: "add",
+          priority: 0,
+          filters: {
+            keywords: new Set([keyword, "weapon"]),
+          },
+        });
       }
     }
   }

--- a/src/module/data/fields/collection-field.mjs
+++ b/src/module/data/fields/collection-field.mjs
@@ -81,6 +81,7 @@ export default class CollectionField extends foundry.data.fields.TypedObjectFiel
     }
 
     // Reconstruct the source array, retaining object references
+    // TODO: support v14 operators
     for (let [id, d] of Object.entries(diff)) {
       if (foundry.utils.isDeletionKey(id)) {
         if (id.startsWith("-")) {

--- a/src/module/data/helpers.mjs
+++ b/src/module/data/helpers.mjs
@@ -39,11 +39,7 @@ export const damageTypes = (inner, { all = false } = {}) => {
   const config = ds.CONFIG;
 
   if (all) schema.all = inner();
-
-  Object.entries(config.damageTypes).reduce((obj, [type, value]) => {
-    obj[type] = inner({ label: value.label });
-    return obj;
-  }, schema);
+  Object.entries(config.damageTypes).forEach(([type, value]) => schema[type] = inner({ label: value.label }));
 
   return new SchemaField(schema);
 };

--- a/src/module/data/item/advancement.mjs
+++ b/src/module/data/item/advancement.mjs
@@ -125,8 +125,8 @@ export default class AdvancementModel extends BaseItemModel {
 
     await chain.initializeRoots({ item: this.parent });
 
-    const [firstUpdate, ...rest] = Object.values(toUpdate);
-    const noUpdates = (Object.keys(firstUpdate ?? {}).length <= 1) && (rest.length === 0);
+    const iter = foundry.utils.objectValues(toUpdate);
+    const noUpdates = (Object.keys(iter.next().value ?? {}).length <= 1) && iter.next().done;
 
     if (!chain.nodes.size && foundry.utils.isEmpty(toCreate) && noUpdates) {
       console.debug("No advancements to apply for", this.parent.name);

--- a/src/module/data/pseudo-documents/advancements/characteristic.mjs
+++ b/src/module/data/pseudo-documents/advancements/characteristic.mjs
@@ -60,7 +60,7 @@ export default class CharacteristicAdvancement extends BaseAdvancement {
 
   /** @inheritdoc */
   get isChoice() {
-    return Object.values(this.characteristics).some(v => v === 0);
+    return foundry.utils.objectValues(this.characteristics).some(v => v === 0);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/item-grant-advancement.mjs
@@ -238,7 +238,8 @@ export default class ItemGrantAdvancement extends BaseAdvancement {
     }
 
     // Drop logic
-    ctx.additionalTypes = Object.entries(ItemGrantAdvancement.ADDITIONAL_TYPES).map(([value, { label }]) => ({ value, label }));
+    ctx.additionalTypes = Object.entries(ItemGrantAdvancement.ADDITIONAL_TYPES)
+      .map(([value, { label }]) => ({ value, label }));
     switch (this.additional.type) {
       case "perk":
         ctx.perkTypes = ds.CONFIG.perks.typeOptions;

--- a/src/module/data/pseudo-documents/advancements/skill-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/skill-advancement.mjs
@@ -31,7 +31,8 @@ export default class SkillAdvancement extends TraitAdvancement {
     const config = ds.CONFIG.skills;
     const any = !this.skills.groups.size && !this.skills.choices.size;
     return Object.entries(config.list).reduce((arr, [value, { label, group }]) => {
-      if (any || this.skills.groups.has(group) || this.skills.choices.has(value)) arr.push({ label, group: config.groups[group].label, value });
+      if (any || this.skills.groups.has(group) || this.skills.choices.has(value))
+        arr.push({ label, group: config.groups[group].label, value });
       return arr;
     }, []);
   }

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -151,10 +151,9 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
       };
     }
 
-    context.fields.characteristic = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label })).concat([{
-      value: "none",
-      label: "COMMON.None",
-    }]);
+    context.fields.characteristic = Object.entries(ds.CONFIG.characteristics)
+      .map(([value, { label }]) => ({ value, label }))
+      .concat([{ value: "none", label: "COMMON.None" }]);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -102,8 +102,10 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
         },
       });
 
-      context.fields.movement = Object.entries(ds.CONFIG.abilities.forcedMovement).map(([value, { label }]) => ({ value, label }));
-      context.fields.properties = Object.entries(ds.CONFIG.PowerRollEffect.forced.properties).map(([value, { label }]) => ({ value, label }));
+      context.fields.movement = Object.entries(ds.CONFIG.abilities.forcedMovement)
+        .map(([value, { label }]) => ({ value, label }));
+      context.fields.properties = Object.entries(ds.CONFIG.PowerRollEffect.forced.properties)
+        .map(([value, { label }]) => ({ value, label }));
     }
   }
 

--- a/src/module/data/pseudo-documents/typed-pseudo-document.mjs
+++ b/src/module/data/pseudo-documents/typed-pseudo-document.mjs
@@ -78,7 +78,7 @@ export default class TypedPseudoDocument extends PseudoDocument {
   /** @inheritdoc */
   static async create(data = {}, { parent, ...operation } = {}) {
     data = foundry.utils.deepClone(data);
-    if (!data.type) data.type = Object.keys(this.TYPES)[0];
+    if (!data.type) data.type = foundry.utils.objectKeys(this.TYPES).next().value;
     if (!(data.type in this.TYPES)) {
       throw new Error(`The '${data.type}' type is not a valid type for a '${this.metadata.documentName}' pseudo-document!`);
     }

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -271,7 +271,8 @@ export default class PowerRoll extends DSRoll {
     // Crits are always a tier 3 result
     if (this.isCritical) return 3;
 
-    const tier = Object.values(this.constructor.RESULT_TIERS).reduce((t, { threshold }) => t + Number(this.total >= threshold), 0);
+    const tier = Object.values(this.constructor.RESULT_TIERS)
+      .reduce((t, { threshold }) => t + Number(this.total >= threshold), 0);
     // Adjusts tiers for double edge/bane
     const adjustment = this.netBoon - Math.sign(this.netBoon);
     return Math.clamp(tier + adjustment, 1, 3);

--- a/src/module/utils/update-from-compendium.mjs
+++ b/src/module/utils/update-from-compendium.mjs
@@ -9,7 +9,7 @@
  * @param {object} [options={}]
  * @param {string}  [options.uuid]         An optional reference for a UUID to use in place of the stored compendiumSource.
  * @param {boolean} [options.skipDialog]   Whether to skip the confirmation dialog.
- * @returns {foundry.abstract.Document[][]} The successful batched operation
+ * @returns {foundry.abstract.Document[][]} The successful batched operation.
  */
 export default async function updateFromCompendium(doc, options = {}) {
   const uuid = options.uuid ?? doc._stats.compendiumSource;
@@ -60,7 +60,8 @@ export default async function updateFromCompendium(doc, options = {}) {
       break;
   }
 
-  Object.entries(compendiumDocument.collections).forEach(([field, collection]) => gatherCollectionUpdates(operation, collection, doc[field]));
+  Object.entries(compendiumDocument.collections)
+    .forEach(([field, collection]) => gatherCollectionUpdates(operation, collection, doc[field]));
 
   const result = await foundry.documents.modifyBatch(operation);
 
@@ -107,7 +108,8 @@ function gatherCollectionUpdates(operation, originalCollection, currentCollectio
     if (currentEntry) {
       toUpdate.push(compendiumUpdateData(original));
 
-      Object.entries(original.collections).forEach(([field, collection]) => gatherCollectionUpdates(operation, collection, currentEntry[field]));
+      Object.entries(original.collections)
+        .forEach(([field, collection]) => gatherCollectionUpdates(operation, collection, currentEntry[field]));
     }
     // Items does not alter WorldCollection#fromCompendium
     // TODO: Fix how this handles Active Effects


### PR DESCRIPTION
Closes #1711.

Object.entries: No use cases found. While we could swap a lot of them for this helper method, it would practically mean rewriting the entire code base for nnegligible gain.

Object.keys: Barely any use.

Object.values: A few use cases.

Mostly these helpers are useful when we had been using `Object.*(arg).find/some` which was rare.

I took this opportunity to fix some line lengths.