### PR TITLE
Fix using non-power roll abilities

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -511,7 +511,7 @@ export default class AbilityModel extends BaseItemModel {
         messageData.system.parts.push(rollPart);
       }
     } else {
-      DrawSteelChatMessage.applyMode(messageData, "roll");
+      DrawSteelChatMessage.applyMode(messageData);
     }
     // TODO: Figure out how to better handle invocations when this.actor is null
     if (resourceSpend) await this.actor?.system.updateResource(resourceSpend * -1);


### PR DESCRIPTION
Using non-power roll abilities was erroring out because `roll` wasn't a valid mode. `applyMode` will infer the mode from the core setting if it's not provided.