### PR TITLE
Removed gmOnly server side validation due to core bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed application of Active Effects that modified a hero's max recoveries. (#1847)
 - Fixed inability to remove targets from ability configuration dialog. (#1850)
 - Fixed retainers and objects not being able to use abilities. (#1856)
+- Fixed a bug where players could not create actors or items even with the appropriate permissions.
 
 ## 1.0.0
 

--- a/system.json
+++ b/system.json
@@ -19,23 +19,19 @@
     },
     "Actor": {
       "hero": {
-        "htmlFields": ["biography.value", "biography.director"],
-        "gmOnlyFields": ["biography.director"]
+        "htmlFields": ["biography.value", "biography.director"]
       },
       "npc": {
-        "htmlFields": ["biography.value", "biography.director"],
-        "gmOnlyFields": ["biography.director"]
+        "htmlFields": ["biography.value", "biography.director"]
       },
       "object": {
-        "htmlFields": ["biography.value", "biography.director"],
-        "gmOnlyFields": ["biography.director"]
+        "htmlFields": ["biography.value", "biography.director"]
       },
       "party": {
         "htmlFields": ["description.value"]
       },
       "retainer": {
-        "htmlFields": ["biography.value", "biography.director"],
-        "gmOnlyFields": ["biography.director"]
+        "htmlFields": ["biography.value", "biography.director"]
       }
     },
     "ChatMessage": {
@@ -56,100 +52,86 @@
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "ancestryTrait": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "career": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "class": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "complication": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "culture": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "feature": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "follower": {
-        "htmlFields": ["description.value", "description.director"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director"]
       },
       "kit": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "perk": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "project": {
-        "htmlFields": ["description.value", "description.director"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director"]
       },
       "subclass": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "title": {
         "filePathFields": {
           "advancements.*.img": ["IMAGE"],
           "advancements.*.traits.*.img": ["IMAGE"]
         },
-        "htmlFields": ["description.value", "description.director", "advancements.*.description"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director", "advancements.*.description"]
       },
       "treasure": {
-        "htmlFields": ["description.value", "description.director"],
-        "gmOnlyFields": ["description.director"]
+        "htmlFields": ["description.value", "description.director"]
       }
     },
     "JournalEntryPage": {


### PR DESCRIPTION
Bug explanation: The gmonly field getting validated on the server is blocking creation of actors and items due to players being unable to update, or apparently create, the fields marked gmOnly

We can add it back in for 1.1 after we update the system version minimum, but with no guarantee core will fix the bug it's probably fine to remove the hard-validation since these fields are hidden in the UI regardless.