### PR TITLE
#1666 Added Test to Advanced Studies

### DIFF
--- a/src/packs/character-options/Complications_luKqW8QDTBJo5AM4/complication_Advanced_Studies_R7wqNjYdF3y7ImL9.json
+++ b/src/packs/character-options/Complications_luKqW8QDTBJo5AM4/complication_Advanced_Studies_R7wqNjYdF3y7ImL9.json
@@ -9,7 +9,7 @@
       "page": "234"
     },
     "description": {
-      "value": "<p>You somehow obtained the notebook of a brilliant but eccentric member of your class. The knowledge held within those notes should help you unlock powerful new abilities—if you can ever figure out what the notes mean.</p><p>Benefit and Drawback: As a respite activity, you can study the notebook. Make a test using your highest characteristic score:</p><dl class=\"power-roll-display\"><dt class=\"tier1\"><p>!</p></dt><dd><p>You summon a hostile demon of your level or lower who attacks you at the end of the respite. The demon acts first in the combat, regardless of the traits or abilities of you or anyother creature involved.</p></dd><dt class=\"tier2\"><p>@</p></dt><dd><p>You learn nothing and your time is wasted.</p></dd><dt class=\"tier3\"><p>#</p></dt><dd><p>You learn one bonus heroic ability from your class that you qualify for. You can use that ability until you finish your next respite.</p></dd></dl>",
+      "value": "<p>You somehow obtained the notebook of a brilliant but eccentric member of your class. The knowledge held within those notes should help you unlock powerful new abilities—if you can ever figure out what the notes mean.</p><p><strong>Benefit and Drawback:</strong> As a respite activity, you can study the notebook. [[/test M A R I P resultSource=JournalEntry.f8eNK5Pte4CSdex0]]{Make a test} using your highest characteristic score:</p><p>@Embed[Compendium.draw-steel.journals.JournalEntry.f8eNK5Pte4CSdex0.JournalEntryPage.W9ZFFVSptj1xfrJd inline]</p>",
       "director": ""
     },
     "_dsid": "advanced-studies",
@@ -27,9 +27,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.359",
     "systemId": "draw-steel",
-    "systemVersion": "0.9.1",
+    "systemVersion": "1.0.0",
     "createdTime": 1754715846118,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/src/packs/journals/JournalEntry_Reference_Pages_f8eNK5Pte4CSdex0.json
+++ b/src/packs/journals/JournalEntry_Reference_Pages_f8eNK5Pte4CSdex0.json
@@ -9104,6 +9104,90 @@
         "lastModifiedBy": null
       },
       "_key": "!journal.pages!f8eNK5Pte4CSdex0.yfhZHK53v6X2ErLb"
+    },
+    {
+      "sort": 126700,
+      "name": "Advanced Studies - Test",
+      "type": "tierOutcome",
+      "category": "cG1sSTG8Duel7meY",
+      "_id": "W9ZFFVSptj1xfrJd",
+      "system": {
+        "tier1": "<p>You summon a hostile demon of your level or lower who attacks you at the end of the respite. The demon acts first in the combat, regardless of the traits or abilities of you or anyother creature involved.</p>",
+        "tier2": "<p>You learn nothing and your time is wasted.</p>",
+        "tier3": "<p>You learn one bonus heroic ability from your class that you qualify for. You can use that ability until you finish your next respite.</p>"
+      },
+      "title": {
+        "show": true,
+        "level": 1
+      },
+      "image": {},
+      "text": {
+        "format": 1
+      },
+      "video": {
+        "controls": true,
+        "volume": 0.5
+      },
+      "src": null,
+      "ownership": {
+        "default": -1,
+        "82t6L1LEqAsCLtHw": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "draw-steel",
+        "systemVersion": "1.0.0",
+        "createdTime": 1775171249863,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!journal.pages!f8eNK5Pte4CSdex0.W9ZFFVSptj1xfrJd"
+    },
+    {
+      "sort": 226700,
+      "name": "Incubator of A’An - Test",
+      "type": "tierOutcome",
+      "category": "cG1sSTG8Duel7meY",
+      "_id": "6c3K2tcdbBZMkqKG",
+      "system": {
+        "tier1": "<p>A’An possesses your body until your next respite. You now must roleplay A’An trapped in your form, prioritizing earning new disciples.</p>",
+        "tier2": "<p>You lose a Recovery.</p>",
+        "tier3": "<p>You suffer no effect.</p>"
+      },
+      "title": {
+        "show": true,
+        "level": 1
+      },
+      "image": {},
+      "text": {
+        "format": 1
+      },
+      "video": {
+        "controls": true,
+        "volume": 0.5
+      },
+      "src": null,
+      "ownership": {
+        "default": -1,
+        "82t6L1LEqAsCLtHw": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "draw-steel",
+        "systemVersion": "1.0.0",
+        "createdTime": 1775172410502,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!journal.pages!f8eNK5Pte4CSdex0.6c3K2tcdbBZMkqKG"
     }
   ],
   "sort": 100000,
@@ -9123,7 +9207,7 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "13.351",
+    "coreVersion": "14.359",
     "systemId": "draw-steel",
     "systemVersion": "0.10.0",
     "createdTime": 1728311620076,
@@ -9473,6 +9557,24 @@
         "lastModifiedBy": "TJSowGV8FgjirefO"
       },
       "_key": "!journal.categories!f8eNK5Pte4CSdex0.1aZTrOL64wvMMpUH"
+    },
+    {
+      "name": "Test Outcomes",
+      "sort": 2000000,
+      "_id": "cG1sSTG8Duel7meY",
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "draw-steel",
+        "systemVersion": "1.0.0",
+        "createdTime": 1775170765047,
+        "modifiedTime": 1775170789994,
+        "lastModifiedBy": "82t6L1LEqAsCLtHw",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!journal.categories!f8eNK5Pte4CSdex0.cG1sSTG8Duel7meY"
     }
   ],
   "_key": "!journal!f8eNK5Pte4CSdex0"


### PR DESCRIPTION
Added a power roll test to Advanced Studies
Created a new Test section created in the Reference Pages for Tests. 
Added a test for Throne of A'An once the item is created. 
Added the test referenced for Advanced Studies within the Reference Page area for tests.

Closes #1666