### PR TITLE
[#1858] Fixed turn end effects expiring during wrong combatant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@
 ### Known Issues
 -->
 
-## 1.0.1
+## 1.0.2
 
 ### Fixed
 
-- Corrected combatant linkage for applied effects, ensuring they expire at the appropriate time (#1858).
+- Corrected combatant linkage for applied effects, ensuring they expire at the appropriate time. (#1858)
+- Cleaned up a console error that would appear when creating a combat. (#1873)
+- Fixed the ability configuration dialog to allow 0 cost abilities. (#1876)
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 ## 1.0.1
 
+### Fixed
+
+- Corrected combatant linkage for applied effects, ensuring they expire at the appropriate time (#1858).
+
+## 1.0.1
+
 ### Changed
 
 - Updated Player-Facing Compendium Content:

--- a/src/module/applications/ux/enrichers/apply-effect.mjs
+++ b/src/module/applications/ux/enrichers/apply-effect.mjs
@@ -130,15 +130,6 @@ async function onClickAnchor() {
     (await fromUuid(this.dataset.uuid)).clone({}, { keepId: noStack, addSource: true }) :
     await DrawSteelActiveEffect.fromStatusEffect(this.dataset.status);
 
-  /** @type {ActiveEffectData} */
-  const updates = {
-    transfer: true,
-    origin: this.dataset.origin,
-  };
-  if (this.dataset.end) updates.duration = { expiry: ds.CONFIG.effectEnds[this.dataset.end].expiryEvent };
-  // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
-  const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
-
   /** @type {Set<DrawSteelActor>} */
   const actors = new Set();
 
@@ -148,11 +139,30 @@ async function onClickAnchor() {
   /** @type {DatabaseWriteOperation[]} */
   const toCreate = [];
 
+  // Only keep the initiative value if using the "alternative" (D&D style countdown) initiative.
+  const keepInitiative = !game.combats.isDefaultInitiativeMode;
+
   for (const token of tokens) {
     const actor = token.actor;
     if (!actor) continue;
     else if (actors.has(actor)) continue;
     else actors.add(actor);
+
+    const combatant = game.combat?.getCombatantsByActor(actor)[0];
+
+    /** @type {ActiveEffectData} */
+    const updates = {
+      transfer: true,
+      origin: this.dataset.origin,
+    };
+    if (this.dataset.end) updates.duration = { expiry: ds.CONFIG.effectEnds[this.dataset.end].expiryEvent };
+    if (combatant) updates.start = {
+      combatant,
+      initiative: keepInitiative ? combatant.initiative : null,
+      time: game.time.worldTime,
+    };
+    // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
+    const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
 
     // reusing the ID will block creation if it's already on the actor
     const existing = actor.effects.get(tempEffect.id);

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -198,15 +198,6 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
       ? await DrawSteelActiveEffect.fromStatusEffect(effectId)
       : this.item.effects.get(effectId).clone({}, { keepId: noStack, addSource: true });
 
-    /** @type {ActiveEffectData} */
-    const updates = {
-      transfer: true,
-      origin: this.item.uuid,
-    };
-    if (config.end) updates.duration = { expiry: ds.CONFIG.effectEnds[config.end].expiryEvent };
-    // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
-    const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
-
     const targetActors = options.targets ?? ds.utils.tokensToActors();
 
     // Need separate operations because all deletions must be done before creations to avoid id collisions
@@ -215,11 +206,31 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
     /** @type {DatabaseWriteOperation[]} */
     const toCreate = [];
 
+    // Only keep the initiative value if using the "alternative" (D&D style countdown) initiative.
+    const keepInitiative = !game.combats.isDefaultInitiativeMode;
+
     for (const actor of targetActors) {
+      const combatant = game.combat?.getCombatantsByActor(actor)[0];
+
+      /** @type {ActiveEffectData} */
+      const updates = {
+        transfer: true,
+        origin: this.item.uuid,
+      };
+      if (config.end) updates.duration = { expiry: ds.CONFIG.effectEnds[config.end].expiryEvent };
+      if (combatant) updates.start = {
+        combatant,
+        initiative: keepInitiative ? combatant.initiative : null,
+        time: game.time.worldTime,
+      };
+      // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
+      const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
+
       // reusing the ID will block creation if it's already on the actor
       const existing = actor.effects.get(tempEffect.id);
       // deleting instead of updating because there may be variances between the old copy and new
       if (existing) toDelete.push({ action: "delete", parent: actor, documentName: "ActiveEffect", ids: [tempEffect.id] });
+
       toCreate.push({ action: "create", parent: actor, documentName: "ActiveEffect", data: [createData], keepId: noStack });
     }
 


### PR DESCRIPTION
The registry uses the assigned `combatant` of the AE, which was defaulting to the *current* combatant, leading to an adverse effect for turn-ends expiry events. This also paves the way for a much simpler implementation of #1857 

Closes #1858