### PR TITLE
AE project integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Added
 
+- Added project data to Active Effects to help implement Imbued treasures. (#1843)
+
 ### Changed
 
 ### Deprecated

--- a/lang/en.json
+++ b/lang/en.json
@@ -1821,6 +1821,9 @@
               "label": "Project Goal"
             },
             "yield": {
+              "kind": {
+                "label": "Treasure Kind"
+              },
               "amount": {
                 "label": "Yield Amount"
               },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1698,6 +1698,11 @@
           "FromTreasure": {
             "Label": "Start Crafting Project",
             "Notification": "Started crafting project for {item}."
+          },
+          "EffectDialog": {
+            "Title": "Leveled Treasure Selection",
+            "Label": "Leveled Treasure",
+            "Hint": "Which leveled treasure item do you want to add this effect to? Selecting blank or closing without selection will create a new leveled treasure."
           }
         },
         "SpendCareerPoints": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1668,8 +1668,8 @@
           },
           "yield": {
             "label": "Yield",
-            "item": {
-              "label": "Yield Item UUID"
+            "document": {
+              "label": "Yield Document UUID"
             },
             "amount": {
               "label": "Yield Amount"

--- a/src/module/applications/sheets/active-effect-config.mjs
+++ b/src/module/applications/sheets/active-effect-config.mjs
@@ -53,6 +53,7 @@ export default class DrawSteelActiveEffectConfig extends foundry.applications.sh
       case "details":
         context.keywordOptions = ds.CONFIG.abilities.keywordOptions;
         context.characteristicOptions = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label }));
+        context.kindOptions = Object.entries(ds.CONFIG.equipment.kinds).map(([value, { label }]) => ({ value, label }));
         break;
     }
 

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -569,7 +569,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
   async _onDropActiveEffect(event, effect) {
     // If the effect is dropped onto the project tab, create the effect as a project instead
     const projectDropTarget = event.target.closest("[data-application-part='projects']");
-    if (projectDropTarget && (this.actor.uuid !== effect.parent?.uuid)) {
+    if (projectDropTarget && (this.actor !== effect.parent)) {
       await effect.system.createProject(this.actor);
       return;
     }

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -547,7 +547,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
         // If it's a treasure dropped on the project tab, create the item as a project
         if (projectDropTarget && (item.type === "treasure")) {
           const name = _loc("DRAW_STEEL.Item.project.Craft.ItemName", { name: item.name });
-          return { name, type: "project", "system.yield.item": item.uuid };
+          return { name, type: "project", "system.yield.document": item.uuid };
         }
         else if (item.supportsAdvancements && (item.getEmbeddedCollection("Advancement").size > 0)) {
           ui.notifications.error("DRAW_STEEL.SHEET.NoCreateAdvancement", { format: { name: item.name } });

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -562,4 +562,18 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
     await this.actor.createEmbeddedDocuments("Item", droppedItemData.filter(_ => _), { keepId: true });
     return folder;
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onDropActiveEffect(event, effect) {
+    // If the effect is dropped onto the project tab, create the effect as a project instead
+    const projectDropTarget = event.target.closest("[data-application-part='projects']");
+    if (projectDropTarget && (this.actor.uuid !== effect.parent?.uuid)) {
+      await effect.system.createProject(this.actor);
+      return;
+    }
+
+    return super._onDropActiveEffect(event, effect);
+  }
 }

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2080,7 +2080,7 @@ const equipmentKinds = {
   },
   weapon: {
     label: "DRAW_STEEL.Item.treasure.Kinds.Weapon",
-    icon: "",
+    icon: "fa-solid fa-sword",
   },
 };
 

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2063,20 +2063,24 @@ const treasureCategories = {
 
 /**
  * Used by Leveled Treasures and Artifacts.
- * @type {Record<string, {label: string}>}
+ * @type {Record<string, {label: string, icon: string}>}
  */
 const equipmentKinds = {
   other: {
     label: "DRAW_STEEL.Item.treasure.Kinds.Other",
+    icon: "fa-solid fa-suitcase",
   },
   armor: {
     label: "DRAW_STEEL.Item.treasure.Kinds.Armor",
+    icon: "fa-solid fa-shield",
   },
   implement: {
     label: "DRAW_STEEL.Item.treasure.Kinds.Implement",
+    icon: "fa-solid fa-wand-sparkles",
   },
   weapon: {
     label: "DRAW_STEEL.Item.treasure.Kinds.Weapon",
+    icon: "",
   },
 };
 

--- a/src/module/data/effect/base-effect.mjs
+++ b/src/module/data/effect/base-effect.mjs
@@ -44,6 +44,7 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
       rollCharacteristic: new fields.SetField(setOptions()),
       goal: new fields.NumberField(),
       yield: new fields.SchemaField({
+        kind: new fields.StringField({ required: true, initial: "weapon" }),
         amount: new FormulaField({ initial: "1" }),
         display: new fields.StringField({ required: true }),
       }),

--- a/src/module/data/effect/base-effect.mjs
+++ b/src/module/data/effect/base-effect.mjs
@@ -162,6 +162,6 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
     if (!actor) return;
 
     const name = _loc("DRAW_STEEL.Item.project.Craft.ItemName", { name: this.parent.name });
-    return getDocumentClass("Item").create({ name, type: "project", "system.yield.item": this.parent.uuid }, { parent: actor });
+    return getDocumentClass("Item").create({ name, type: "project", "system.yield.document": this.parent.uuid }, { parent: actor });
   }
 }

--- a/src/module/data/effect/base-effect.mjs
+++ b/src/module/data/effect/base-effect.mjs
@@ -150,4 +150,18 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
 
     return roll.toMessage(messageData, messageOptions);
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Creates a project for this equipment on the provided actor.
+   * @param {DrawSteelActor} actor
+   * @returns {DrawSteelItem}
+   */
+  async createProject(actor) {
+    if (!actor) return;
+
+    const name = _loc("DRAW_STEEL.Item.project.Craft.ItemName", { name: this.parent.name });
+    return getDocumentClass("Item").create({ name, type: "project", "system.yield.item": this.parent.uuid }, { parent: actor });
+  }
 }

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -404,7 +404,7 @@ export default class ProjectModel extends BaseItemModel {
   async _createCraftedEffect(doc, amount) {
     // Prompt for adding to existing item, or adding to a new item.
     const treasures = this.actor.items.documentsByType.treasure
-      .filter(treasure => treasure.system.category === "leveled")
+      .filter(treasure => (treasure.system.category === "leveled") && (treasure.system.kind === doc.system.project.yield.kind))
       .map(treasure => ({ label: treasure.name, value: treasure.id }));
     const { createFormGroup, createSelectInput } = foundry.applications.fields;
 
@@ -423,14 +423,24 @@ export default class ProjectModel extends BaseItemModel {
 
     const fd = await ds.applications.api.DSDialog.input({
       content,
-      window: { title: "DRAW_STEEL.Item.project.Craft.EffectDialog.Title" },
+      window: {
+        title: "DRAW_STEEL.Item.project.Craft.EffectDialog.Title",
+        icon: ds.CONFIG.equipment.kinds[doc.system.project.yield.kind ?? "other"].icon,
+      },
     });
 
     let item;
     if (fd?.treasure) item = this.actor.items.get(fd.treasure);
     else {
       const defaultName = getDocumentClass("Item").defaultName({ type: "treasure", parent: this.actor });
-      item = await getDocumentClass("Item").create({ name: defaultName, type: "treasure", "system.category": "leveled" }, { parent: this.actor });
+      item = await getDocumentClass("Item").create({
+        name: defaultName,
+        type: "treasure",
+        system: {
+          category: "leveled",
+          kind: doc.system.project.yield.kind,
+        },
+      }, { parent: this.actor });
     }
 
     const effectData = doc.toObject();

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -355,12 +355,12 @@ export default class ProjectModel extends BaseItemModel {
   async completeCraftingProject() {
     if (!this.actor) return console.error("This project has no owner actor.");
 
-    const doc = await fromUuid(this.yield.document);
+    const document = await fromUuid(this.yield.document);
     const yieldRoll = await new DSRoll(this.yield.amount).evaluate();
     const amount = yieldRoll.total;
 
-    if (doc.documentName === "Item") await this._createCraftedItem(doc, amount);
-    else if (doc.documentName === "ActiveEffect") await this._createCraftedEffect(doc, amount);
+    if (document.documentName === "Item") await this._createCraftedItem(document, amount);
+    else if (document.documentName === "ActiveEffect") await this._createCraftedEffect(document, amount);
 
     const labelSuffix = game.i18n.pluralRules.select(amount);
 
@@ -368,7 +368,7 @@ export default class ProjectModel extends BaseItemModel {
       format: {
         actor: this.actor.name,
         amount,
-        item: doc.name,
+        item: document.name,
       },
     });
   }
@@ -377,17 +377,17 @@ export default class ProjectModel extends BaseItemModel {
 
   /**
    * Perform the item creation and updates when the yielded document is an Item.
-   * @param {DrawSteelItem} doc    The document yielded from this project.
-   * @param {number} amount        The amount yielded.
+   * @param {DrawSteelItem} item    The yielded item from this project.
+   * @param {number} amount         The amount yielded.
    * @protected
    */
-  async _createCraftedItem(doc, amount) {
+  async _createCraftedItem(item, amount) {
     // If there's an existing item, add the amount to the item's quantity, otherwise create a new item with the quantity amount
-    const existingItem = this.actor.items.find(i => i.dsid === doc.dsid);
+    const existingItem = this.actor.items.find(i => i.dsid === item.dsid);
     if (existingItem) {
       await existingItem.update({ "system.quantity": existingItem.system.quantity + amount });
     } else {
-      const itemData = game.items.fromCompendium(doc, { clearFolder: true });
+      const itemData = game.items.fromCompendium(item, { clearFolder: true });
       itemData.system.quantity = amount;
       await this.actor.createEmbeddedDocuments("Item", [itemData]);
     }
@@ -396,15 +396,15 @@ export default class ProjectModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /**
-   * Perform the item creation and updates when the yielded document is an Item.
-   * @param {DrawSteelActiveEffect} doc   The document yielded from this project.
-   * @param {number} amount               The amount yielded.
+   * Prompt for treasure selection and create the effect on the chosen item.
+   * @param {DrawSteelActiveEffect} effect   The yielded effect from this project.
+   * @param {number} amount                  The amount yielded.
    * @protected
    */
-  async _createCraftedEffect(doc, amount) {
+  async _createCraftedEffect(effect, amount) {
     // Prompt for adding to existing item, or adding to a new item.
     const treasures = this.actor.items.documentsByType.treasure
-      .filter(treasure => (treasure.system.category === "leveled") && (treasure.system.kind === doc.system.project.yield.kind))
+      .filter(treasure => (treasure.system.category === "leveled") && (treasure.system.kind === effect.system.project.yield.kind))
       .map(treasure => ({ label: treasure.name, value: treasure.id }));
     const { createFormGroup, createSelectInput } = foundry.applications.fields;
 
@@ -421,11 +421,12 @@ export default class ProjectModel extends BaseItemModel {
       }),
     }));
 
+    const kindConfig = ds.CONFIG.equipment.kinds;
     const fd = await ds.applications.api.DSDialog.input({
       content,
       window: {
         title: "DRAW_STEEL.Item.project.Craft.EffectDialog.Title",
-        icon: ds.CONFIG.equipment.kinds[doc.system.project.yield.kind ?? "other"].icon,
+        icon: kindConfig[effect.system.project.yield.kind]?.icon ?? kindConfig.other.icon,
       },
     });
 
@@ -438,12 +439,12 @@ export default class ProjectModel extends BaseItemModel {
         type: "treasure",
         system: {
           category: "leveled",
-          kind: doc.system.project.yield.kind,
+          kind: effect.system.project.yield.kind,
         },
       }, { parent: this.actor });
     }
 
-    const effectData = doc.toObject();
+    const effectData = effect.toObject();
     effectData.transfer = true;
     await item.createEmbeddedDocuments("ActiveEffect", [effectData]);
   }

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -75,13 +75,13 @@ export default class ProjectModel extends BaseItemModel {
     const allowed = await super._preCreate(data, options, user);
     if (allowed === false) return false;
 
-    // If creating with item UUID, transfer the item project data to the project item
-    const itemUUID = data.system?.yield?.item;
-    const yieldItem = await fromUuid(itemUUID);
-    if (yieldItem?.type === "treasure") {
-      const { prerequisites, rollCharacteristic, goal, source } = yieldItem.system.project;
+    // If creating with a doucment UUID, transfer the document's project data to the project item.
+    const uuid = data.system?.yield?.item;
+    const yieldDocument = await fromUuid(uuid);
+    if ((yieldDocument?.type === "treasure") || (yieldDocument.documentName === "ActiveEffect")) {
+      const { prerequisites, rollCharacteristic, goal, source } = yieldDocument.system.project;
       this.parent.updateSource({
-        img: yieldItem.img,
+        img: yieldDocument.img,
         system: {
           type: "crafting",
           prerequisites,
@@ -89,9 +89,9 @@ export default class ProjectModel extends BaseItemModel {
           goal,
           projectSource: source,
           yield: {
-            item: itemUUID,
-            amount: yieldItem.system.project.yield.amount,
-            display: yieldItem.system.project.yield.display,
+            item: uuid,
+            amount: yieldDocument.system.project.yield.amount,
+            display: yieldDocument.system.project.yield.display,
           },
         },
       });
@@ -344,19 +344,12 @@ export default class ProjectModel extends BaseItemModel {
   async completeCraftingProject() {
     if (!this.actor) return console.error("This project has no owner actor.");
 
-    const item = await fromUuid(this.yield.item);
-    const existingItem = this.actor.items.find(i => i.dsid === item.dsid);
+    const doc = await fromUuid(this.yield.item);
     const yieldRoll = await new DSRoll(this.yield.amount).evaluate();
     const amount = yieldRoll.total;
 
-    // If there's an existing item, add the amount to the item's quantity, otherwise create a new item with the quantity amount
-    if (existingItem) {
-      await existingItem.update({ "system.quantity": existingItem.system.quantity + amount });
-    } else {
-      const itemData = game.items.fromCompendium(item, { clearFolder: true });
-      itemData.system.quantity = amount;
-      await this.actor.createEmbeddedDocuments("Item", [itemData]);
-    }
+    if (doc.documentName === "Item") await this._createCraftedItem(doc, amount);
+    else if (doc.documentName === "ActiveEffect") await this._createCraftedEffect(doc, amount);
 
     const labelSuffix = game.i18n.pluralRules.select(amount);
 
@@ -364,9 +357,70 @@ export default class ProjectModel extends BaseItemModel {
       format: {
         actor: this.actor.name,
         amount,
-        item: item.name,
+        item: doc.name,
       },
     });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform the item creation and updates when the yielded document is an Item.
+   * @param {*} doc      The document yielded from this project.
+   * @param {*} amount   The amount yielded.
+   */
+  async _createCraftedItem(doc, amount) {
+    // If there's an existing item, add the amount to the item's quantity, otherwise create a new item with the quantity amount
+    const existingItem = this.actor.items.find(i => i.dsid === doc.dsid);
+    if (existingItem) {
+      await existingItem.update({ "system.quantity": existingItem.system.quantity + amount });
+    } else {
+      const itemData = game.items.fromCompendium(doc, { clearFolder: true });
+      itemData.system.quantity = amount;
+      await this.actor.createEmbeddedDocuments("Item", [itemData]);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform the item creation and updates when the yielded document is an Item.
+   * @param {*} doc      The document yielded from this project.
+   * @param {*} amount   The amount yielded.
+   */
+  async _createCraftedEffect(doc, amount) {
+    // Prompt for adding to existing item, or adding to a new item.
+    const treasures = this.actor.items.documentsByType.treasure.filter(treasure => treasure.system.category === "leveled").map(treasure => ({ label: treasure.name, value: treasure.id }));
+    const { createFormGroup, createSelectInput } = foundry.applications.fields;
+
+    const content = document.createElement("div");
+
+    content.append(createFormGroup({
+      label: "DRAW_STEEL.Item.project.Craft.EffectDialog.Label",
+      hint: "DRAW_STEEL.Item.project.Craft.EffectDialog.Hint",
+      localize: true,
+      input: createSelectInput({
+        name: "treasure",
+        options: treasures,
+        blank: "",
+      }),
+    }));
+
+    const fd = await ds.applications.api.DSDialog.input({
+      content,
+      window: { title: "DRAW_STEEL.Item.project.Craft.EffectDialog.Title" },
+    });
+
+    let item;
+    if (fd?.treasure) item = this.actor.items.get(fd.treasure);
+    else {
+      const defaultName = getDocumentClass("Item").defaultName({ type: "treasure", parent: this.actor });
+      item = (await this.actor.createEmbeddedDocuments("Item", [{ name: defaultName, type: "treasure", "system.category": "leveled" }]))[0];
+    }
+
+    const effectData = doc.toObject();
+    effectData.transfer = true;
+    await item.createEmbeddedDocuments("ActiveEffect", [effectData]);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -50,12 +50,22 @@ export default class ProjectModel extends BaseItemModel {
     schema.points = new fields.NumberField({ required: true, integer: true, min: 0, initial: 0 });
     schema.events = new fields.DocumentUUIDField({ initial: "Compendium.draw-steel.tables.RollTable.ebiZk3Sfa6Jw1JKk", type: "RollTable" });
     schema.yield = new fields.SchemaField({
-      item: new fields.DocumentUUIDField(),
+      document: new fields.DocumentUUIDField(),
       amount: new FormulaField({ initial: "1" }),
       display: new fields.StringField({ required: true }),
     });
 
     return schema;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static migrateData(data) {
+    // 1.1 migration
+    foundry.abstract.Document._addDataFieldMigration(data, "yield.item", "yield.document");
+
+    return super.migrateData(data);
   }
 
   /* -------------------------------------------------- */
@@ -77,7 +87,7 @@ export default class ProjectModel extends BaseItemModel {
     if (allowed === false) return false;
 
     // If creating with a doment UUID, transfer the document's project data to the project item.
-    const uuid = data.system?.yield?.item;
+    const uuid = data.system?.yield?.document;
     const yieldDocument = await fromUuid(uuid);
     if ((yieldDocument?.type === "treasure") || (yieldDocument.documentName === "ActiveEffect")) {
       const { prerequisites, rollCharacteristic, goal, source } = yieldDocument.system.project;
@@ -131,7 +141,7 @@ export default class ProjectModel extends BaseItemModel {
         },
       });
 
-      if (this.yield.item) this.completeCraftingProject();
+      if (this.yield.document) this.completeCraftingProject();
     }
   }
 
@@ -170,8 +180,8 @@ export default class ProjectModel extends BaseItemModel {
     const characteristicList = Array.from(this.rollCharacteristic).map(c => ds.CONFIG.characteristics[c]?.label ?? c);
     context.formattedCharacteristics = characteristicFormatter.format(characteristicList);
 
-    if (this.yield.item) {
-      const item = await fromUuid(this.yield.item);
+    if (this.yield.document) {
+      const item = await fromUuid(this.yield.document);
       context.itemLink = item?.toAnchor().outerHTML;
     }
   }
@@ -345,7 +355,7 @@ export default class ProjectModel extends BaseItemModel {
   async completeCraftingProject() {
     if (!this.actor) return console.error("This project has no owner actor.");
 
-    const doc = await fromUuid(this.yield.item);
+    const doc = await fromUuid(this.yield.document);
     const yieldRoll = await new DSRoll(this.yield.amount).evaluate();
     const amount = yieldRoll.total;
 

--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -11,7 +11,8 @@ import { setOptions } from "../helpers.mjs";
  * @import { DocumentHTMLEmbedConfig, EnrichmentOptions } from "@client/applications/ux/text-editor.mjs";
  * @import { ApplicationConfiguration } from "@client/applications/_types.mjs";
  * @import { DatabaseCreateOperation } from "@common/abstract/_types.mjs";
- * @import { ProjectRollModifiers, ProjectRollPrompt, ProjectRollPromptOptions } from  "../../_types.js"
+ * @import { ProjectRollModifiers, ProjectRollPrompt, ProjectRollPromptOptions } from  "../../_types.js";
+ * @import { DrawSteelItem, DrawSteelActiveEffect } from "../../documents/_module.mjs";
  */
 
 const fields = foundry.data.fields;
@@ -75,7 +76,7 @@ export default class ProjectModel extends BaseItemModel {
     const allowed = await super._preCreate(data, options, user);
     if (allowed === false) return false;
 
-    // If creating with a doucment UUID, transfer the document's project data to the project item.
+    // If creating with a doment UUID, transfer the document's project data to the project item.
     const uuid = data.system?.yield?.item;
     const yieldDocument = await fromUuid(uuid);
     if ((yieldDocument?.type === "treasure") || (yieldDocument.documentName === "ActiveEffect")) {
@@ -366,8 +367,9 @@ export default class ProjectModel extends BaseItemModel {
 
   /**
    * Perform the item creation and updates when the yielded document is an Item.
-   * @param {*} doc      The document yielded from this project.
-   * @param {*} amount   The amount yielded.
+   * @param {DrawSteelItem} doc    The document yielded from this project.
+   * @param {number} amount        The amount yielded.
+   * @protected
    */
   async _createCraftedItem(doc, amount) {
     // If there's an existing item, add the amount to the item's quantity, otherwise create a new item with the quantity amount
@@ -385,12 +387,15 @@ export default class ProjectModel extends BaseItemModel {
 
   /**
    * Perform the item creation and updates when the yielded document is an Item.
-   * @param {*} doc      The document yielded from this project.
-   * @param {*} amount   The amount yielded.
+   * @param {DrawSteelActiveEffect} doc   The document yielded from this project.
+   * @param {number} amount               The amount yielded.
+   * @protected
    */
   async _createCraftedEffect(doc, amount) {
     // Prompt for adding to existing item, or adding to a new item.
-    const treasures = this.actor.items.documentsByType.treasure.filter(treasure => treasure.system.category === "leveled").map(treasure => ({ label: treasure.name, value: treasure.id }));
+    const treasures = this.actor.items.documentsByType.treasure
+      .filter(treasure => treasure.system.category === "leveled")
+      .map(treasure => ({ label: treasure.name, value: treasure.id }));
     const { createFormGroup, createSelectInput } = foundry.applications.fields;
 
     const content = document.createElement("div");
@@ -415,7 +420,7 @@ export default class ProjectModel extends BaseItemModel {
     if (fd?.treasure) item = this.actor.items.get(fd.treasure);
     else {
       const defaultName = getDocumentClass("Item").defaultName({ type: "treasure", parent: this.actor });
-      item = (await this.actor.createEmbeddedDocuments("Item", [{ name: defaultName, type: "treasure", "system.category": "leveled" }]))[0];
+      item = await getDocumentClass("Item").create({ name: defaultName, type: "treasure", "system.category": "leveled" }, { parent: this.actor });
     }
 
     const effectData = doc.toObject();

--- a/src/module/data/item/treasure.mjs
+++ b/src/module/data/item/treasure.mjs
@@ -146,6 +146,6 @@ export default class TreasureModel extends BaseItemModel {
     if (!actor) return;
 
     const name = _loc("DRAW_STEEL.Item.project.Craft.ItemName", { name: this.parent.name });
-    return getDocumentClass("Item").create({ name, type: "project", "system.yield.item": this.parent.uuid }, { parent: actor });
+    return getDocumentClass("Item").create({ name, type: "project", "system.yield.document": this.parent.uuid }, { parent: actor });
   }
 }

--- a/templates/embeds/item/project.hbs
+++ b/templates/embeds/item/project.hbs
@@ -18,7 +18,7 @@
     {{/if}}
 
     {{#if itemLink}}
-    <dt class="item-link">{{localize "DOCUMENT.Item"}}</dt>
+    <dt class="item-link">{{localize "DOCUMENT.Document"}}</dt>
     <dd class="item-link">{{{itemLink}}}</dd>
     {{/if}}
   </dl>

--- a/templates/sheets/active-effect/details.hbs
+++ b/templates/sheets/active-effect/details.hbs
@@ -25,6 +25,7 @@
     {{formGroup systemFields.project.fields.source value=source.system.project.source}}
     {{formGroup systemFields.project.fields.rollCharacteristic value=source.system.project.rollCharacteristic options=characteristicOptions}}
     {{formGroup systemFields.project.fields.goal value=source.system.project.goal}}
+    {{formGroup systemFields.project.fields.yield.fields.kind value=source.system.project.yield.kind options=kindOptions blank=false}}
     {{formGroup systemFields.project.fields.yield.fields.amount value=source.system.project.yield.amount}}
     {{formGroup systemFields.project.fields.yield.fields.display value=source.system.project.yield.display}}
   </fieldset>

--- a/templates/sheets/item/partials/project.hbs
+++ b/templates/sheets/item/partials/project.hbs
@@ -12,7 +12,7 @@
 {{formGroup systemFields.events value=system.events}}
 <fieldset>
   <legend>{{systemFields.yield.label}}</legend>
-  {{formGroup systemFields.yield.fields.item value=system.yield.item}}
+  {{formGroup systemFields.yield.fields.document value=system.yield.document}}
   {{formGroup systemFields.yield.fields.amount value=system.yield.amount}}
   {{formGroup systemFields.yield.fields.display value=system.yield.display}}
 </fieldset>


### PR DESCRIPTION
Closes #1843 

Adds the integration with AE to Projects. If an AE is dropped on the project tab, it will create a new project with the yielded item set to the AE. Once the project is completed, it prompts for which item to attach the AE to. If blank is selected or it's closed without selection, it will create a new item and attach the AE to it.