### PR TITLE
[#1847] Update `recoveries.max` field to remove the max and be non-persisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 ### Known Issues
 -->
 
+## 1.0.1
+
+### Fixed
+
+- Fixed application of Active Effects that modified a hero's max recoveries. (#1847)
+
 ## 1.0.0
 
 The latest version of Draw Steel is v14-exclusive. You can see the full v14 stable release notes [here](https://foundryvtt.com/releases/14.359) as well as the Stable 2 bugfixes [here](https://foundryvtt.com/releases/14.360) (Foundry Version 14.360 is a required minimum, please update if you already installed v14.359). This Draw Steel release fully incorporates new features like:

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -56,7 +56,7 @@ export default class HeroModel extends CreatureModel {
 
     schema.recoveries = new fields.SchemaField({
       value: requiredInteger(),
-      max: requiredInteger({ max: 0 }),
+      max: requiredInteger({ persisted: false }),
       bonus: requiredInteger({ persisted: false }),
       divisor: new fields.NumberField({ initial: 3, nullable: false, persisted: false }),
     });


### PR DESCRIPTION
Closes #1847 