### PR TITLE
Implement a `SquadModel#takeDamage` method

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -976,7 +976,8 @@
       "Error": {
         "MinionMustSquad": "Minions can only be added to Squad groups.",
         "MinionNoSquad": "Applying damage directly to a minion because it's not in a squad.",
-        "TooManySquad": "Applying damage directly to a minion because it's in multiple squads."
+        "TooManySquad": "Applying damage directly to a minion because it's in multiple squads.",
+        "DamagingInapplicableActors": "There are actors included in the squad's damage application that are not a minion in this squad."
       },
       "ToggleVisibility": "Toggle Visibility"
     },

--- a/src/module/applications/ux/enrichers/roll.mjs
+++ b/src/module/applications/ux/enrichers/roll.mjs
@@ -151,6 +151,9 @@ function enrichDamageHeal(parsedConfig, label, options) {
     ignoredImmunities: [],
   };
 
+  const doc = options.relativeTo;
+  if (doc && (doc.documentName === "Item") && (doc.type === "ability") && doc.system.keywords.has("area")) linkConfig.aoe = true;
+
   for (const c of parsedConfig) {
     const formulaParts = [];
     if (c.formula) formulaParts.push(c.formula);
@@ -159,6 +162,7 @@ function enrichDamageHeal(parsedConfig, label, options) {
     for (const value of c.values) {
       const normalizedValue = value.toLowerCase();
       if (normalizedValue === "scaling") c.scaling = true;
+      else if (normalizedValue === "aoe") c.aoe = true;
       else if (normalizedValue in ds.CONFIG.damageTypes) c.type.push(normalizedValue);
       else if (normalizedValue in ds.CONFIG.healingTypes) c.type.push(normalizedValue);
       else if (["heal", "healing"].includes(normalizedValue)) c.type.push("value");
@@ -175,6 +179,7 @@ function enrichDamageHeal(parsedConfig, label, options) {
       linkConfig.damageTypes.push(c.type.join("|"));
       linkConfig.ignoredImmunities.push(c.ignoredImmunities.join("|"));
       linkConfig.scaling ||= c.scaling;
+      linkConfig.aoe ||= c.aoe;
     }
   }
 
@@ -224,7 +229,7 @@ function enrichDamageHeal(parsedConfig, label, options) {
  * @param {PointerEvent} event
  */
 async function rollDamageHeal(link, event) {
-  let { formulas, rollType, damageTypes, ignoredImmunities: rawIgnoredImmunities, scaling } = link.dataset;
+  let { formulas, rollType, damageTypes, ignoredImmunities: rawIgnoredImmunities, scaling, aoe } = link.dataset;
   const configKey = rollType === "damage" ? "damageTypes" : "healingTypes";
 
   if (!["damage", "healing"].includes(rollType)) throw new Error("The button's roll type must be damage or healing");
@@ -244,7 +249,7 @@ async function rollDamageHeal(link, event) {
     });
     return {
       formula,
-      options: { type: types[0], types, isHeal: rollType !== "damage", ignoredImmunities },
+      options: { type: types[0], types, isHeal: rollType !== "damage", ignoredImmunities, aoe },
     };
   });
 

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -371,7 +371,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    * @param {object} [options] Options to modify the damage application.
    * @param {string} [options.type]   Valid damage type.
    * @param {Array<string>} [options.ignoredImmunities]  Which damage immunities to ignore.
-   * @returns {{weakness?: number, immunity?: number}}
+   * @returns {{immunity?: number, weakness?: number }}
    */
   calculateImmunityAndWeakness(options = {}) {
     const immunityAndWeakness = {};
@@ -405,20 +405,10 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    * @returns {Promise<DrawSteelActor | DrawSteelCombatantGroup>}
    */
   async takeDamage(damage, options = {}) {
-    const { weakness = 0, immunity = 0 } = this.calculateImmunityAndWeakness(options);
-
-    damage = Math.max(0, damage + weakness - immunity);
-
-    if (damage === 0) {
-      ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", { format: { name: this.parent.name } });
-      return this.parent;
-    }
-
-    const damageTypeOption = { ds: { damageType: options.type } };
     if (this.isMinion) {
       const combatGroups = this.combatGroups;
       if (combatGroups.size === 1) {
-        return this.combatGroup.update({ "system.staminaValue": this.combatGroup.system.staminaValue - damage }, damageTypeOption);
+        return this.combatGroup.system.takeDamage([this.parent], damage, options);
       }
       else if (combatGroups.size === 0) {
         ui.notifications.warn("DRAW_STEEL.CombatantGroup.Error.MinionNoSquad", { localize: true });
@@ -427,6 +417,16 @@ export default class BaseActorModel extends DrawSteelSystemModel {
         ui.notifications.warn("DRAW_STEEL.CombatantGroup.Error.TooManySquad", { localize: true });
       }
     }
+
+    const { immunity = 0, weakness = 0 } = this.calculateImmunityAndWeakness(options);
+
+    damage = Math.max(0, damage + weakness - immunity);
+
+    if (damage === 0) {
+      ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", { format: { name: this.parent.name } });
+      return this.parent;
+    }
+
     // If there's damage left after weakness/immunities, apply damage to temporary stamina then stamina value
     return this.parent.modifyTokenAttribute("stamina", -1 * damage, true, false);
   }

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -367,18 +367,20 @@ export default class BaseActorModel extends DrawSteelSystemModel {
   /* -------------------------------------------------- */
 
   /**
-   * Deal damage to the actor, accounting for immunities and resistances.
-   * @param {number} damage    The amount of damage to take.
+   * Calculate the applicable immunity and weakness based on the damage type and ignored immunities.
    * @param {object} [options] Options to modify the damage application.
    * @param {string} [options.type]   Valid damage type.
    * @param {Array<string>} [options.ignoredImmunities]  Which damage immunities to ignore.
-   * @returns {Promise<DrawSteelActor | DrawSteelCombatantGroup>}
+   * @returns {{weakness?: number, immunity?: number}}
    */
-  async takeDamage(damage, options = {}) {
+  calculateImmunityAndWeakness(options = {}) {
+    const immunityAndWeakness = {};
+
     // Determine highest weakness between all weakness and the damage's type weakness
     const allWeakness = this.damage.weaknesses.all;
     const specificWeakness = this.damage.weaknesses[options.type] ?? 0; // Null check in case the damage type is untyped
     const weaknessAmount = Math.max(allWeakness, specificWeakness);
+    if (weaknessAmount > 0) immunityAndWeakness.weakness = weaknessAmount;
 
     options.ignoredImmunities ??= [];
     // Reduce the immunities list to non-ignored immunities
@@ -387,8 +389,25 @@ export default class BaseActorModel extends DrawSteelSystemModel {
       return acc;
     }, {});
     const immunityAmount = Math.max(immunities.all ?? 0, immunities[options.type] ?? 0); // Null check in case type is not in immunities
+    if (immunityAmount > 0) immunityAndWeakness.immunity = immunityAmount;
 
-    damage = Math.max(0, damage + weaknessAmount - immunityAmount);
+    return immunityAndWeakness;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Deal damage to the actor, accounting for immunities and resistances.
+   * @param {number} damage    The amount of damage to take.
+   * @param {object} [options] Options to modify the damage application.
+   * @param {string} [options.type]   Valid damage type.
+   * @param {Array<string>} [options.ignoredImmunities]  Which damage immunities to ignore.
+   * @returns {Promise<DrawSteelActor | DrawSteelCombatantGroup>}
+   */
+  async takeDamage(damage, options = {}) {
+    const { weakness = 0, immunity = 0 } = this.calculateImmunityAndWeakness(options);
+
+    damage = Math.max(0, damage + weakness - immunity);
 
     if (damage === 0) {
       ui.notifications.info("DRAW_STEEL.Actor.DamageNotification.ImmunityReducedToZero", { format: { name: this.parent.name } });

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -1,4 +1,5 @@
 import BaseCombatantGroupModel from "./base.mjs";
+import { DrawSteelActor } from "../../documents/_module.mjs";
 import DrawSteelCombatant from "../../documents/combatant.mjs";
 
 const fields = foundry.data.fields;
@@ -150,5 +151,34 @@ export default class SquadModel extends BaseCombatantGroupModel {
       await minion.actor?.toggleStatusEffect(CONFIG.specialStatusEffects.DEFEATED, { overlay: true, active: true });
     }
     await this.combat.updateEmbeddedDocuments("Combatant", combatantUpdates);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Deal damage to the squad, accounting for immunities and resistances which are applied only once per squad.
+   * @param {Array<DrawSteelActor>} minions    The minions that are taking the damage.
+   * @param {number} damagePerMinion           The amount of damage to take.
+   * @param {object} [options]                 Options to modify the damage application.
+   * @param {string} [options.type]            Valid damage type.
+   * @param {boolean} [options.aoe]            Is this an AOE that should have the damage capped?
+   * @param {Array<string>} [options.ignoredImmunities]  Which damage immunities to ignore.
+   * @returns {Promise<DrawSteelCombatantGroup>}
+   */
+  async takeDamage(minions, damagePerMinion, options = {}) {
+    if (!minions.length) return this;
+
+    // Get all minions immunities and weaknesses and reduce it to the highest ones.
+    const applicableImmunityWeakness = { immunity: 0, weakness: 0 };
+    for (const minion of minions) {
+      const { immunity = 0, weakness = 0 } = minion.system.calculateImmunityAndWeakness(options);
+      applicableImmunityWeakness.immunity = Math.max(immunity, applicableImmunityWeakness.immunity);
+      applicableImmunityWeakness.weakness = Math.max(weakness, applicableImmunityWeakness.weakness);
+    }
+
+    if (options.aoe) damagePerMinion = Math.min(damagePerMinion, minions[0].system.stamina.max);
+    const damage = Math.max(0, (damagePerMinion * minions.length) + applicableImmunityWeakness.weakness - applicableImmunityWeakness.immunity);
+
+    return this.parent.update({ "system.staminaValue": this.staminaValue - damage }, { ds: { damageType: options.type } });
   }
 }

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -156,7 +156,7 @@ export default class SquadModel extends BaseCombatantGroupModel {
   /* -------------------------------------------------- */
 
   /**
-   * Deal damage to the squad, accounting for immunities and resistances which are applied only once per squad.
+   * Deal damage to the squad's minion stamina pool, accounting for immunities and resistances which are applied only once per squad.
    * @param {Array<DrawSteelActor>} minions    The minions that are taking the damage.
    * @param {number} damagePerMinion           The amount of damage to take.
    * @param {object} [options]                 Options to modify the damage application.
@@ -166,12 +166,14 @@ export default class SquadModel extends BaseCombatantGroupModel {
    * @returns {Promise<DrawSteelCombatantGroup>}
    */
   async takeDamage(minions, damagePerMinion, options = {}) {
-    // Converting this.minions to an Array of associated actors since the minions parameter is an Array of actors.
-    const squadActors = Array.from(this.minions.map(minion => minion.actor));
-    // Filtering the minions parameter to only actors in the squad.
-    minions = minions.filter(minion => squadActors.includes(minion));
-
     if (!minions.length) return this;
+
+    // Return early if the provided minion actors are not part of this squad.
+    const squadActors = Array.from(this.minions.map(minion => minion.actor));
+    if (!minions.every(minion => squadActors.includes(minion))) {
+      ui.notifications.error("DRAW_STEEL.CombatantGroup.Error.DamagingInapplicableActors", { localize: true });
+      return this;
+    }
 
     // Get all minions immunities and weaknesses and reduce it to the highest ones.
     const applicableImmunityWeakness = { immunity: 0, weakness: 0 };

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -166,6 +166,11 @@ export default class SquadModel extends BaseCombatantGroupModel {
    * @returns {Promise<DrawSteelCombatantGroup>}
    */
   async takeDamage(minions, damagePerMinion, options = {}) {
+    // Converting this.minions to an Array of associated actors since the minions parameter is an Array of actors.
+    const squadActors = Array.from(this.minions.map(minion => minion.actor));
+    // Filtering the minions parameter to only actors in the squad.
+    minions = minions.filter(minion => squadActors.includes(minion));
+
     if (!minions.length) return this;
 
     // Get all minions immunities and weaknesses and reduce it to the highest ones.

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -208,7 +208,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
       flavor,
       type: damageType,
       ignoredImmunities,
-      aoe: this.parent.hasTemplate,
+      aoe: this.parent.keywords.has("area"),
     });
   }
 

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -208,6 +208,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
       flavor,
       type: damageType,
       ignoredImmunities,
+      aoe: this.parent.hasTemplate,
     });
   }
 

--- a/src/module/rolls/damage.mjs
+++ b/src/module/rolls/damage.mjs
@@ -117,7 +117,7 @@ export default class DamageRoll extends DSRoll {
     // Group actors by combatant group if they are a minion with only one combat group, otherwise group the rest in a single array.
     const { actors = [], ...groups } = Object.groupBy(targets, (target => {
       if (!target.isMinion || !target.system.combatGroup || (target.system.combatGroups.size > 1)) return "actors";
-      else return target.system.combatGroup.id;
+      else return target.system.combatGroup.uuid;
     }));
 
     let amount = this.total;
@@ -136,8 +136,8 @@ export default class DamageRoll extends DSRoll {
     }
 
     // Damage minion sqauds
-    for (const actors of Object.values(groups)) {
-      const group = actors[0].system.combatGroup;
+    for (const [uuid, actors] of Object.entries(groups)) {
+      const group = fromUuidSync(uuid);
       group.system.takeDamage(actors, amount, { type: this.type, ignoredImmunities: this.ignoredImmunities, aoe: this.aoe });
     }
   }

--- a/src/module/rolls/damage.mjs
+++ b/src/module/rolls/damage.mjs
@@ -68,6 +68,16 @@ export default class DamageRoll extends DSRoll {
   /* -------------------------------------------------- */
 
   /**
+   * Is this damage from an AOE ability?
+   * @type {boolean}
+   */
+  get aoe() {
+    return this.options.aoe || false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Produces a button with relevant data to applying this damage.
    * @param {number} index The index of this roll in the `rolls` array of the message.
    * @returns {HTMLButtonElement} A button that.
@@ -104,10 +114,17 @@ export default class DamageRoll extends DSRoll {
   async applyDamage(targets, options = {}) {
     targets ??= ds.utils.tokensToActors();
 
+    // Group actors by combatant group if they are a minion with only one combat group, otherwise group the rest in a single array.
+    const { actors = [], ...groups } = Object.groupBy(targets, (target => {
+      if (!target.isMinion || !target.system.combatGroup || (target.system.combatGroups.size > 1)) return "actors";
+      else return target.system.combatGroup.id;
+    }));
+
     let amount = this.total;
     if (options.halfDamage) amount = Math.floor(amount / 2);
 
-    for (const actor of targets) {
+    // Damage actors that aren't minions or in a combat group.
+    for (const actor of actors) {
       if (this.isHeal) {
         const isTemp = this.type !== "value";
         if (isTemp && (amount < actor.system.stamina.temporary)) ui.notifications.warn("DRAW_STEEL.ChatMessage.base.Buttons.ApplyHeal.TempCapped", {
@@ -116,6 +133,12 @@ export default class DamageRoll extends DSRoll {
         else await actor.modifyTokenAttribute(isTemp ? "stamina.temporary" : "stamina", amount, !isTemp, !isTemp);
       }
       else await actor.system.takeDamage(amount, { type: this.type, ignoredImmunities: this.ignoredImmunities });
+    }
+
+    // Damage minion sqauds
+    for (const actors of Object.values(groups)) {
+      const group = actors[0].system.combatGroup;
+      group.system.takeDamage(actors, amount, { type: this.type, ignoredImmunities: this.ignoredImmunities, aoe: this.aoe });
     }
   }
 }


### PR DESCRIPTION
Benefits and Improvements: 
- Allows us to only account for immunity and weakness only once for the whole squad instead of per minion as was before.
- Adds an `aoe` option that when true, clamps the damage per minion to their stamina threshold
   - The `aoe` option can either be set as an option on the damage roll or passed as an option to the `takeDamage` method. 
   - It automatically gets set from the damage PRE's `toDamageRoll` method.