### PR TITLE
NPC Embeds (No ability list yet)

### DIFF
--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -207,28 +207,6 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
   /* -------------------------------------------------- */
 
   /**
-   * Constructs a record of valid characteristics and their associated field.
-   * @param {boolean} edit Are the characteristics editable inline?
-   * @returns {Record<string, {field: NumberField, value: number}>}
-   * @protected
-   */
-  _getCharacteristics(edit) {
-    const isEdit = this.isEditMode && edit;
-    const data = isEdit ? this.actor._source : this.actor;
-    return Object.keys(ds.CONFIG.characteristics).reduce((obj, chc) => {
-      const value = foundry.utils.getProperty(data, `system.characteristics.${chc}.value`);
-      obj[chc] = {
-        isEdit,
-        field: this.actor.system.schema.getField(["characteristics", chc, "value"]),
-        value: isEdit ? (value || null) : (value ?? 0),
-      };
-      return obj;
-    }, {});
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
    * Constructs a tooltip of data paths.
    * @protected
    */

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -166,7 +166,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       case "stats":
         context.combatTooltip = this._getCombatTooltip();
         context.movement = this._getMovement();
-        context.damageIW = this._getImmunitiesWeaknesses();
+        context.damageIW = this.actor.system._getImmunitiesWeaknesses?.();
         break;
       case "features":
         context.features = await this._prepareFeaturesContext();
@@ -267,37 +267,6 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
     return {
       list: formatter.format(languageList),
       options: languageOptions,
-    };
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Constructs an object with the formatted immunities and weaknesses with a list of damage labels.
-   * @returns {{immunities: string, weaknesses: string, labels: Record<string, string>}}
-   * @protected
-   */
-  _getImmunitiesWeaknesses() {
-    const labels = {
-      all: _loc("DRAW_STEEL.Actor.base.FIELDS.damage.immunities.all.label"),
-      ...Object.entries(ds.CONFIG.damageTypes).reduce((acc, [type, { label }]) => {
-        acc[type] = label;
-        return acc;
-      }, {}),
-    };
-
-    const immunities = Object.entries(this.actor.system.damage.immunities)
-      .filter(([damageType, value]) => value > 0)
-      .map(([damageType, value]) => `<span class="immunity">${labels[damageType]} ${value}</span>`);
-    const weaknesses = Object.entries(this.actor.system.damage.weaknesses)
-      .filter(([damageType, value]) => value > 0)
-      .map(([damageType, value]) => `<span class="weakness">${labels[damageType]} ${value}</span>`);
-
-    const formatter = game.i18n.getListFormatter({ type: "unit" });
-    return {
-      immunities: formatter.format(immunities),
-      weaknesses: formatter.format(weaknesses),
-      labels,
     };
   }
 

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -165,7 +165,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
         break;
       case "stats":
         context.combatTooltip = this._getCombatTooltip();
-        context.movement = this._getMovement();
+        context.movement = this.actor.system._getMovement?.();
         context.damageIW = this.actor.system._getImmunitiesWeaknesses?.();
         break;
       case "features":
@@ -221,32 +221,6 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       }
     }
     return tooltip;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Constructs an object with the actor's movement types as well as all options available from CONFIG.Token.movement.actions.
-   * @returns {{flying: boolean, list: string, options: FormSelectOption[]}}
-   * @protected
-   */
-  _getMovement() {
-    const formatter = game.i18n.getListFormatter({ type: "unit" });
-    const actorMovement = this.actor.system.movement;
-    const canHover = actorMovement.types.has("fly") || actorMovement.types.has("teleport");
-    const movementList = Array.from(actorMovement.types).map(m => {
-      let label = _loc(CONFIG.Token.movement.actions[m]?.label ?? m);
-      if ((m === "teleport") && (actorMovement.teleport !== actorMovement.value)) label += " " + actorMovement.teleport;
-      return label;
-    });
-    if (canHover && actorMovement.hover) movementList.push(_loc("DRAW_STEEL.Actor.base.FIELDS.movement.hover.label"));
-    return {
-      canHover,
-      list: formatter.format(movementList),
-      options: Object.entries(CONFIG.Token.movement.actions)
-        .filter(([key, _action]) => ds.CONFIG.speedOptions.includes(key))
-        .map(([value, { label }]) => ({ value, label })),
-    };
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -88,7 +88,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
     await super._preparePartContext(partId, context, options);
     switch (partId) {
       case "stats":
-        context.characteristics = this._getCharacteristics(false);
+        context.characteristics = this.actor.system._getCharacteristics(false);
         context.unfilledSkill = !!this.actor.system._unfilledTraits.skill?.size;
         context.skills = this._getSkills();
         break;

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -73,7 +73,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
         context.malice = game.actors.malice;
         break;
       case "stats":
-        context.characteristics = this._getCharacteristics(true);
+        context.characteristics = this.actor.system._getCharacteristics(this.isEditMode);
         context.isSingleSquadMinion = this.actor.isMinion && (this.actor.system.combatGroups.size === 1);
         if (context.isSingleSquadMinion) context.combatGroup = this.actor.system.combatGroup;
         break;

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -68,7 +68,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
     await super._preparePartContext(partId, context, options);
     switch (partId) {
       case "header":
-        context.monsterKeywords = this._getMonsterKeywords();
+        context.monsterKeywords = this.actor.system._getMonsterKeywords();
         context.showMalice = game.user.isGM && !this.actor.system.isMinion;
         context.malice = game.actors.malice;
         break;
@@ -82,17 +82,6 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
         break;
     }
     return context;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Fetches the printable string for the monster's keywords.
-   * @returns {string[]}
-   */
-  _getMonsterKeywords() {
-    const monsterKeywords = ds.CONFIG.monsters.keywords;
-    return Array.from(this.actor.system.monster.keywords).map(k => monsterKeywords[k]?.label).filter(k => k);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -61,17 +61,6 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
   };
 
   /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  _getMovement() {
-    const data = super._getMovement();
-
-    data.show = !!this.actor.system.movement.value;
-
-    return data;
-  }
-
-  /* -------------------------------------------------- */
   /*   Actions                                          */
   /* -------------------------------------------------- */
 

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -67,7 +67,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
         context.mentorLink = this.document.system.retainer.mentor?.toAnchor();
         break;
       case "stats":
-        context.characteristics = this._getCharacteristics(true);
+        context.characteristics = this.actor.system._getCharacteristics(this.isEditMode);
         break;
     }
     return context;

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -453,4 +453,35 @@ export default class BaseActorModel extends DrawSteelSystemModel {
   async updateResource(delta) {
     throw new Error("This method is abstract and must be implemented by a subclass");
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Constructs an object with the formatted immunities and weaknesses with a list of damage labels.
+   * @returns {{immunities: string, weaknesses: string, labels: Record<string, string>}}
+   * @protected
+   */
+  _getImmunitiesWeaknesses() {
+    const labels = {
+      all: _loc("DRAW_STEEL.Actor.base.FIELDS.damage.immunities.all.label"),
+      ...Object.entries(ds.CONFIG.damageTypes).reduce((acc, [type, { label }]) => {
+        acc[type] = label;
+        return acc;
+      }, {}),
+    };
+
+    const immunities = Object.entries(this.damage.immunities)
+      .filter(([damageType, value]) => value > 0)
+      .map(([damageType, value]) => `<span class="immunity">${labels[damageType]} ${value}</span>`);
+    const weaknesses = Object.entries(this.damage.weaknesses)
+      .filter(([damageType, value]) => value > 0)
+      .map(([damageType, value]) => `<span class="weakness">${labels[damageType]} ${value}</span>`);
+
+    const formatter = game.i18n.getListFormatter({ type: "unit" });
+    return {
+      immunities: formatter.format(immunities),
+      weaknesses: formatter.format(weaknesses),
+      labels,
+    };
+  }
 }

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -484,4 +484,40 @@ export default class BaseActorModel extends DrawSteelSystemModel {
       labels,
     };
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Constructs an object with the actor's movement types as well as all options available from CONFIG.Token.movement.actions.
+   * @param {boolean} [excludeWalk=false] Whether to include the Walk movement type.
+   * @returns {{canHover: boolean, list: string, options: FormSelectOption[]}}
+   * @protected
+   */
+  _getMovement(excludeWalk = false) {
+    const formatter = game.i18n.getListFormatter({ type: "unit" });
+    const actorMovement = this.movement;
+    const canHover = actorMovement.types.has("fly") || actorMovement.types.has("teleport");
+    const movementList = Array.from(actorMovement.types).map(m => {
+      let label = _loc(CONFIG.Token.movement.actions[m]?.label ?? m);
+      if ((m === "teleport") && (actorMovement.teleport !== actorMovement.value)) label += " " + actorMovement.teleport;
+      return label;
+    });
+
+    if (canHover && actorMovement.hover) movementList.push(_loc("DRAW_STEEL.Actor.base.FIELDS.movement.hover.label"));
+
+    if (excludeWalk) {
+      const walkIndex = movementList.indexOf(_loc(CONFIG.Token.movement.actions.walk.label));
+      movementList.splice(walkIndex, 1);
+    }
+
+    return {
+      canHover,
+      list: formatter.format(movementList),
+      options: Object.entries(CONFIG.Token.movement.actions)
+        .filter(([key, _action]) => ds.CONFIG.speedOptions.includes(key))
+        .map(([value, { label }]) => ({ value, label })),
+      show: !!this.movement.value,
+
+    };
+  }
 }

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -459,7 +459,6 @@ export default class BaseActorModel extends DrawSteelSystemModel {
   /**
    * Constructs an object with the formatted immunities and weaknesses with a list of damage labels.
    * @returns {{immunities: string, weaknesses: string, labels: Record<string, string>}}
-   * @protected
    */
   _getImmunitiesWeaknesses() {
     const labels = {
@@ -491,7 +490,6 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    * Constructs an object with the actor's movement types as well as all options available from CONFIG.Token.movement.actions.
    * @param {boolean} [excludeWalk=false] Whether to include the Walk movement type.
    * @returns {{canHover: boolean, list: string, options: FormSelectOption[]}}
-   * @protected
    */
   _getMovement(excludeWalk = false) {
     const formatter = game.i18n.getListFormatter({ type: "unit" });

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -180,6 +180,8 @@ export default class CreatureModel extends BaseActorModel {
     if (this.parent.statuses.has("restrained") && ["might", "agility"].includes(options.characteristic)) modifiers.banes += 1;
   }
 
+  /* ------------------------------------------------- */
+
   /**
      * Constructs a record of valid characteristics and their associated field.
      * @param {boolean} fromSource If true, use Actor's source data; else, use prepared data.

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -179,4 +179,21 @@ export default class CreatureModel extends BaseActorModel {
     // Restrained condition - might and agility tests take a bane
     if (this.parent.statuses.has("restrained") && ["might", "agility"].includes(options.characteristic)) modifiers.banes += 1;
   }
+
+  /**
+     * Constructs a record of valid characteristics and their associated field.
+     * @param {boolean} fromSource If true, use Actor's source data; else, use prepared data.
+     * @returns {Record<string, {field: NumberField, value: number}}
+     */
+  _getCharacteristics(fromSource) {
+    const data = fromSource ? this._source : this;
+    return Object.keys(ds.CONFIG.characteristics).reduce((obj, chc) => {
+      const value = foundry.utils.getProperty(data, `characteristics.${chc}.value`);
+      obj[chc] = {
+        field: this.schema.getField(["characteristics", chc, "value"]),
+        value: value ?? 0,
+      };
+      return obj;
+    }, {});
+  }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -211,7 +211,7 @@ export default class NPCModel extends CreatureModel {
     const context = {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
-      damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
+      damageIW: this._getImmunitiesWeaknesses(),
       monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -1,8 +1,7 @@
-import { systemID, systemPath } from "../../constants.mjs";
 import { requiredInteger, setOptions } from "../helpers.mjs";
+import { systemID, systemPath } from "../../constants.mjs";
 import CreatureModel from "./creature.mjs";
 import SourceModel from "../models/source.mjs";
-import { systemID } from "../../constants.mjs";
 
 /**
  * @import { DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -204,10 +204,11 @@ export default class NPCModel extends CreatureModel {
   async toEmbed(config, options) {
     // All NPCs are rendered inline
     config.inline = true;
-    console.log(config, options);
+    // console.log(config, options);
 
     const context = {
       actor: this.parent,
+      monsterKeywords: this.parent.sheet._getMonsterKeywords(),
       system: this,
       systemFields: this.schema.fields,
     };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -227,6 +227,13 @@ export default class NPCModel extends CreatureModel {
     return embed;
   }
 
+  /* ------------------------------------------------- */
+
+  /** @inheritdoc */
+  onEmbed(element) {
+    element.querySelector("a[data-action='openSheet']")?.addEventListener("click", () => this.parent.sheet.render({ force: true }));
+  }
+
   /* -------------------------------------------------- */
 
   /**

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -210,7 +210,7 @@ export default class NPCModel extends CreatureModel {
 
     const context = {
       actor: this.parent,
-      characteristics: this.parent.sheet._getCharacteristics(true),
+      characteristics: this._getCharacteristics(false),
       damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
       monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -206,13 +206,13 @@ export default class NPCModel extends CreatureModel {
     config.inline = true;
 
     const walkLabel = game.i18n.localize(CONFIG.Token.movement.actions.walk.label);
-    const walkRe = new RegExp(`${walkLabel}[,]?`, "i");
+    const walkRe = new RegExp(`${walkLabel}[,]?`);
 
     const context = {
       actor: this.parent,
       characteristics: this.parent.sheet._getCharacteristics(true),
       damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
-      monsterKeywords: this.parent.sheet._getMonsterKeywords(),
+      monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,
       systemFields: this.schema.fields,

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -225,7 +225,6 @@ export default class NPCModel extends CreatureModel {
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 
     return embed;
-
   }
 
   /* -------------------------------------------------- */
@@ -315,6 +314,6 @@ export default class NPCModel extends CreatureModel {
    */
   _getMonsterKeywords() {
     const monsterKeywords = ds.CONFIG.monsters.keywords;
-    return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(k => k);
+    return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(_ => _);
   }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -212,7 +212,7 @@ export default class NPCModel extends CreatureModel {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
       damageIW: this._getImmunitiesWeaknesses(),
-      monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
+      monsterKeywords: this._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,
       systemFields: this.schema.fields,
@@ -305,5 +305,16 @@ export default class NPCModel extends CreatureModel {
     /** @type {MaliceModel} */
     const malice = game.actors.malice;
     await game.settings.set(systemID, "malice", { value: malice.value + delta });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetches the printable string for the monster's keywords.
+   * @returns {string[]}
+   */
+  _getMonsterKeywords() {
+    const monsterKeywords = ds.CONFIG.monsters.keywords;
+    return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(k => k);
   }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -213,7 +213,7 @@ export default class NPCModel extends CreatureModel {
       characteristics: this._getCharacteristics(false),
       damageIW: this._getImmunitiesWeaknesses(),
       monsterKeywords: this._getMonsterKeywords().join(", "),
-      movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
+      movement: this._getMovement(true).list,
       system: this,
       systemFields: this.schema.fields,
     };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -213,11 +213,13 @@ export default class NPCModel extends CreatureModel {
       systemFields: this.schema.fields,
     };
 
-    const wrapper = document.createElement("div");
+    const embed = document.createElement("div");
 
-    wrapper.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+    embed.classList.add("draw-steel", "actor", "npc");
 
-    return wrapper;
+    embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+
+    return embed;
 
   }
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -205,10 +205,15 @@ export default class NPCModel extends CreatureModel {
     // All NPCs are rendered inline
     config.inline = true;
 
+    const walkLabel = game.i18n.localize(CONFIG.Token.movement.actions.walk.label);
+    const walkRe = new RegExp(`${walkLabel}[,]?`, "i");
+
     const context = {
       actor: this.parent,
       characteristics: this.parent.sheet._getCharacteristics(true),
+      damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
       monsterKeywords: this.parent.sheet._getMonsterKeywords(),
+      movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,
       systemFields: this.schema.fields,
     };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -205,7 +205,7 @@ export default class NPCModel extends CreatureModel {
     // All NPCs are rendered inline
     config.inline = true;
 
-    const walkLabel = game.i18n.localize(CONFIG.Token.movement.actions.walk.label);
+    const walkLabel = _loc(CONFIG.Token.movement.actions.walk.label);
     const walkRe = new RegExp(`${walkLabel}[,]?`);
 
     const context = {
@@ -220,7 +220,7 @@ export default class NPCModel extends CreatureModel {
 
     const embed = document.createElement("div");
 
-    embed.classList.add("draw-steel", "actor", "npc");
+    embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -1,3 +1,4 @@
+import { systemID, systemPath } from "../../constants.mjs";
 import { requiredInteger, setOptions } from "../helpers.mjs";
 import CreatureModel from "./creature.mjs";
 import SourceModel from "../models/source.mjs";
@@ -196,6 +197,28 @@ export default class NPCModel extends CreatureModel {
     }
 
     return freeStrike;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async toEmbed(config, options) {
+    // All NPCs are rendered inline
+    config.inline = true;
+    console.log(config, options);
+
+    const context = {
+      actor: this.parent,
+      system: this,
+      systemFields: this.schema.fields,
+    };
+
+    const wrapper = document.createElement("div");
+
+    wrapper.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+
+    return wrapper;
+
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -204,10 +204,10 @@ export default class NPCModel extends CreatureModel {
   async toEmbed(config, options) {
     // All NPCs are rendered inline
     config.inline = true;
-    // console.log(config, options);
 
     const context = {
       actor: this.parent,
+      characteristics: this.parent.sheet._getCharacteristics(true),
       monsterKeywords: this.parent.sheet._getMonsterKeywords(),
       system: this,
       systemFields: this.schema.fields,

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -50,7 +50,7 @@ document-embed, .item-embed {
     min-width: unset;
 
     background-image: linear-gradient(var(--color-statblock), transparent 5rem);
-    border-radius: 8px 8px 0px 0px ;
+    border-radius: 8px 8px 0px 0px;
 
     margin-inline: 1rem;
 
@@ -58,7 +58,7 @@ document-embed, .item-embed {
       display: flex;
       justify-content: space-between;
       gap: 8px;
-      font-size: 1.25em;
+      font-size: 1.125em;
       font-family: 'Newsreader', serif;
       border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
@@ -107,7 +107,7 @@ document-embed, .item-embed {
       .basic-stats {
         gap: 8px;
         justify-content: center;
-        font-size: 1.125rem;
+        font-size: 1rem;
         text-align: center;
         margin-block: 8px 0;
 
@@ -121,7 +121,7 @@ document-embed, .item-embed {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         align-items: center;
-        font-size: 1.125em;
+        font-size: 1em;
         padding-inline: 8px;
 
         div:nth-child(even) {
@@ -140,6 +140,8 @@ document-embed, .item-embed {
           align-items: center;
           justify-content: center;
           gap: 0.5ch;
+          font-size: 1.125em;
+
 
           .label::first-letter {
             font-family: 'Draw Steel Glyphs';

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -46,11 +46,33 @@ document-embed, .item-embed {
   }
 
   div.actor.npc {
+    --color-statblock: rgb(175, 175, 175);
+
+    background-image: linear-gradient(var(--color-statblock), transparent);
+    border-radius: 8px 8px 0px 0px ;
+    border-bottom: 1px solid gray;
+
     header {
+      display: flex;
+      justify-content: space-between;
+
+      font-family: 'Newsreader', serif;
+
+
+      padding-inline-end: 1rem;
 
       img {
-        flex: 0 0 150px;
-        width: 150px;
+        flex: 0 0 5rem;
+        width: 5rem;
+      }
+
+      .level-ev {
+        justify-content: center;
+        text-align: right;
+
+        .level {
+          font-weight: bold;
+        }
       }
     }
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -45,6 +45,8 @@ document-embed, .item-embed {
     }
   }
 
+  div.actor.npc {}
+
   /* Non-Actor/Item Embeds inside a Draw Steel application */
   .draw-steel & {
     .roll-table-embed {

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -81,11 +81,19 @@ document-embed, .item-embed {
     }
 
     section.stats {
+      gap: 8px;
+
+      .label {
+        font-weight: 600;
+      }
+
       .basic-stats {
         gap: 8px;
 
         font-size: 1.125rem;
         text-align: center;
+
+        margin-block: 8px 0;
 
         > div {
           display: flex;
@@ -96,8 +104,10 @@ document-embed, .item-embed {
       .secondary-stats {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
+        align-items: center;
+        font-size: 1.125em;
 
-        margin: 8px;
+        padding-inline: 8px;
 
         div:nth-child(even) {
           text-align: end;
@@ -113,22 +123,16 @@ document-embed, .item-embed {
           display: flex;
           align-items: center;
           justify-content: center;
-          gap: 8px;
+          gap: 0.5ch;
 
 
-          .label {
-            font-weight: 600;
-
-            &::first-letter {
+          .label::first-letter {
               font-family: 'Draw Steel Glyphs';
               font-weight: normal;
               letter-spacing: 1px;
             }
-          }
 
-          .value {
-            font-weight: normal;
-          }
+
 
         }
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -69,8 +69,17 @@ document-embed, .item-embed {
         }
 
         h2 {
-        font-size: 1.125em;
-            margin: 0;
+          font-size: 1.125em;
+          margin: 0;
+
+          a {
+            color: unset !important;
+
+          }
+
+          a:hover {
+            text-decoration: underline;
+          }
         }
       }
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -45,7 +45,21 @@ document-embed, .item-embed {
     }
   }
 
-  div.actor.npc {}
+  div.actor.npc {
+    header {
+
+      img {
+        flex: 0 0 150px;
+        width: 150px;
+      }
+    }
+
+    section {
+      .characteristics legend button {
+        display: none;
+      }
+    }
+  }
 
   /* Non-Actor/Item Embeds inside a Draw Steel application */
   .draw-steel & {

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -55,9 +55,9 @@ document-embed, .item-embed {
     header {
       display: flex;
       justify-content: space-between;
+      gap: 8px;
 
       font-family: 'Newsreader', serif;
-
 
       padding-inline-end: 1rem;
 
@@ -76,7 +76,18 @@ document-embed, .item-embed {
       }
     }
 
-    section {
+    section.stats {
+      .basic-stats {
+        gap: 8px;
+
+        font-size: 1.125rem;
+        text-align: center;
+
+        > div {
+          display: flex;
+          flex-direction: column;
+        }
+      }
       .characteristics legend button {
         display: none;
       }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -47,9 +47,12 @@ document-embed, .item-embed {
 
   div.actor.npc {
     --color-statblock: rgb(175, 175, 175);
+    min-width: unset;
 
     background-image: linear-gradient(var(--color-statblock), transparent 5rem);
     border-radius: 8px 8px 0px 0px ;
+
+    margin-inline: 1rem;
 
     header {
       display: flex;
@@ -64,6 +67,10 @@ document-embed, .item-embed {
         img {
           flex: 0 0 5rem;
           width: 5rem;
+        }
+
+        .name-keywords {
+          padding: 12px;
         }
 
         h2 {
@@ -99,6 +106,7 @@ document-embed, .item-embed {
 
       .basic-stats {
         gap: 8px;
+        justify-content: center;
         font-size: 1.125rem;
         text-align: center;
         margin-block: 8px 0;
@@ -123,6 +131,7 @@ document-embed, .item-embed {
 
       .characteristics {
         display: flex;
+        flex-wrap: wrap;
         justify-content: space-around;
         border-block: 1px solid gray;
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -74,7 +74,6 @@ document-embed, .item-embed {
 
           a {
             color: unset !important;
-
           }
 
           a:hover {
@@ -141,15 +140,11 @@ document-embed, .item-embed {
 
 
           .label::first-letter {
-              font-family: 'Draw Steel Glyphs';
-              font-weight: normal;
-              letter-spacing: 1px;
-            }
-
-
-
+            font-family: 'Draw Steel Glyphs';
+            font-weight: normal;
+            letter-spacing: 1px;
+          }
         }
-
       }
     }
 
@@ -188,7 +183,6 @@ document-embed, .item-embed {
     &.support {
       --color-statblock: #F4D8C2;
     }
-
   }
 
   /* Non-Actor/Item Embeds inside a Draw Steel application */

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -56,6 +56,7 @@ document-embed, .item-embed {
       justify-content: space-between;
       gap: 8px;
 
+      font-size: 1.25em;
       font-family: 'Newsreader', serif;
 
       border-bottom: 1px solid gray;
@@ -68,6 +69,7 @@ document-embed, .item-embed {
         }
 
         h2 {
+        font-size: 1.125em;
             margin: 0;
         }
       }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -61,14 +61,17 @@ document-embed, .item-embed {
       border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
-      img {
-        flex: 0 0 5rem;
-        width: 5rem;
+      .image-name-keywords {
+        img {
+          flex: 0 0 5rem;
+          width: 5rem;
+        }
+
+        h2 {
+            margin: 0;
+        }
       }
 
-      h2 {
-        margin: 0;
-      }
 
       .level-ev {
         justify-content: center;

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -48,7 +48,7 @@ document-embed, .item-embed {
   div.actor.npc {
     --color-statblock: rgb(175, 175, 175);
 
-    background-image: linear-gradient(var(--color-statblock), transparent);
+    background-image: linear-gradient(var(--color-statblock), transparent 5rem);
     border-radius: 8px 8px 0px 0px ;
 
     header {
@@ -143,6 +143,43 @@ document-embed, .item-embed {
 
       }
     }
+
+    &.ambusher {
+      --color-statblock: #F9DD63;
+    }
+
+    &.artillery {
+      --color-statblock: #CAC6DC;
+    }
+
+    &.brute {
+      --color-statblock: #9CBADF;
+    }
+
+    &.controller {
+      --color-statblock: #F5918F;
+    }
+
+    &.defender {
+      --color-statblock: #CEC9AA;
+    }
+
+    &.harrier {
+      --color-statblock: #E8C0C3;
+    }
+
+    &.hexer {
+      --color-statblock: #D8E1C3;
+    }
+
+    &.mount {
+      --color-statblock: #BADDEA;
+    }
+
+    &.support {
+      --color-statblock: #F4D8C2;
+    }
+
   }
 
   /* Non-Actor/Item Embeds inside a Draw Steel application */

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -50,7 +50,6 @@ document-embed, .item-embed {
 
     background-image: linear-gradient(var(--color-statblock), transparent);
     border-radius: 8px 8px 0px 0px ;
-    border-bottom: 1px solid gray;
 
     header {
       display: flex;
@@ -59,11 +58,16 @@ document-embed, .item-embed {
 
       font-family: 'Newsreader', serif;
 
+      border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
       img {
         flex: 0 0 5rem;
         width: 5rem;
+      }
+
+      h2 {
+        margin: 0;
       }
 
       .level-ev {
@@ -88,8 +92,46 @@ document-embed, .item-embed {
           flex-direction: column;
         }
       }
-      .characteristics legend button {
-        display: none;
+
+      .secondary-stats {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+
+        margin: 8px;
+
+        div:nth-child(even) {
+          text-align: end;
+        }
+      }
+
+      .characteristics {
+        display: flex;
+        justify-content: space-around;
+        border-block: 1px solid gray;
+
+        .characteristic {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+
+
+          .label {
+            font-weight: 600;
+
+            &::first-letter {
+              font-family: 'Draw Steel Glyphs';
+              font-weight: normal;
+              letter-spacing: 1px;
+            }
+          }
+
+          .value {
+            font-weight: normal;
+          }
+
+        }
+
       }
     }
   }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -55,10 +55,8 @@ document-embed, .item-embed {
       display: flex;
       justify-content: space-between;
       gap: 8px;
-
       font-size: 1.25em;
       font-family: 'Newsreader', serif;
-
       border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
@@ -82,7 +80,6 @@ document-embed, .item-embed {
         }
       }
 
-
       .level-ev {
         justify-content: center;
         text-align: right;
@@ -102,10 +99,8 @@ document-embed, .item-embed {
 
       .basic-stats {
         gap: 8px;
-
         font-size: 1.125rem;
         text-align: center;
-
         margin-block: 8px 0;
 
         > div {
@@ -119,7 +114,6 @@ document-embed, .item-embed {
         grid-template-columns: repeat(2, 1fr);
         align-items: center;
         font-size: 1.125em;
-
         padding-inline: 8px;
 
         div:nth-child(even) {
@@ -137,7 +131,6 @@ document-embed, .item-embed {
           align-items: center;
           justify-content: center;
           gap: 0.5ch;
-
 
           .label::first-letter {
             font-family: 'Draw Steel Glyphs';

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,0 +1,3 @@
+{{log this}}
+<header></header>
+<section></section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,3 +1,24 @@
-{{log this}}
-<header></header>
-<section></section>
+<header class="flexrow">
+  <img src="{{actor.img}}" alt="{{actor.name}}">
+  <h1>
+    {{actor.name}}
+  </h1>
+  <dl>
+    <dt class="level">{{systemFields.monster.fields.level.label}}</dt>
+    <dd class="level"> {{system.level}}</dd>
+    <dt class="ev">{{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}</dt>
+    <dd class="ev">{{system.evLabel}}</dd>
+  </dl>
+  <div class="tags flexrow">
+    {{#each monsterKeywords as |keyword|}}
+    <div class="tag">{{keyword}}</div>
+    {{/each}}
+    {{!-- Organization/Role Tags --}}
+    {{#if system.monster.organizationLabel}}
+    <div class="tag">{{system.monster.organizationLabel}}</div>
+    {{/if}}
+    {{#if system.monster.roleLabel}}
+    <div class="tag">{{system.monster.roleLabel}}</div>
+    {{/if}}
+  </div>
+</header>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -78,13 +78,7 @@
     </div>
     <div class="movement">
       <span class="label">{{systemFields.movement.label}}:</span>
-      <span class="value">
-        {{#if movement}}
-        {{movement}}
-        {{else}}
-        —
-        {{/if}}
-      </span>
+      <span class="value">{{ifThen movement movement "—"}}</span>
     </div>
     <div class="with-captain">
       <span class="label">{{localize "With Captain"}}:</span>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -3,7 +3,7 @@
     <img src="{{actor.img}}" alt="{{actor.name}}">
     <div class="flexcol name-keywords">
       <h2 class="name">
-        <a data-link data-uuid="{{actor.uuid}}">{{actor.name}}</a>
+        <a data-action="openSheet">{{actor.name}}</a>
       </h2>
       <div class="keywords">
         {{monsterKeywords}}

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -59,11 +59,26 @@
     </div>
   </div>
 
-  <div class="immunities">
-
+  <div class="secondary-stats">
+    <div class="immunities">
+      <span class="label">{{systemFields.damage.fields.immunities.label}}:</span>
+    </div>
+    <div class="weakness">{{systemFields.damage.fields.weaknesses.label}}:</div>
+    <div class="movement">{{systemFields.movement.label}}:</div>
+    <div class="with-captain">{{localize "With Captain"}}:</div>
   </div>
 
-  <div class="characteristics">
+  <div class="characteristics flexrow">
+    {{#each characteristics as |chr key|}}
+    <div class="characteristic">
+      <div class="label">
+        {{chr.field.label}}
+      </div>
+      <div class="value">
+        {{numberFormat chr.value sign=true}}
+      </div>
+    </div>
+    {{/each}}
   </div>
 
 </section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,24 +1,36 @@
-<header class="flexrow">
-  <img src="{{actor.img}}" alt="{{actor.name}}">
-  <h1>
-    {{actor.name}}
-  </h1>
-  <dl>
-    <dt class="level">{{systemFields.monster.fields.level.label}}</dt>
-    <dd class="level"> {{system.level}}</dd>
-    <dt class="ev">{{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}</dt>
-    <dd class="ev">{{system.evLabel}}</dd>
-  </dl>
-  <div class="tags flexrow">
-    {{#each monsterKeywords as |keyword|}}
-    <div class="tag">{{keyword}}</div>
-    {{/each}}
-    {{!-- Organization/Role Tags --}}
-    {{#if system.monster.organizationLabel}}
-    <div class="tag">{{system.monster.organizationLabel}}</div>
-    {{/if}}
-    {{#if system.monster.roleLabel}}
-    <div class="tag">{{system.monster.roleLabel}}</div>
-    {{/if}}
+<header>
+  <div class="flexrow">
+    <img src="{{actor.img}}" alt="{{actor.name}}">
+    <div class="flexcol">
+      <h2>
+        {{actor.name}}
+      </h2>
+      <div class="tags flexrow">
+        {{#each monsterKeywords as |keyword|}}
+        <div class="tag">{{keyword}}{{#unless @last}},{{/unless}}</div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
+  <div class="flexcol level-ev">
+    <div class="level">
+      <span>
+        {{systemFields.monster.fields.level.label}}
+        {{system.level}}
+        <span class="tags">
+          {{!-- Organization/Role Tags --}}
+          {{#if system.monster.organizationLabel}}
+          <span class="tag">{{system.monster.organizationLabel}}</span>
+          {{/if}}
+          {{#if system.monster.roleLabel}}
+          <span class="tag">{{system.monster.roleLabel}}</span>
+          {{/if}}
+        </span>
+      </span>
+    </div>
+    <div class="ev">
+      {{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}
+      {{system.evLabel}}
+    </div>
   </div>
 </header>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -34,3 +34,36 @@
     </div>
   </div>
 </header>
+
+<section class="stats flexcol">
+  <div class="basic-stats flexrow">
+    <div class="size">
+      {{system.combat.size}}
+      <strong>{{systemFields.combat.fields.size.label}}</strong>
+    </div>
+    <div class="speed">
+      {{system.movement.value}}
+      <strong>{{localize "DRAW_STEEL.Actor.base.FIELDS.movement.value.label"}}</strong>
+    </div>
+    <div class="stamina">
+      {{system.stamina.max}}
+      <strong>{{systemFields.stamina.label}}</strong>
+    </div>
+    <div class="stability">
+      {{system.combat.stability}}
+      <strong>{{systemFields.combat.fields.stability.label}}</strong>
+    </div>
+    <div class="free-strike">
+      {{system.monster.freeStrike}}
+      <strong>{{systemFields.monster.fields.freeStrike.label}}</strong>
+    </div>
+  </div>
+
+  <div class="immunities">
+
+  </div>
+
+  <div class="characteristics">
+  </div>
+
+</section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -97,5 +97,4 @@
     </div>
     {{/each}}
   </div>
-
 </section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -61,14 +61,43 @@
 
   <div class="secondary-stats">
     <div class="immunities">
-      <span class="label">{{systemFields.damage.fields.immunities.label}}:</span>
+      <span class="label">
+        {{systemFields.damage.fields.immunities.label}}:
+      </span>
+      <span class="value">
+        {{#if damageIW.immunities}}
+        {{{damageIW.immunities}}}
+        {{else}}
+        —
+        {{/if}}
+      </span>
     </div>
-    <div class="weakness">{{systemFields.damage.fields.weaknesses.label}}:</div>
-    <div class="movement">{{systemFields.movement.label}}:</div>
-    <div class="with-captain">{{localize "With Captain"}}:</div>
+    <div class="weakness">
+      <span class="label">{{systemFields.damage.fields.weaknesses.label}}:</span>
+      <span class="value">
+        {{#if damageIW.weaknesses}}
+        {{{damageIW.weaknesses}}}
+        {{else}}
+        —
+        {{/if}}
+      </span>
+    </div>
+    <div class="movement">
+      <span class="label">{{systemFields.movement.label}}:</span>
+      <span class="value">
+        {{#if movement}}
+        {{movement}}
+        {{else}}
+        —
+        {{/if}}
+      </span>
+    </div>
+    <div class="with-captain">
+      <span class="label">{{localize "With Captain"}}:</span>
+    </div>
   </div>
 
-  <div class="characteristics flexrow">
+  <div class="characteristics">
     {{#each characteristics as |chr key|}}
     <div class="characteristic">
       <div class="label">

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,32 +1,26 @@
 <header>
-  <div class="flexrow">
+  <div class="flexrow image-name-keywords">
     <img src="{{actor.img}}" alt="{{actor.name}}">
-    <div class="flexcol">
-      <h2>
+    <div class="flexcol name-keywords">
+      <h2 class="name">
         {{actor.name}}
       </h2>
-      <div class="tags flexrow">
-        {{#each monsterKeywords as |keyword|}}
-        <div class="tag">{{keyword}}{{#unless @last}},{{/unless}}</div>
-        {{/each}}
+      <div class="keywords">
+        {{monsterKeywords}}
       </div>
     </div>
   </div>
   <div class="flexcol level-ev">
     <div class="level">
-      <span>
-        {{systemFields.monster.fields.level.label}}
-        {{system.level}}
-        <span class="tags">
-          {{!-- Organization/Role Tags --}}
-          {{#if system.monster.organizationLabel}}
-          <span class="tag">{{system.monster.organizationLabel}}</span>
-          {{/if}}
-          {{#if system.monster.roleLabel}}
-          <span class="tag">{{system.monster.roleLabel}}</span>
-          {{/if}}
-        </span>
-      </span>
+      {{systemFields.monster.fields.level.label}}
+      {{system.level}}
+      {{!-- Organization/Role Tags --}}
+      {{#if system.monster.organizationLabel}}
+      {{system.monster.organizationLabel}}
+      {{/if}}
+      {{#if system.monster.roleLabel}}
+      {{system.monster.roleLabel}}
+      {{/if}}
     </div>
     <div class="ev">
       {{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -3,7 +3,7 @@
     <img src="{{actor.img}}" alt="{{actor.name}}">
     <div class="flexcol name-keywords">
       <h2 class="name">
-        {{actor.name}}
+        <a data-link data-uuid="{{actor.uuid}}">{{actor.name}}</a>
       </h2>
       <div class="keywords">
         {{monsterKeywords}}


### PR DESCRIPTION
This MR adds the ability to embed NPC Actors using the `@Embed` syntax:

<img width="626" height="746" alt="image" src="https://github.com/user-attachments/assets/f36607d5-f30c-42ab-9b5c-6fafa7c4f921" />

- As discussed, this just covers the "top part" of the stat block, and does not implement the NPC's list of abilities. That will happen in a future MR.
- The primary gradient color is automatically determined by the NPC's role. 
- The only thing that isn't implemented in the "top part" is the `With Captain` section. I noticed that this is an AE on the Actor, and thus it's a little difficult to translate into human readable format without some hacky work pulling the labels from the data model. I propose that we add the human-readable text to the AE's description, which I am happy to do as part of this MR. For example, if the AE gives a `+2` bonus to `system.stamina.max`, we would simply add the description "+2 bonus to Stamina". Let me know what you think.

Closes #901 