### PR TITLE
[#1845] Adjusted CSS for ability configuration dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 ### Changed
 
+- Updated Player-Facing Compendium Content:
+  - Implemented roll-data scaling change values for ancestry traits.
+  - Updated many censor and conduit abilities to feature new AE keys like improved forced movement distance and scaling with roll data.
 - Tweaked styling of Ability Configuration dialog. (#1845)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ## 1.0.1
 
+### Changed
+
+- Tweaked styling of Ability Configuration dialog. (#1845)
+
 ### Fixed
 
 - Fixed application of Active Effects that modified a hero's max recoveries. (#1847)

--- a/src/styles/system/applications/apps/ability-configuration-dialog.css
+++ b/src/styles/system/applications/apps/ability-configuration-dialog.css
@@ -1,19 +1,27 @@
 .draw-steel.ability-configuration-dialog {
   &.two-column section.window-content {
     display: grid;
-    grid-template-columns: auto auto;
+    grid: "targets resource" "targets damage" / 1fr 1fr;
     .roll-config {
       grid-row: 1 / span 2;
     }
     .ability-config {
-      align-self: end;
+      align-self: flex-start;
     }
     footer {
-      align-self: start;
+      align-self: flex-end;
     }
   }
 
   a.header {
     width: 100%;
+  }
+
+  .group label span {
+    white-space: nowrap;
+  }
+
+  fieldset + .form-group {
+    margin-top: 0.5rem;
   }
 }


### PR DESCRIPTION
<img width="696" height="257" alt="image" src="https://github.com/user-attachments/assets/fc3f02dd-b2f9-427e-9aa4-a8fdfd50247b" />


<img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/16a809c4-1a82-4630-8714-ccb4d11231cb" />

<img width="400" height="143" alt="image" src="https://github.com/user-attachments/assets/9ee0cc04-31a0-4e76-a0b3-7fe037eb637e" />

<img width="695" height="275" alt="image" src="https://github.com/user-attachments/assets/eb9ebf26-bf5e-4a4d-a939-7968c3d83599" />

<img width="395" height="244" alt="image" src="https://github.com/user-attachments/assets/3f1c4b6b-a100-4a31-b548-08831c787835" />


Closes #1845 