### PR TITLE
Update respite effect refresh to pass actors as a `Set`

### DIFF
--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -306,7 +306,7 @@ export default class HeroModel extends CreatureModel {
    * @returns {Promise<DrawSteelActor>}
    */
   async takeRespite() {
-    await foundry.documents.ActiveEffect.registry.refresh("respite", { actors: [this.parent] });
+    await foundry.documents.ActiveEffect.registry.refresh("respite", { actors: new Set([this.parent]) });
 
     return this.parent.update({
       system: {


### PR DESCRIPTION
The `refresh` expects actors to be a `Set` instead of an `Array`.