### PR TITLE
Refactored size logic to use actor size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ The latest version of Draw Steel is v14-exclusive. You can see the full v14 stab
 - Created an "Effects and Imbues" compendium pack. (#1163)
 - Added Draw Steel inserts to the "Custom" section of prosemirror, allowing users to easily format their text with system-specific html. (#1267)
 - Updated formula fields to use the new core `HTMLFormulaInputElement`. (#1501)
-- Active Effects can now modify token properties, e.g. `token.height` and `token.width`. (#1528)
 - Added roll functionality to followers. Rolling with a follower first prompts for a project, then performs the roll. (#1722)
 
 ### Changed
@@ -52,6 +51,7 @@ The latest version of Draw Steel is v14-exclusive. You can see the full v14 stab
 - Implemented field placeholders where possible. (#1326)
 - Restructured i18n usage to conform to Intl.PluralRules. (#1436)
 - Refactored data preparation pipeline to use non-persisted effects. (#1521)
+- Creature token sizes are now inferred from their actor sizes, so active effects targeting `system.combat.size.value` will also adjust token sizes automatically. (#1528)
 - Migrated roll modes to the new core message modes. (#1681)
 - Migrated `forced.pull` (etc.) to `forced.bonuses.pull`
 - Refactored various system methods to use new core methods to simplify logic and improve performance. (#1158, #1284, #1711)

--- a/src/docs/Active-Effects.md
+++ b/src/docs/Active-Effects.md
@@ -160,7 +160,7 @@ Draw Steel also supports modifying the default roll formula for tests. `system.c
 |:---:|---|
 |Save Bonus|`system.combat.save.bonus`|
 |Save Threshold|`system.combat.save.threshold`|
-|Actor Size (on sheet, not token size)|`system.combat.size.value`|
+|Actor Size|`system.combat.size.value`|
 |Actor Size Letter|`system.combat.size.letter`|
 |Stability|`system.combat.stability`|
 |Initiative Threshold|`system.combat.initiativeThreshold`|
@@ -244,6 +244,8 @@ Token properties can be targeted by prefixing with `token.`. The following prope
 | Image (Static) |`token.texture.src`|
 | Use dynamic token ring |`token.ring.enabled`|
 | Image (Dynamic Token Ring) |`token.ring.subject.texture`|
+
+Note that width, height, depth are all by default inferred from `system.combat.size.value`, so for most use cases only that key is needed.
 
 ## Ability Modifiers
 

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -64,27 +64,9 @@ export default class CreatureModel extends BaseActorModel {
 
     // Creature token sizes can be strongly determined from actor size
     this.parent.tokenActiveEffectChanges.initial.push(
-      {
-        key: "width",
-        phase: "initial",
-        priority: 5,
-        type: "override",
-        value: this.combat.size.value,
-      },
-      {
-        key: "height",
-        phase: "initial",
-        priority: 5,
-        type: "override",
-        value: this.combat.size.value,
-      },
-      {
-        key: "depth",
-        phase: "initial",
-        priority: 5,
-        type: "override",
-        value: this.combat.size.value,
-      },
+      ...["width", "height", "depth"].map(key => ({
+        key, phase: "initial", priority: 5, type: "override", value: this.combat.size.value,
+      })),
     );
   }
 

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -61,6 +61,31 @@ export default class CreatureModel extends BaseActorModel {
     this.potency.weak += highestCharacteristic - 2 + this.potency.bonuses;
     this.potency.average += highestCharacteristic - 1 + this.potency.bonuses;
     this.potency.strong += highestCharacteristic + this.potency.bonuses;
+
+    // Creature token sizes can be strongly determined from actor size
+    this.parent.tokenActiveEffectChanges.initial.push(
+      {
+        key: "width",
+        phase: "initial",
+        priority: 5,
+        type: "override",
+        value: this.combat.size.value,
+      },
+      {
+        key: "height",
+        phase: "initial",
+        priority: 5,
+        type: "override",
+        value: this.combat.size.value,
+      },
+      {
+        key: "depth",
+        phase: "initial",
+        priority: 5,
+        type: "override",
+        value: this.combat.size.value,
+      },
+    );
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -87,7 +87,8 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
 
   /** @inheritdoc */
   static applyChange(targetDoc, change, options = {}) {
-    if (typeof change.effect?.system.apply === "function") return change.effect.system.apply(targetDoc, change, options);
+    if (typeof change.effect?.system.apply === "function")
+      return change.effect.system.apply(targetDoc, change, options);
     return super.applyChange(targetDoc, change, options);
   }
 

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -87,7 +87,7 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
 
   /** @inheritdoc */
   static applyChange(targetDoc, change, options = {}) {
-    if (typeof change.effect.system.apply === "function") return change.effect.system.apply(targetDoc, change, options);
+    if (typeof change.effect?.system.apply === "function") return change.effect.system.apply(targetDoc, change, options);
     return super.applyChange(targetDoc, change, options);
   }
 


### PR DESCRIPTION
Now strongly inferring size for creatures. This change does not affect objects or anything else not inheriting from `CreatureModel` because they may have more irregular shapes.