### PR TITLE
Implemented renderChild

### DIFF
--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -431,7 +431,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editCharacteristics(event, target) {
-    return this.renderChild(new CharacteristicInput({ document: this.document }));
+    this.renderChild(new CharacteristicInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -294,19 +294,25 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #addOrigin(event, target) {
+    // Not as clean as renderChild because there's less automatic cleanup, but at least guarantees these things end up in the same detached window
+    const renderOptions = {
+      window: {
+        windowId: this.window.windowId,
+      },
+    };
     // TODO: Replace this with opening a compendium browser as part of #130
     switch (target.dataset.type) {
       case "ancestry":
-        game.packs.get("draw-steel.origins").render({ force: true });
+        game.packs.get("draw-steel.origins").render(true, renderOptions);
         break;
       case "culture":
-        game.packs.get("draw-steel.origins").render({ force: true });
+        game.packs.get("draw-steel.origins").render(true, renderOptions);
         break;
       case "career":
-        game.packs.get("draw-steel.origins").render({ force: true });
+        game.packs.get("draw-steel.origins").render(true, renderOptions);
         break;
       case "class":
-        game.packs.get("draw-steel.classes").render({ force: true });
+        game.packs.get("draw-steel.classes").render(true, renderOptions);
         break;
     }
   }
@@ -425,7 +431,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editCharacteristics(event, target) {
-    return new CharacteristicInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new CharacteristicInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -294,25 +294,19 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #addOrigin(event, target) {
-    // Not as clean as renderChild because there's less automatic cleanup, but at least guarantees these things end up in the same detached window
-    const renderOptions = {
-      window: {
-        windowId: this.window.windowId,
-      },
-    };
     // TODO: Replace this with opening a compendium browser as part of #130
     switch (target.dataset.type) {
       case "ancestry":
-        game.packs.get("draw-steel.origins").render(true, renderOptions);
+        game.packs.get("draw-steel.origins").render(true);
         break;
       case "culture":
-        game.packs.get("draw-steel.origins").render(true, renderOptions);
+        game.packs.get("draw-steel.origins").render(true);
         break;
       case "career":
-        game.packs.get("draw-steel.origins").render(true, renderOptions);
+        game.packs.get("draw-steel.origins").render(true);
         break;
       case "class":
-        game.packs.get("draw-steel.classes").render(true, renderOptions);
+        game.packs.get("draw-steel.classes").render(true);
         break;
     }
   }

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -601,7 +601,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    */
   static async #showImage(event, target) {
     const { img, name, uuid } = this.item;
-    return this.renderChild(new foundry.applications.apps.ImagePopout({ src: img, uuid, window: { title: name } }));
+    this.renderChild(new foundry.applications.apps.ImagePopout({ src: img, uuid, window: { title: name } }));
   }
 
   /* -------------------------------------------------- */
@@ -614,7 +614,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    return this.renderChild(new DocumentSourceInput({ document: this.item }));
+    this.renderChild(new DocumentSourceInput({ document: this.item }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -601,7 +601,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    */
   static async #showImage(event, target) {
     const { img, name, uuid } = this.item;
-    new foundry.applications.apps.ImagePopout({ src: img, uuid, window: { title: name } }).render({ force: true });
+    return this.renderChild(new foundry.applications.apps.ImagePopout({ src: img, uuid, window: { title: name } }));
   }
 
   /* -------------------------------------------------- */
@@ -614,7 +614,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    new DocumentSourceInput({ document: this.item }).render({ force: true });
+    return this.renderChild(new DocumentSourceInput({ document: this.item }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -163,7 +163,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    return this.renderChild(new DocumentSourceInput({ document: this.document }));
+    this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -175,7 +175,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editMonsterMetadata(event, target) {
-    return this.renderChild(new MonsterMetadataInput({ document: this.document }));
+    this.renderChild(new MonsterMetadataInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -163,7 +163,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    new DocumentSourceInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -175,7 +175,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editMonsterMetadata(event, target) {
-    new MonsterMetadataInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new MonsterMetadataInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -83,7 +83,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    return this.renderChild(new DocumentSourceInput({ document: this.document }));
+    this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -95,6 +95,6 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editObjectMetadata(event, target) {
-    return this.renderChild(new ObjectMetadataInput({ document: this.document }));
+    this.renderChild(new ObjectMetadataInput({ document: this.document }));
   }
 }

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -83,7 +83,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    new DocumentSourceInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -95,6 +95,6 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editObjectMetadata(event, target) {
-    new ObjectMetadataInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new ObjectMetadataInput({ document: this.document }));
   }
 }

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -105,7 +105,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editRetainerMetadata(event, target) {
-    new RetainerMetadataInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new RetainerMetadataInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -117,7 +117,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    new DocumentSourceInput({ document: this.document }).render({ force: true });
+    return this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
 }

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -105,7 +105,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editRetainerMetadata(event, target) {
-    return this.renderChild(new RetainerMetadataInput({ document: this.document }));
+    this.renderChild(new RetainerMetadataInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -117,7 +117,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    return this.renderChild(new DocumentSourceInput({ document: this.document }));
+    this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
 }


### PR DESCRIPTION
Various helper apps like metadata now use `renderChild` to ensure they stick with their parent app