### PR TITLE
[#1850] Fixed removing targets from dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - Fixed application of Active Effects that modified a hero's max recoveries. (#1847)
+- Fixed inability to remove targets from ability configuration dialog. (#1850)
 
 ## 1.0.0
 

--- a/src/module/applications/apps/ability-configuration-dialog.mjs
+++ b/src/module/applications/apps/ability-configuration-dialog.mjs
@@ -50,17 +50,19 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
   #targetHook = Hooks.on("targetToken", (user, token, targeted) => {
     if ((user !== game.user) || !this.options.context.targets) return;
 
-    for (const targetData of foundry.utils.iterateValues(this.options.context.targets)) {
-      if (targetData.uuid === token.actor.uuid) return;
-    }
+    if (targeted) {
+      for (const targetData of foundry.utils.iterateValues(this.options.context.targets)) {
+        if (targetData.uuid === token.actor.uuid) return;
+      }
 
-    if (targeted) this.options.context.targets[token.id] = {
-      actor: token.actor,
-      token: token.document,
-      tokenUuid: token.document.uuid,
-      uuid: token.actor.uuid,
-      modifiers: this.item.system.getTargetModifiers(token),
-    };
+      this.options.context.targets[token.id] = {
+        actor: token.actor,
+        token: token.document,
+        tokenUuid: token.document.uuid,
+        uuid: token.actor.uuid,
+        modifiers: this.item.system.getTargetModifiers(token),
+      };
+    }
     else delete this.options.context.targets[token.id];
 
     // Re-render to update the target list and modifiers.


### PR DESCRIPTION
The duplicate check should only happen if it's trying to add

Closes #1850