### PR TITLE
Fix required integer persisted value

### DIFF
--- a/src/module/data/helpers.mjs
+++ b/src/module/data/helpers.mjs
@@ -7,10 +7,10 @@ const { NumberField, SchemaField, StringField } = foundry.data.fields;
  * @param {number} [options.min=0]      The minimum value for the field.
  * @param {number} [options.max]        The maximum value for the field.
  * @param {string} [options.label]      Label for the field.
- * @param {boolean} [options.persisted] Is the field saved to the database?
+ * @param {boolean} [options.persisted=true] Is the field saved to the database?
  * @returns A number field that is non-nullable and always defined.
  */
-export const requiredInteger = ({ initial = 0, min = 0, max, label, persisted } = {}) => new NumberField({ initial, label, min, max, persisted, required: true, nullable: false, integer: true });
+export const requiredInteger = ({ initial = 0, min = 0, max, label, persisted = true } = {}) => new NumberField({ initial, label, min, max, persisted, required: true, nullable: false, integer: true });
 
 /* -------------------------------------------------- */
 


### PR DESCRIPTION
If `persisted` isn't passed it's `undefined` and the value of field would get set back to default instead of using the `_source` value.