### PR TITLE
[#475] Added new pseudodocumentfor Special effect texts

### DIFF
--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -289,6 +289,7 @@ Hooks.once("i18nInit", () => {
   // Localize pseudo-documents. Base first, then loop through the types in use
   foundry.helpers.Localization.localizeDataModel(data.pseudoDocuments.powerRollEffects.BasePowerRollEffect);
   foundry.helpers.Localization.localizeDataModel(data.pseudoDocuments.advancements.BaseAdvancement);
+  foundry.helpers.Localization.localizeDataModel(data.pseudoDocuments.specialEffects.BaseSpecialEffect);
 
   const localizePseudos = record => {
     for (const cls of Object.values(record)) {
@@ -298,6 +299,7 @@ Hooks.once("i18nInit", () => {
 
   localizePseudos(data.pseudoDocuments.powerRollEffects.BasePowerRollEffect.TYPES);
   localizePseudos(data.pseudoDocuments.advancements.BaseAdvancement.TYPES);
+  localizePseudos(data.pseudoDocuments.specialEffects.BaseSpecialEffect.TYPES);
 
   // Register formula editor autocomplete contexts after ds.CONFIG localization so labels show localized.
   CONFIG.formulaEditor.contexts.default = {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2459,7 +2459,8 @@
     "SpecialEffect": {
       "base": "Effect",
       "persistent": "Persistent",
-      "spend": "Spend"
+      "spend": "Spend",
+      "strained": "Strained"
     }
   },
   "TOKEN.MOVEMENT": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -332,12 +332,16 @@
         "description": {
           "label": "Description"
         },
+        "essence": {
+          "label": "Essence Cost"
+        },
         "resource": {
           "multiple": {
             "label": "Multiple"
           }
         }
       },
+      "persistent": "Persistent {value}",
       "spend": {
         "single": "Spend {value} {resourceName}",
         "multiple": "Spend {value}+ {resourceName}"
@@ -2454,6 +2458,7 @@
     },
     "SpecialEffect": {
       "base": "Effect",
+      "persistent": "Persistent",
       "spend": "Spend"
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,7 +2,8 @@
   "DOCUMENT": {
     "Advancement": "Advancement",
     "AdvancementPl": "Advancements",
-    "PowerRollEffect": "Power Roll Effect"
+    "PowerRollEffect": "Power Roll Effect",
+    "SpecialEffect": "Special Effect"
   },
   "DRAW_STEEL": {
     "COMPENDIUM": {
@@ -320,6 +321,22 @@
         },
         "DefaultDisplay": "Each target gains {amount} {resource}.",
         "ButtonText": "Gain {amount} {resource}"
+      }
+    },
+    "SPECIAL_EFFECT": {
+      "FIELDS": {
+        "before": {
+          "label": "Before Power Roll",
+          "hint": "Place this effect before the power roll. Sort order determines display relative to other special effects."
+        },
+        "description": {
+          "label": "Description"
+        },
+        "resource": {
+          "multiple": {
+            "label": "Multiple"
+          }
+        }
       }
     },
     "SHEET": {
@@ -2445,6 +2462,10 @@
       "forced": "Forced Movement",
       "resource": "Gain Resource",
       "other": "Other"
+    },
+    "SpecialEffect": {
+      "base": "Effect",
+      "spend": "Spend"
     }
   },
   "TOKEN.MOVEMENT": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -337,6 +337,10 @@
             "label": "Multiple"
           }
         }
+      },
+      "spend": {
+        "single": "Spend {value} {resourceName}",
+        "multiple": "Spend {value}+ {resourceName}"
       }
     },
     "SHEET": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1118,23 +1118,8 @@
               }
             }
           },
-          "effect": {
-            "label": "Effect",
-            "before": {
-              "label": "Effect (Before Power Roll)"
-            },
-            "after": {
-              "label": "Effect (After Power Roll)"
-            }
-          },
-          "spend": {
-            "label": "Spend",
-            "value": {
-              "label": "Spend Cost"
-            },
-            "text": {
-              "label": "Spend Effect"
-            }
+          "effects": {
+            "label": "Effects"
           }
         },
         "ResourceCost": "Costs {value} {name}",

--- a/src/module/applications/api/document-sheet.mjs
+++ b/src/module/applications/api/document-sheet.mjs
@@ -474,7 +474,6 @@ export default class DSDocumentSheet extends api.HandlebarsApplicationMixin(api.
       return this._onDropDocument(event, document);
     }
 
-    // TODO: Add drag and drop for PseudoDocuments
     const pseudoClass = ModelCollection.documentClasses[data.type];
     if (pseudoClass) {
       const pseudo = await pseudoClass.fromDropData(data);

--- a/src/module/applications/apps/ability-configuration-dialog.mjs
+++ b/src/module/applications/apps/ability-configuration-dialog.mjs
@@ -178,17 +178,17 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
     context.resource.show = this.item.system.resource;
 
     // Heroic resource/malice spend
-    if (this.item.system.spend.value || this.item.system.spend.text) {
+    if (this.item.system.effects.documentsByType.spend.length) {
       context.resource.show = true;
       const coreResource = this.actor.system.coreResource;
+      context.resource.name = coreResource.name;
+      context.resource.max = foundry.utils.getProperty(coreResource.target, coreResource.path) - coreResource.minimum;
 
-      const max = foundry.utils.getProperty(coreResource.target, coreResource.path) - coreResource.minimum;
-      if (max) context.spendConfig = {
-        max,
-        slider: !this.item.system.spend.value,
-        value: this.item.system.spend.value || "",
-        name: coreResource.name,
-      };
+      context.spendConfig = this.item.system.effects.documentsByType.spend.map(e => ({
+        id: e.id,
+        multiple: e.resource.multiple,
+        value: e.resource.value,
+      }));
     }
   }
 

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -1,6 +1,7 @@
 import { DrawSteelActiveEffect, DrawSteelChatMessage } from "../../documents/_module.mjs";
 import BaseAdvancement from "../../data/pseudo-documents/advancements/base-advancement.mjs";
 import BasePowerRollEffect from "../../data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs";
+import BaseSpecialEffect from "../../data/pseudo-documents/special-effect/base-special-effect.mjs";
 import DSDocumentSheet from "../api/document-sheet.mjs";
 import DocumentSourceInput from "../apps/document-source-input.mjs";
 import enrichHTML from "../../utils/enrich-html.mjs";
@@ -169,9 +170,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         context.advancementIcon = BaseAdvancement.metadata.icon;
         break;
       case "impact":
+        context.specialEffectIcon = BaseSpecialEffect.metadata.icon;
         context.powerRollEffectIcon = BasePowerRollEffect.metadata.icon;
-        context.enrichedBeforeEffect = await enrichHTML(this.item.system.effect.before, { relativeTo: this.item });
-        context.enrichedAfterEffect = await enrichHTML(this.item.system.effect.after, { relativeTo: this.item });
         break;
       case "effects":
         context.effects = await this._prepareActiveEffectCategories();
@@ -822,6 +822,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         return (await this._onDropAdvancement(event, pseudo)) ?? null;
       case "PowerRollEffect":
         return (await this._onDropPowerRollEffect(event, pseudo)) ?? null;
+      case "SpecialEffect":
+        return (await this._onDropSpecialEffect(event, pseudo)) ?? null;
     }
     return null;
   }
@@ -885,6 +887,34 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
 
     return result ?? null;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle a dropped SpecialEffect.
+   * @param {DragEvent} event             The initiating drop event.
+   * @param {BaseSpecialEffect} effect  The dropped SpecialEffect.
+   * @returns {Promise<BaseSpecialEffect|null>} A Promise resolving to the dropped SpecialEffect (if sorting), a newly created SpecialEffect,
+   *                                         or null in case of failure or no action being taken.
+   * @protected
+   */
+  async _onDropSpecialEffect(event, effect) {
+    if (!this.item.isOwner || !effect) return null;
+
+    if (this.item.uuid === effect.document?.uuid) {
+      const result = await this._onSortPseudoDocument(event, effect);
+      return result?.length ? effect : null;
+    }
+
+    const keepId = !this.item.getEmbeddedCollection("SpecialEffect").has(effect.id);
+    const effectData = effect.toObject();
+
+    const result = await BaseSpecialEffect.create(effectData, { keepId, parent: this.item, renderSheet: false });
+
+    return result ?? null;
+  }
+
+  /* -------------------------------------------------- */
 
   /**
    * Handle a drop event for an existing embedded PseudoDocument to sort that PseudoDocument relative to its siblings.

--- a/src/module/applications/sheets/pseudo-documents/_module.mjs
+++ b/src/module/applications/sheets/pseudo-documents/_module.mjs
@@ -1,2 +1,3 @@
 export { default as AdvancementSheet } from "./advancement-sheet.mjs";
 export { default as PowerRollEffectSheet } from "./power-roll-effect-sheet.mjs";
+export { default as SpecialEffectSheet } from "./special-effect-sheet.mjs";

--- a/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
@@ -24,7 +24,6 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
 
   /** @inheritdoc */
   static PARTS = {
-    ...super.PARTS,
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
     },

--- a/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
@@ -14,7 +14,7 @@ export default class SpecialEffectSheet extends PseudoDocumentSheet {
     details: {
       template: systemPath("templates/sheets/pseudo-documents/special-effect/content.hbs"),
       // Modules can push to this or otherwise load their details partial templates
-      templates: ["spend.hbs"].map(t => systemPath(`templates/sheets/pseudo-documents/special-effect/${t}`)),
+      templates: ["persistent.hbs", "spend.hbs"].map(t => systemPath(`templates/sheets/pseudo-documents/special-effect/${t}`)),
     },
   };
 

--- a/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
@@ -40,12 +40,8 @@ export default class SpecialEffectSheet extends PseudoDocumentSheet {
    * @returns {Promise<object>}     Mutated rendering context.
    */
   async #prepareDetailsContext(context, options) {
-
     context.detailsPartial = this.pseudoDocument.detailsPartial;
-
     context.ctx = await this.pseudoDocument.getSheetContext(options);
-
     return context;
   }
-
 }

--- a/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
@@ -1,0 +1,51 @@
+import PseudoDocumentSheet from "../../api/pseudo-document-sheet.mjs";
+import { systemPath } from "../../../constants.mjs";
+
+export default class SpecialEffectSheet extends PseudoDocumentSheet {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["special-effect"],
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    details: {
+      template: systemPath("templates/sheets/pseudo-documents/special-effect/content.hbs"),
+      // Modules can push to this or otherwise load their details partial templates
+      templates: ["spend.hbs"].map(t => systemPath(`templates/sheets/pseudo-documents/special-effect/${t}`)),
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+
+    switch (partId) {
+      case "details":
+        return this.#prepareDetailsContext(context, options);
+    }
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare context for the details tab.
+   * @param {object} context    Rendering context.
+   * @returns {Promise<object>}     Mutated rendering context.
+   */
+  async #prepareDetailsContext(context, options) {
+
+    context.detailsPartial = this.pseudoDocument.detailsPartial;
+
+    context.ctx = await this.pseudoDocument.getSheetContext(options);
+
+    return context;
+  }
+
+}

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1910,6 +1910,11 @@ export const SpecialEffect = {
     defaultImage: "icons/svg/coins.svg",
     documentClass: pseudoDocuments.specialEffects.SpendSpecialEffect,
   },
+  strained: {
+    label: "TYPES.SpecialEffect.strained",
+    defaultImage: "icons/svg/anchor.svg",
+    documentClass: pseudoDocuments.specialEffects.StrainedSpecialEffect,
+  },
 };
 preLocalize("SpecialEffect", { key: "label" });
 

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1885,8 +1885,8 @@ preLocalize("MessagePart", { key: "label" });
 
 /**
  * @typedef SpecialEffectType
- * @property {string} label                                                 Human-readable label.
- * @property {string} defaultImage                                          The default image for PowerRollEffects of this type.
+ * @property {string} label                                                     Human-readable label.
+ * @property {string} defaultImage                                              The default image for PowerRollEffects of this type.
  * @property {pseudoDocuments.specialEffects.BaseSpecialEffect} documentClass   The pseudo-document class.
  */
 

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1900,6 +1900,11 @@ export const SpecialEffect = {
     defaultImage: "icons/svg/book.svg",
     documentClass: pseudoDocuments.specialEffects.BaseSpecialEffect,
   },
+  persistent: {
+    label: "TYPES.SpecialEffect.persistent",
+    defaultImage: "icons/svg/fire-shield.svg",
+    documentClass: pseudoDocuments.specialEffects.PersistentSpecialEffect,
+  },
   spend: {
     label: "TYPES.SpecialEffect.spend",
     defaultImage: "icons/svg/coins.svg",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1884,6 +1884,33 @@ preLocalize("MessagePart", { key: "label" });
 /* -------------------------------------------------- */
 
 /**
+ * @typedef SpecialEffectType
+ * @property {string} label                                                 Human-readable label.
+ * @property {string} defaultImage                                          The default image for PowerRollEffects of this type.
+ * @property {pseudoDocuments.specialEffects.BaseSpecialEffect} documentClass   The pseudo-document class.
+ */
+
+/**
+ * Valid types for the SpecialEffect pseudo-document.
+ * @type {Record<string, SpecialEffectType>}
+ */
+export const SpecialEffect = {
+  base: {
+    label: "TYPES.SpecialEffect.base",
+    defaultImage: "icons/svg/book.svg",
+    documentClass: pseudoDocuments.specialEffects.BaseSpecialEffect,
+  },
+  spend: {
+    label: "TYPES.SpecialEffect.spend",
+    defaultImage: "icons/svg/coins.svg",
+    documentClass: pseudoDocuments.specialEffects.SpendSpecialEffect,
+  },
+};
+preLocalize("SpecialEffect", { key: "label" });
+
+/* -------------------------------------------------- */
+
+/**
  * @typedef CultureAspect
  * @property {string} label         Human-readable label.
  * @property {string} skillGroups   A set of skill groups this aspect gives access to.

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -78,11 +78,7 @@ declare module "./ability.mjs" {
       value: number;
       text: string;
     };
-    effect: {
-      before: string;
-      after: string;
-      special: ModelCollection<SpecialEffect>;
-    };
+    effects: ModelCollection<SpecialEffect>;
   }
 
   export interface AbilityUseOptions {

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -1,5 +1,6 @@
 import { AppliedPowerRollEffect, DamagePowerRollEffect, ForcedMovementPowerRollEffect, OtherPowerRollEffect } from "../pseudo-documents/power-roll-effects/_module.mjs";
 import { CharacteristicAdvancement, ItemGrantAdvancement, LanguageAdvancement, SkillAdvancement } from "../pseudo-documents/advancements/_module.mjs";
+import { BaseSpecialEffect, SpendSpecialEffect } from "../pseudo-documents/special-effect/_module.mjs"
 import DrawSteelItem from "../../documents/item.mjs";
 import ModelCollection from "../../utils/model-collection.mjs";
 import { PowerRollModifiers } from "../../_types.js";
@@ -31,6 +32,7 @@ declare module "./base-item.mjs" {
 declare module "./ability.mjs" {
 
   type PowerRollEffects = AppliedPowerRollEffect | DamagePowerRollEffect | ForcedMovementPowerRollEffect | OtherPowerRollEffect;
+  type SpecialEffect = BaseSpecialEffect | SpendSpecialEffect;
 
   export default interface AbilityModel {
     description: never;
@@ -79,6 +81,7 @@ declare module "./ability.mjs" {
     effect: {
       before: string;
       after: string;
+      special: ModelCollection<SpecialEffect>;
     };
   }
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -33,7 +33,7 @@ export default class AbilityModel extends BaseItemModel {
       detailsPartial: [systemPath("templates/sheets/item/partials/ability.hbs")],
       embedded: {
         PowerRollEffect: "system.power.effects",
-        SpecialEffect: "system.effect.special",
+        SpecialEffect: "system.effects",
       },
     };
   }
@@ -98,11 +98,8 @@ export default class AbilityModel extends BaseItemModel {
       }, { persisted: false }),
     });
 
-    schema.effect = new fields.SchemaField({
-      before: new fields.HTMLField(),
-      after: new fields.HTMLField(),
-      special: new ds.data.fields.CollectionField(ds.data.pseudoDocuments.specialEffects.BaseSpecialEffect),
-    });
+    schema.effects = new ds.data.fields.CollectionField(ds.data.pseudoDocuments.specialEffects.BaseSpecialEffect);
+
     schema.spend = new fields.SchemaField({
       value: new fields.NumberField({ integer: true }),
       text: new fields.StringField({ required: true }),
@@ -120,19 +117,46 @@ export default class AbilityModel extends BaseItemModel {
 
     // 1.1 effect migration, based on Document._addDataFieldMigration
     const { hasProperty, getProperty, setProperty, deleteProperty } = foundry.utils;
-    const spendId = "spend".padEnd(16, "0");
-    if ((hasProperty(data, "spend.value") || hasProperty(data, "spend.text")) && !hasProperty(data, `effect.special.${spendId}`)) {
-      const value = getProperty(data, "spend.value");
-      setProperty(data, `effect.special.${spendId}`, {
-        type: "spend",
-        _id: spendId,
-        resource: {
-          value,
-          multiple: value === null,
-        },
-        description: `<p>${getProperty(data, "spend.text") ?? ""}</p>`,
-      });
-      deleteProperty(data, "spend");
+    const { Document } = foundry.abstract;
+    if (!hasProperty(data, "effects")) {
+      const spendID = "spend".padEnd(16, "0");
+      if ((getProperty(data, "spend.value") || getProperty(data, "spend.text")) && !hasProperty(data, `effects.${spendID}`)) {
+        const value = getProperty(data, "spend.value");
+        setProperty(data, `effects.${spendID}`, {
+          _id: spendID,
+          type: "spend",
+          sort: CONST.SORT_INTEGER_DENSITY, // guarantees after "after" effects if present
+          resource: {
+            value,
+            multiple: value === null,
+          },
+          description: `<p>${getProperty(data, "spend.text") ?? ""}</p>`,
+        });
+        deleteProperty(data, "spend");
+      }
+      if (data.effect?.before) {
+        const beforeID = "before".padEnd(16, "0");
+        Document._addDataFieldMigration(data, "effect.before", `effects.${beforeID}`, (data) => {
+          const description = getProperty(data, "effect.before");
+          return {
+            _id: beforeID,
+            type: "base",
+            description,
+            before: true,
+          };
+        });
+      }
+      if (data.effect?.after) {
+        const afterID = "after".padEnd(16, "0");
+        Document._addDataFieldMigration(data, "effect.after", `effects.${afterID}`, (data) => {
+          const description = getProperty(data, "effect.after");
+          return {
+            _id: afterID,
+            type: "base",
+            description,
+          };
+        });
+      }
     }
 
     return super.migrateData(data);
@@ -424,16 +448,13 @@ export default class AbilityModel extends BaseItemModel {
 
     context.beforeEffects = [];
     context.afterEffects = [];
-    for (const effect of this.effect.special) {
+    for (const effect of this.effects.sortedContents) {
       const displayData = {
         label: effect.label,
         text: await enrichHTML(effect.description, { relativeTo: this.parent }),
       };
       context[effect.before ? "beforeEffects" : "afterEffects"].push(displayData);
     }
-
-    context.enrichedBeforeEffect = await enrichHTML(this.effect.before, { relativeTo: this.parent });
-    context.enrichedAfterEffect = await enrichHTML(this.effect.after, { relativeTo: this.parent });
 
     context.spendLabel = _loc("DRAW_STEEL.Item.ability.SpendLabel", {
       value: this.spend.value ?? "",

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -118,6 +118,23 @@ export default class AbilityModel extends BaseItemModel {
     // Game release updates
     if (data.type === "action") data.type = "main";
 
+    // 1.1 effect migration, based on Document._addDataFieldMigration
+    const { hasProperty, getProperty, setProperty, deleteProperty } = foundry.utils;
+    const spendId = "spend".padEnd(16, "0");
+    if ((hasProperty(data, "spend.value") || hasProperty(data, "spend.text")) && !hasProperty(data, `effect.special.${spendId}`)) {
+      const value = getProperty(data, "spend.value");
+      setProperty(data, `effect.special.${spendId}`, {
+        type: "spend",
+        _id: spendId,
+        resource: {
+          value,
+          multiple: value === null,
+        },
+        description: `<p>${getProperty(data, "spend.text") ?? ""}</p>`,
+      });
+      deleteProperty(data, "spend");
+    }
+
     return super.migrateData(data);
   }
 
@@ -126,6 +143,8 @@ export default class AbilityModel extends BaseItemModel {
   /** @inheritdoc */
   prepareDerivedData() {
     super.prepareDerivedData();
+
+    this.#resourceName = null;
 
     this.power.roll.enabled = !this.power.roll.reactive && (this.power.effects.size > 0);
   }
@@ -326,26 +345,40 @@ export default class AbilityModel extends BaseItemModel {
 
   /* -------------------------------------------------- */
 
-  /** @inheritdoc */
-  async getSheetContext(context) {
-    const config = ds.CONFIG.abilities;
-    const formattedLabels = this.formattedLabels;
+  /**
+   * Cached reference to the resource name, reset during data prep.
+   * @type {string}
+   */
+  #resourceName = null;
 
-    let resourceName = this.actor?.system.coreResource?.name;
+  /**
+   * A cached reference to the heroic resource consumed by this ability.
+   * @type {string}
+   */
+  get resourceName() {
+    if (!this.#resourceName) this.#resourceName = this.actor?.system.coreResource?.name;
 
-    if (!resourceName && (this.prerequisites.dsid.size === 1)) {
+    if (!this.#resourceName && (this.prerequisites.dsid.size === 1)) {
       const dsid = this.prerequisites.dsid.first();
       let classEntry = ds.registry.class.filter(e => e.dsid === dsid).at(-1);
       if (!classEntry) {
         const subclass = ds.registry.subclass.filter(e => e.dsid === dsid).at(-1);
         if (subclass) classEntry = ds.registry.class.filter(e => e.dsid === subclass.classLink).at(-1);
       }
-      if (classEntry) resourceName = classEntry.primary;
+      if (classEntry) this.#resourceName = classEntry.primary;
     }
 
-    resourceName ??= _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label");
+    return this.#resourceName ??= _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label");
+  }
 
-    context.resourceName = resourceName;
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async getSheetContext(context) {
+    const config = ds.CONFIG.abilities;
+    const formattedLabels = this.formattedLabels;
+
+    context.resourceName = this.resourceName;
 
     context.keywordList = formattedLabels.keywords;
 
@@ -389,12 +422,22 @@ export default class AbilityModel extends BaseItemModel {
       context.powerRollBonus = this.power.roll.formula.replace("@chr", characteristicsFormatter.format(Array.from(characteristicList)));
     }
 
+    context.beforeEffects = [];
+    context.afterEffects = [];
+    for (const effect of this.effect.special) {
+      const displayData = {
+        label: effect.label,
+        text: await enrichHTML(effect.description, { relativeTo: this.parent }),
+      };
+      context[effect.before ? "beforeEffects" : "afterEffects"].push(displayData);
+    }
+
     context.enrichedBeforeEffect = await enrichHTML(this.effect.before, { relativeTo: this.parent });
     context.enrichedAfterEffect = await enrichHTML(this.effect.after, { relativeTo: this.parent });
 
     context.spendLabel = _loc("DRAW_STEEL.Item.ability.SpendLabel", {
       value: this.spend.value ?? "",
-      name: resourceName,
+      name: this.resourceName,
     });
   }
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -380,7 +380,7 @@ export default class AbilityModel extends BaseItemModel {
    * @type {string}
    */
   get resourceName() {
-    if (!this.#resourceName) this.#resourceName = this.actor?.system.coreResource?.name;
+    this.#resourceName ??= this.actor?.system.coreResource?.name;
 
     if (!this.#resourceName && (this.prerequisites.dsid.size === 1)) {
       const dsid = this.prerequisites.dsid.first();
@@ -455,11 +455,6 @@ export default class AbilityModel extends BaseItemModel {
       };
       context[effect.before ? "beforeEffects" : "afterEffects"].push(displayData);
     }
-
-    context.spendLabel = _loc("DRAW_STEEL.Item.ability.SpendLabel", {
-      value: this.spend.value ?? "",
-      name: this.resourceName,
-    });
   }
 
   /* -------------------------------------------------- */
@@ -610,9 +605,7 @@ export default class AbilityModel extends BaseItemModel {
 
     let resourceSpend = fd.resource ?? 0;
 
-    if (fd.spend) {
-      resourceSpend += typeof fd.spend === "boolean" ? this.spend.value : fd.spend;
-    }
+    for (const spend of Object.values(fd.spend ?? {})) resourceSpend += spend;
 
     if (resourceSpend) {
       messageData.flavor = _loc("DRAW_STEEL.Item.ability.ConfigureUse.SpentFlavor", {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -33,6 +33,7 @@ export default class AbilityModel extends BaseItemModel {
       detailsPartial: [systemPath("templates/sheets/item/partials/ability.hbs")],
       embedded: {
         PowerRollEffect: "system.power.effects",
+        SpecialEffect: "system.effect.special",
       },
     };
   }
@@ -100,6 +101,7 @@ export default class AbilityModel extends BaseItemModel {
     schema.effect = new fields.SchemaField({
       before: new fields.HTMLField(),
       after: new fields.HTMLField(),
+      special: new ds.data.fields.CollectionField(ds.data.pseudoDocuments.specialEffects.BaseSpecialEffect),
     });
     schema.spend = new fields.SchemaField({
       value: new fields.NumberField({ integer: true }),

--- a/src/module/data/pseudo-documents/_module.mjs
+++ b/src/module/data/pseudo-documents/_module.mjs
@@ -1,6 +1,7 @@
 export * as advancements from "./advancements/_module.mjs";
 export * as messageParts from "./message-parts/_module.mjs";
 export * as powerRollEffects from "./power-roll-effects/_module.mjs";
+export * as specialEffects from "./special-effect/_module.mjs";
 
 export { default as PseudoDocument } from "./pseudo-document.mjs";
 export { default as TypedPseudoDocument } from "./typed-pseudo-document.mjs";

--- a/src/module/data/pseudo-documents/_types.d.ts
+++ b/src/module/data/pseudo-documents/_types.d.ts
@@ -1,6 +1,7 @@
 import "./advancements/_types";
 import "./message-parts/_types";
 import "./power-roll-effects/_types";
+import "./special-effect/_types";
 
 import { DialogV2Configuration, DialogV2WaitOptions } from "@client/applications/api/dialog.mjs";
 import { ApplicationConfiguration } from "@client/applications/_types";

--- a/src/module/data/pseudo-documents/special-effect/_module.mjs
+++ b/src/module/data/pseudo-documents/special-effect/_module.mjs
@@ -1,0 +1,2 @@
+export { default as BaseSpecialEffect } from "./base-special-effect.mjs";
+export { default as SpendSpecialEffect } from "./spend-effect.mjs";

--- a/src/module/data/pseudo-documents/special-effect/_module.mjs
+++ b/src/module/data/pseudo-documents/special-effect/_module.mjs
@@ -1,2 +1,3 @@
 export { default as BaseSpecialEffect } from "./base-special-effect.mjs";
+export { default as PersistentSpecialEffect } from "./persistent-effect.mjs";
 export { default as SpendSpecialEffect } from "./spend-effect.mjs";

--- a/src/module/data/pseudo-documents/special-effect/_module.mjs
+++ b/src/module/data/pseudo-documents/special-effect/_module.mjs
@@ -1,3 +1,4 @@
 export { default as BaseSpecialEffect } from "./base-special-effect.mjs";
 export { default as PersistentSpecialEffect } from "./persistent-effect.mjs";
 export { default as SpendSpecialEffect } from "./spend-effect.mjs";
+export { default as StrainedSpecialEffect } from "./strained-effect.mjs";

--- a/src/module/data/pseudo-documents/special-effect/_types.d.ts
+++ b/src/module/data/pseudo-documents/special-effect/_types.d.ts
@@ -1,0 +1,17 @@
+export {}
+
+declare module "./base-special-effect.mjs" {
+  export default interface BaseSpecialEffect {
+    description: string;
+    before: boolean;
+  }
+}
+
+declare module "./spend-effect.mjs" {
+  export default interface BaseSpecialEffect {
+    resource: {
+      value: number;
+      multiple: boolean;
+    }
+  }
+}

--- a/src/module/data/pseudo-documents/special-effect/_types.d.ts
+++ b/src/module/data/pseudo-documents/special-effect/_types.d.ts
@@ -1,14 +1,21 @@
-export {}
+import AbilityModel from "../../item/ability.mjs";
 
 declare module "./base-special-effect.mjs" {
   export default interface BaseSpecialEffect {
+    parent: AbilityModel;
     description: string;
     before: boolean;
   }
 }
 
+declare module "./persistent-effect.mjs" {
+  export default interface PersistentSpecialEffect {
+    essence: number;
+  }
+}
+
 declare module "./spend-effect.mjs" {
-  export default interface BaseSpecialEffect {
+  export default interface SpendSpecialEffect {
     resource: {
       value: number;
       multiple: boolean;

--- a/src/module/data/pseudo-documents/special-effect/base-special-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/base-special-effect.mjs
@@ -51,6 +51,16 @@ export default class BaseSpecialEffect extends TypedPseudoDocument {
   /* -------------------------------------------------- */
 
   /**
+   * The label for this in the ability display.
+   * @type {string}
+   */
+  get label() {
+    return this.name;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Type-specific context prep for this Special Effect.
    * Called by SpecialEffectSheet##prepareDetailsContext.
    * @param {object} options The rendering options.

--- a/src/module/data/pseudo-documents/special-effect/base-special-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/base-special-effect.mjs
@@ -1,0 +1,62 @@
+import TypedPseudoDocument from "../typed-pseudo-document.mjs";
+
+const { BooleanField, HTMLField } = foundry.data.fields;
+
+/**
+ * A nested data model for special text entries in abilities like Strained or Persist.
+ */
+export default class BaseSpecialEffect extends TypedPseudoDocument {
+  /** @inheritdoc */
+  static get metadata() {
+    return {
+      ...super.metadata,
+      documentName: "SpecialEffect",
+      icon: "fa-solid fa-file-lines",
+      sheetClass: ds.applications.sheets.pseudoDocuments.SpecialEffectSheet,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static get TYPE() {
+    return "base";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.SPECIAL_EFFECT");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      description: new HTMLField(),
+      before: new BooleanField(),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * A handlebars template partial inserted above the prosemirror editor.
+   * @type {string} Returns null if no handlebar template is needed for this subtype.
+   */
+  get detailsPartial() {
+    return null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Type-specific context prep for this Special Effect.
+   * Called by SpecialEffectSheet##prepareDetailsContext.
+   * @param {object} options The rendering options.
+   * @returns {Promise<object>} Additional context information.
+   */
+  async getSheetContext(options) {
+    return {};
+  }
+}

--- a/src/module/data/pseudo-documents/special-effect/persistent-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/persistent-effect.mjs
@@ -1,0 +1,37 @@
+import BaseSpecialEffect from "./base-special-effect.mjs";
+import { systemPath } from "../../../constants.mjs";
+
+const { NumberField } = foundry.data.fields;
+
+/**
+ * Persistent effects are used by the Elementalist.
+ */
+export default class PersistentSpecialEffect extends BaseSpecialEffect {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "persistent";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      essence: new NumberField({ integer: true, initial: 1, positive: true, nullable: false, required: true }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get detailsPartial() {
+    return systemPath("templates/sheets/pseudo-documents/special-effect/persistent.hbs");
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get label() {
+    return _loc("DRAW_STEEL.SPECIAL_EFFECT.persistent", { value: this.essence });
+  }
+}

--- a/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
@@ -1,0 +1,50 @@
+import BaseSpecialEffect from "./base-special-effect.mjs";
+import { systemPath } from "../../../constants.mjs";
+
+const { BooleanField, NumberField, SchemaField } = foundry.data.fields;
+
+/**
+ * Some abilities have a “Spend X [Heroic Resource]” entry in the body of the ability. These grant additional effects
+ * to an ability, where X is the amount of your Heroic Resource you must spend to activate those effects. If an entry
+ * reads “Spend X+ [Heroic Resource],” you can spend as much of your available Heroic Resource as you like in multiples
+ * of X to increase the effect’s impact, as described in the entry’s details.
+ */
+export default class SpendSpecialEffect extends BaseSpecialEffect {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "spend";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      resource: new SchemaField({
+        value: new NumberField({ integer: true, initial: 1, positive: true, nullable: false, required: true }),
+        multiple: new BooleanField(),
+      }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get detailsPartial() {
+    return systemPath("templates/sheets/pseudo-documents/special-effect/spend.hbs");
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Type-specific context prep for this Special Effect.
+   * Called by SpecialEffectSheet##prepareDetailsContext.
+   * @param {object} options The rendering options.
+   * @returns {Promise<object>} Additional context information.
+   */
+  async getSheetContext(options) {
+    return {
+      resourceName: this.document.actor?.system.coreResource?.name ?? _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label"),
+    };
+  }
+}

--- a/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
@@ -43,12 +43,7 @@ export default class SpendSpecialEffect extends BaseSpecialEffect {
 
   /* -------------------------------------------------- */
 
-  /**
-   * Type-specific context prep for this Special Effect.
-   * Called by SpecialEffectSheet##prepareDetailsContext.
-   * @param {object} options The rendering options.
-   * @returns {Promise<object>} Additional context information.
-   */
+  /** @inheritdoc */
   async getSheetContext(options) {
     return {
       resourceName: this.parent.resourceName,

--- a/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
@@ -36,6 +36,13 @@ export default class SpendSpecialEffect extends BaseSpecialEffect {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  get label() {
+    return _loc(`DRAW_STEEL.SPECIAL_EFFECT.spend.${this.resource.multiple ? "multiple" : "single"}`, { value: this.resource.value, resourceName: this.parent.resourceName });
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Type-specific context prep for this Special Effect.
    * Called by SpecialEffectSheet##prepareDetailsContext.
@@ -44,7 +51,7 @@ export default class SpendSpecialEffect extends BaseSpecialEffect {
    */
   async getSheetContext(options) {
     return {
-      resourceName: this.document.actor?.system.coreResource?.name ?? _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label"),
+      resourceName: this.parent.resourceName,
     };
   }
 }

--- a/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/spend-effect.mjs
@@ -38,7 +38,9 @@ export default class SpendSpecialEffect extends BaseSpecialEffect {
 
   /** @inheritdoc */
   get label() {
-    return _loc(`DRAW_STEEL.SPECIAL_EFFECT.spend.${this.resource.multiple ? "multiple" : "single"}`, { value: this.resource.value, resourceName: this.parent.resourceName });
+    return _loc(`DRAW_STEEL.SPECIAL_EFFECT.spend.${this.resource.multiple ? "multiple" : "single"}`,
+      { value: this.resource.value, resourceName: this.parent.resourceName },
+    );
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/special-effect/strained-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/strained-effect.mjs
@@ -1,0 +1,18 @@
+import BaseSpecialEffect from "./base-special-effect.mjs";
+
+/**
+ * Strained effects are used by the Talent.
+ */
+export default class StrainedSpecialEffect extends BaseSpecialEffect {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "strained";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get label() {
+    return _loc("TYPES.SpecialEffect.strained");
+  }
+}

--- a/src/module/utils/model-collection.mjs
+++ b/src/module/utils/model-collection.mjs
@@ -1,12 +1,13 @@
+import BaseAdvancement from "../data/pseudo-documents/advancements/base-advancement.mjs";
+import BaseMessagePart from "../data/pseudo-documents/message-parts/base-message-part.mjs";
+import BasePowerRollEffect from "../data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs";
+import BaseSpecialEffect from "../data/pseudo-documents/special-effect/base-special-effect.mjs";
+
 /**
  * @import DataModel from "@common/abstract/data.mjs";
  * @import PseudoDocument from "../data/pseudo-documents/pseudo-document.mjs";
  * @import Collection from "@common/utils/collection.mjs";
  */
-
-import BaseAdvancement from "../data/pseudo-documents/advancements/base-advancement.mjs";
-import BaseMessagePart from "../data/pseudo-documents/message-parts/base-message-part.mjs";
-import BasePowerRollEffect from "../data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs";
 
 /**
  * Specialized collection type for stored data models.
@@ -46,6 +47,7 @@ export default class ModelCollection extends foundry.utils.Collection {
     Advancement: BaseAdvancement,
     MessagePart: BaseMessagePart,
     PowerRollEffect: BasePowerRollEffect,
+    SpecialEffect: BaseSpecialEffect,
   };
 
   /* -------------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -43,9 +43,10 @@
     "Item": {
       "ability": {
         "filePathFields": {
-          "power.effects.*.img": ["IMAGE"]
+          "power.effects.*.img": ["IMAGE"],
+          "effects.*.img": ["IMAGE"]
         },
-        "htmlFields": ["effect.before", "effect.after", "effect.special.*.description"]
+        "htmlFields": ["effects.*.description"]
       },
       "ancestry": {
         "filePathFields": {

--- a/system.json
+++ b/system.json
@@ -45,7 +45,7 @@
         "filePathFields": {
           "power.effects.*.img": ["IMAGE"]
         },
-        "htmlFields": ["effect.before", "effect.after"]
+        "htmlFields": ["effect.before", "effect.after", "effect.special.*.description"]
       },
       "ancestry": {
         "filePathFields": {

--- a/templates/apps/ability-configuration-dialog/ability.hbs
+++ b/templates/apps/ability-configuration-dialog/ability.hbs
@@ -12,19 +12,19 @@
       <p class="hint">{{localize "DRAW_STEEL.Item.ability.ConfigureUse.Resource.hint" value=ability.system.resource name=resource.name}}</p>
     </div>
     {{/if}}
-    {{#if spendConfig}}
+    {{#each spendConfig}}
     <div class="form-group">
-      <label>{{localize "DRAW_STEEL.Item.ability.ConfigureUse.Spend.label" value=spendConfig.value name=resource.name}}</label>
+      <label>{{localize (concat "DRAW_STEEL.SPECIAL_EFFECT.spend." (ifThen multiple "multiple" "single")) value=value resourceName=@root.resource.name}}</label>
       <div class="form-fields">
-        {{#if spendConfig.slider}}
-        <range-picker name="spend" max="{{spendConfig.max}}" min="0" step="1" value="{{spend}}"></range-picker>
+        {{#if multiple}}
+        <range-picker name="{{concat "spend." id}}" max="{{@root.resource.max}}" min="0" step="{{value}}" value="{{lookup @root.spend id}}"></range-picker>
         {{else}}
-        <input type="checkbox" name="spend" {{checked spend}}>
+        <input type="checkbox" name="{{concat "spend." id}}" {{checked (lookup @root.spend id)}} data-dtype="Number" value="{{value}}">
         {{/if}}
       </div>
       <p class="hint">{{localize "DRAW_STEEL.Item.ability.ConfigureUse.Spend.hint"}}</p>
     </div>
-    {{/if}}
+    {{/each}}
   </fieldset>
   {{/if}}
   {{#if damageOptions}}

--- a/templates/embeds/item/ability.hbs
+++ b/templates/embeds/item/ability.hbs
@@ -29,12 +29,6 @@
   </dl>
 </section>
 <section class="effect before">
-  {{#if system.effect.before}}
-  <dl>
-    <dt class="effect">{{systemFields.effect.label}}</dt>
-    <dd class="effect">{{{enrichedBeforeEffect}}}</dd>
-  </dl>
-  {{/if}}
   {{#each beforeEffects}}
   <dl>
     <dt class="effect">{{label}}</dt>
@@ -63,12 +57,6 @@
 </section>
 {{/if}}
 <section class="effect after">
-  {{#if system.effect.after}}
-  <dl>
-    <dt class="effect">{{systemFields.effect.label}}</dt>
-    <dd class="effect">{{{enrichedAfterEffect}}}</dd>
-  </dl>
-  {{/if}}
   {{#each afterEffects}}
   <dl>
     <dt class="effect">{{label}}</dt>

--- a/templates/embeds/item/ability.hbs
+++ b/templates/embeds/item/ability.hbs
@@ -64,11 +64,3 @@
   </dl>
   {{/each}}
 </section>
-{{#if system.spend.text}}
-<section class="spend">
-  <dl>
-    <dt>{{spendLabel}}</dt>
-    <dd>{{{system.spend.text}}}</dd>
-  </dl>
-</section>
-{{/if}}

--- a/templates/embeds/item/ability.hbs
+++ b/templates/embeds/item/ability.hbs
@@ -28,14 +28,20 @@
     {{/if}}
   </dl>
 </section>
-{{#if system.effect.before}}
 <section class="effect before">
+  {{#if system.effect.before}}
   <dl>
     <dt class="effect">{{systemFields.effect.label}}</dt>
     <dd class="effect">{{{enrichedBeforeEffect}}}</dd>
   </dl>
+  {{/if}}
+  {{#each beforeEffects}}
+  <dl>
+    <dt class="effect">{{label}}</dt>
+    <dd class="effect">{{{text}}}</dd>
+  </dl>
+  {{/each}}
 </section>
-{{/if}}
 {{#if powerRolls}}
 <section class="powerResult">
   {{#unless system.power.roll.reactive}}
@@ -56,14 +62,20 @@
   </dl>
 </section>
 {{/if}}
-{{#if system.effect.after}}
 <section class="effect after">
+  {{#if system.effect.after}}
   <dl>
     <dt class="effect">{{systemFields.effect.label}}</dt>
     <dd class="effect">{{{enrichedAfterEffect}}}</dd>
   </dl>
+  {{/if}}
+  {{#each afterEffects}}
+  <dl>
+    <dt class="effect">{{label}}</dt>
+    <dd class="effect">{{{text}}}</dd>
+  </dl>
+  {{/each}}
 </section>
-{{/if}}
 {{#if system.spend.text}}
 <section class="spend">
   <dl>

--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -1,16 +1,5 @@
 {{! Impact Tab }}
 <section class="tab standard-form {{tab.cssClass}}" data-group="primary" data-tab="impact" data-subtype="{{document.type}}">
-  <div class="effect form-group stacked">
-    <label>{{systemFields.effect.fields.before.label}}</label>
-    {{#if isPlay}}
-    {{{enrichedBeforeEffect}}}
-    {{else}}
-    <div class="form-fields">
-      {{formInput systemFields.effect.fields.before value=system.effect.before height="200"}}
-    </div>
-    {{/if}}
-  </div>
-
   <fieldset class="power-roll-data">
     <legend>{{localize "DRAW_STEEL.Item.ability.FIELDS.power.label"}}</legend>
     {{#with systemFields.power.fields.roll.fields as |powerRoll|}}
@@ -45,20 +34,32 @@
     {{/each}}
   </fieldset>
 
+  <fieldset data-pseudo-document-name="SpecialEffect">
+    <legend>{{systemFields.effects.label}}</legend>
+    {{#unless isPlay}}
+    <div class="section-header">
+      <button type="button" data-action="createPseudoDocument">
+        <i class="{{specialEffectIcon}}"></i>
+        {{localize "DOCUMENT.Create" type=(localize "DOCUMENT.SpecialEffect")}}
+      </button>
+    </div>
+    {{/unless}}
+    {{!-- Using document.system to ensure initialized values in edit mode --}}
+    {{#each document.system.effects.sortedContents}}
+    <div class="form-group draggable" data-pseudo-id="{{id}}">
+      <img class="pre-img" src="{{img}}" alt="{{name}}">
+      <label> {{name}} </label>
+      <div class="form-fields">
+        <button type="button" data-action="renderPseudoDocumentSheet" class="icon fa-fw fa-solid fa-cog" {{disabled (not @root.editable)}}></button>
+        <button type="button" data-action="deletePseudoDocument" class="icon fa-fw fa-solid fa-trash" {{disabled @root.isPlay}}></button>
+      </div>
+    </div>
+    {{/each}}
+  </fieldset>
+
   <fieldset>
     <legend>{{systemFields.spend.label}}</legend>
     {{formGroup systemFields.spend.fields.value value=system.spend.value disabled=@root.isPlay}}
     {{formGroup systemFields.spend.fields.text value=system.spend.text disabled=@root.isPlay}}
   </fieldset>
-
-  <div class="effect form-group stacked">
-    <label>{{systemFields.effect.fields.after.label}}</label>
-    {{#if isPlay}}
-    {{{enrichedAfterEffect}}}
-    {{else}}
-    <div class="form-fields">
-      {{formInput systemFields.effect.fields.after value=system.effect.after height="200"}}
-    </div>
-    {{/if}}
-  </div>
 </section>

--- a/templates/sheets/item/impact.hbs
+++ b/templates/sheets/item/impact.hbs
@@ -56,10 +56,4 @@
     </div>
     {{/each}}
   </fieldset>
-
-  <fieldset>
-    <legend>{{systemFields.spend.label}}</legend>
-    {{formGroup systemFields.spend.fields.value value=system.spend.value disabled=@root.isPlay}}
-    {{formGroup systemFields.spend.fields.text value=system.spend.text disabled=@root.isPlay}}
-  </fieldset>
 </section>

--- a/templates/sheets/pseudo-documents/special-effect/content.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/content.hbs
@@ -1,0 +1,9 @@
+<section class="standard-form">
+  {{formGroup fields.name value=source.name placeholder=(localize (concat "TYPES.SpecialEffect." source.type)) name="name"}}
+  {{formGroup fields.img value=source.img name="img"}}
+  {{#if detailsPartial}}
+  {{> (lookup @root "detailsPartial") @root}}
+  {{/if}}
+  {{formGroup fields.before value=source.before name="before"}}
+  {{formInput fields.description value=source.description height=300 name="description"}}
+</section>

--- a/templates/sheets/pseudo-documents/special-effect/details.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/details.hbs
@@ -1,0 +1,1 @@
+<section class="{{tabs.details.cssClass}}" data-tab="{{tabs.details.id}}" data-group="{{tabs.details.group}}"></section>

--- a/templates/sheets/pseudo-documents/special-effect/identity.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/identity.hbs
@@ -1,0 +1,6 @@
+<section class="{{tabs.identity.cssClass}}" data-tab="{{tabs.identity.id}}" data-group="{{tabs.identity.group}}">
+  {{formGroup fields.name value=source.name placeholder=(localize (concat "TYPES.SpecialEffect." source.type)) name="name"}}
+  {{formGroup fields.img value=source.img name="img"}}
+
+  {{formInput fields.description value=source.description height=300 name="description"}}
+</section>

--- a/templates/sheets/pseudo-documents/special-effect/persistent.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/persistent.hbs
@@ -1,0 +1,1 @@
+{{formGroup fields.essence value=source.essence name="essence" classes="slim"}}

--- a/templates/sheets/pseudo-documents/special-effect/spend.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/spend.hbs
@@ -1,4 +1,3 @@
-
 <div class="form-group">
   {{formGroup fields.resource.fields.value value=source.resource.value name="resource.value" label=ctx.resourceName classes="slim"}}
   {{formGroup fields.resource.fields.multiple value=source.resource.multiple name="resource.multiple"}}

--- a/templates/sheets/pseudo-documents/special-effect/spend.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/spend.hbs
@@ -1,0 +1,5 @@
+
+<div class="form-group">
+  {{formGroup fields.resource.fields.value value=source.resource.value name="resource.value" label=ctx.resourceName classes="slim"}}
+  {{formGroup fields.resource.fields.multiple value=source.resource.multiple name="resource.multiple"}}
+</div>


### PR DESCRIPTION
Implements a new pseudodocument named "SpecialEffect" that has a `description` HTML field. These can be placed before or after the power roll and cover a plain "Effect/Special" text entry, "Spend", "Persistent", and "Strained". A migration has been provided to turn `effect.before`, `effect.after`, and `spend` fields into SpecialEffects, however a one-time migration will be desirable because this was not a simple field-to-field transfer.

<img width="1155" height="586" alt="image" src="https://github.com/user-attachments/assets/bae1c99c-1162-4590-9b2e-8eca5b261dde" />

Closes #475