### PR TITLE
Implement "With Captain" effects.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1811,7 +1811,7 @@
           },
           "isWithCaptain": {
             "label": "\"With Captain\" Effect",
-            "hint": "Apply effect when the Actor is in the presence of their Captain. Only one \"With Captain\" effect can be active at a time."
+            "hint": "Effect to be applied when the Actor is in the presence of their Captain. An Actor may have only one \"With Captain\" effect at a time."
           },
           "project": {
             "label": "Project",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1806,6 +1806,10 @@
               "label": "Saving Throw Formula"
             }
           },
+          "isWithCaptain": {
+            "label": "\"With Captain\" Effect",
+            "hint": "Apply effect when the Actor is in the presence of their Captain. Only one \"With Captain\" effect can be active at a time."
+          },
           "project": {
             "label": "Project",
             "prerequisites": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1796,6 +1796,9 @@
         "Dying": "Dying",
         "Winded": "Winded"
       },
+      "WithCaptainEffects": {
+        "embedLabel": "With Captain"
+      },
       "base": {
         "FIELDS": {
           "end": {

--- a/src/module/applications/sheets/active-effect-config.mjs
+++ b/src/module/applications/sheets/active-effect-config.mjs
@@ -54,6 +54,7 @@ export default class DrawSteelActiveEffectConfig extends foundry.applications.sh
         context.keywordOptions = ds.CONFIG.abilities.keywordOptions;
         context.characteristicOptions = Object.entries(ds.CONFIG.characteristics).map(([value, { label }]) => ({ value, label }));
         context.kindOptions = Object.entries(ds.CONFIG.equipment.kinds).map(([value, { label }]) => ({ value, label }));
+        context.hideWithCaptainField = this.document.parent.effects.some((e) => e.system.isWithCaptain && (e.id !== this.document.id));
         break;
     }
 

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -207,28 +207,6 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
   /* -------------------------------------------------- */
 
   /**
-   * Constructs a record of valid characteristics and their associated field.
-   * @param {boolean} edit Are the characteristics editable inline?
-   * @returns {Record<string, {field: NumberField, value: number}>}
-   * @protected
-   */
-  _getCharacteristics(edit) {
-    const isEdit = this.isEditMode && edit;
-    const data = isEdit ? this.actor._source : this.actor;
-    return Object.keys(ds.CONFIG.characteristics).reduce((obj, chc) => {
-      const value = foundry.utils.getProperty(data, `system.characteristics.${chc}.value`);
-      obj[chc] = {
-        isEdit,
-        field: this.actor.system.schema.getField(["characteristics", chc, "value"]),
-        value: isEdit ? (value || null) : (value ?? 0),
-      };
-      return obj;
-    }, {});
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
    * Constructs a tooltip of data paths.
    * @protected
    */

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -166,7 +166,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       case "stats":
         context.combatTooltip = this._getCombatTooltip();
         context.movement = this._getMovement();
-        context.damageIW = this._getImmunitiesWeaknesses();
+        context.damageIW = this.actor.system._getImmunitiesWeaknesses?.();
         break;
       case "features":
         context.features = await this._prepareFeaturesContext();
@@ -267,37 +267,6 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
     return {
       list: formatter.format(languageList),
       options: languageOptions,
-    };
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Constructs an object with the formatted immunities and weaknesses with a list of damage labels.
-   * @returns {{immunities: string, weaknesses: string, labels: Record<string, string>}}
-   * @protected
-   */
-  _getImmunitiesWeaknesses() {
-    const labels = {
-      all: _loc("DRAW_STEEL.Actor.base.FIELDS.damage.immunities.all.label"),
-      ...Object.entries(ds.CONFIG.damageTypes).reduce((acc, [type, { label }]) => {
-        acc[type] = label;
-        return acc;
-      }, {}),
-    };
-
-    const immunities = Object.entries(this.actor.system.damage.immunities)
-      .filter(([damageType, value]) => value > 0)
-      .map(([damageType, value]) => `<span class="immunity">${labels[damageType]} ${value}</span>`);
-    const weaknesses = Object.entries(this.actor.system.damage.weaknesses)
-      .filter(([damageType, value]) => value > 0)
-      .map(([damageType, value]) => `<span class="weakness">${labels[damageType]} ${value}</span>`);
-
-    const formatter = game.i18n.getListFormatter({ type: "unit" });
-    return {
-      immunities: formatter.format(immunities),
-      weaknesses: formatter.format(weaknesses),
-      labels,
     };
   }
 

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -165,7 +165,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
         break;
       case "stats":
         context.combatTooltip = this._getCombatTooltip();
-        context.movement = this._getMovement();
+        context.movement = this.actor.system._getMovement?.();
         context.damageIW = this.actor.system._getImmunitiesWeaknesses?.();
         break;
       case "features":
@@ -221,32 +221,6 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
       }
     }
     return tooltip;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Constructs an object with the actor's movement types as well as all options available from CONFIG.Token.movement.actions.
-   * @returns {{flying: boolean, list: string, options: FormSelectOption[]}}
-   * @protected
-   */
-  _getMovement() {
-    const formatter = game.i18n.getListFormatter({ type: "unit" });
-    const actorMovement = this.actor.system.movement;
-    const canHover = actorMovement.types.has("fly") || actorMovement.types.has("teleport");
-    const movementList = Array.from(actorMovement.types).map(m => {
-      let label = _loc(CONFIG.Token.movement.actions[m]?.label ?? m);
-      if ((m === "teleport") && (actorMovement.teleport !== actorMovement.value)) label += " " + actorMovement.teleport;
-      return label;
-    });
-    if (canHover && actorMovement.hover) movementList.push(_loc("DRAW_STEEL.Actor.base.FIELDS.movement.hover.label"));
-    return {
-      canHover,
-      list: formatter.format(movementList),
-      options: Object.entries(CONFIG.Token.movement.actions)
-        .filter(([key, _action]) => ds.CONFIG.speedOptions.includes(key))
-        .map(([value, { label }]) => ({ value, label })),
-    };
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -23,7 +23,7 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
     classes: ["actor"],
     position: {
       width: 700,
-      height: 600,
+      height: 620,
     },
     actions: {
       // We're not extending ActorSheetV2 because we ultimately don't want to inherit most of the framework Foundry defaults to

--- a/src/module/applications/sheets/hero-sheet.mjs
+++ b/src/module/applications/sheets/hero-sheet.mjs
@@ -88,7 +88,7 @@ export default class DrawSteelHeroSheet extends DrawSteelActorSheet {
     await super._preparePartContext(partId, context, options);
     switch (partId) {
       case "stats":
-        context.characteristics = this._getCharacteristics(false);
+        context.characteristics = this.actor.system._getCharacteristics(false);
         context.unfilledSkill = !!this.actor.system._unfilledTraits.skill?.size;
         context.skills = this._getSkills();
         break;

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -73,7 +73,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
         context.malice = game.actors.malice;
         break;
       case "stats":
-        context.characteristics = this._getCharacteristics(true);
+        context.characteristics = this.actor.system._getCharacteristics(this.isEditMode);
         context.isSingleSquadMinion = this.actor.isMinion && (this.actor.system.combatGroups.size === 1);
         if (context.isSingleSquadMinion) context.combatGroup = this.actor.system.combatGroup;
         break;

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -68,7 +68,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
     await super._preparePartContext(partId, context, options);
     switch (partId) {
       case "header":
-        context.monsterKeywords = this._getMonsterKeywords();
+        context.monsterKeywords = this.actor.system._getMonsterKeywords();
         context.showMalice = game.user.isGM && !this.actor.system.isMinion;
         context.malice = game.actors.malice;
         break;
@@ -82,17 +82,6 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
         break;
     }
     return context;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Fetches the printable string for the monster's keywords.
-   * @returns {string[]}
-   */
-  _getMonsterKeywords() {
-    const monsterKeywords = ds.CONFIG.monsters.keywords;
-    return Array.from(this.actor.system.monster.keywords).map(k => monsterKeywords[k]?.label).filter(k => k);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -14,6 +14,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
       updateSource: this.#updateSource,
       editMonsterMetadata: this.#editMonsterMetadata,
       freeStrike: this.#freeStrike,
+      toggleWithCaptainEffect: this.#toggleWithCaptainEffect,
     },
     window: {
       controls: [{
@@ -74,6 +75,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
         break;
       case "stats":
         context.characteristics = this.actor.system._getCharacteristics(this.isEditMode);
+        context.withCaptain = this._getWithCaptainContext();
         context.isSingleSquadMinion = this.actor.isMinion && (this.actor.system.combatGroups.size === 1);
         if (context.isSingleSquadMinion) context.combatGroup = this.actor.system.combatGroup;
         break;
@@ -82,6 +84,22 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
         break;
     }
     return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetches the context for the "With Captain" effect.
+   * @returns {{description: string; exists: boolean; effectEnabled: boolean; effectId: string}}
+   */
+  _getWithCaptainContext() {
+    const effect = this.actor.effects.find((e) => e.system.isWithCaptain);
+    return {
+      description: this.actor.system._getWithCaptainDescription(),
+      effectEnabled: !effect?.disabled,
+      effectId: effect?.id,
+      exists: !!effect,
+    };
   }
 
   /* -------------------------------------------------- */
@@ -188,5 +206,19 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
    */
   static async #freeStrike(event, target) {
     this.actor.system.performFreeStrike();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Toggle the "With Captain" effect.
+   * @this DrawSteelNPCSheet
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static #toggleWithCaptainEffect(event, target) {
+    const id = target.closest("[data-effect-id]").dataset.effectId;
+    const effect = this.actor.effects.get(id);
+    effect.update({ disabled: !target.checked });
   }
 }

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -61,17 +61,6 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
   };
 
   /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  _getMovement() {
-    const data = super._getMovement();
-
-    data.show = !!this.actor.system.movement.value;
-
-    return data;
-  }
-
-  /* -------------------------------------------------- */
   /*   Actions                                          */
   /* -------------------------------------------------- */
 

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -67,7 +67,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
         context.mentorLink = this.document.system.retainer.mentor?.toAnchor();
         break;
       case "stats":
-        context.characteristics = this._getCharacteristics(true);
+        context.characteristics = this.actor.system._getCharacteristics(this.isEditMode);
         break;
     }
     return context;

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -453,4 +453,35 @@ export default class BaseActorModel extends DrawSteelSystemModel {
   async updateResource(delta) {
     throw new Error("This method is abstract and must be implemented by a subclass");
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Constructs an object with the formatted immunities and weaknesses with a list of damage labels.
+   * @returns {{immunities: string, weaknesses: string, labels: Record<string, string>}}
+   * @protected
+   */
+  _getImmunitiesWeaknesses() {
+    const labels = {
+      all: _loc("DRAW_STEEL.Actor.base.FIELDS.damage.immunities.all.label"),
+      ...Object.entries(ds.CONFIG.damageTypes).reduce((acc, [type, { label }]) => {
+        acc[type] = label;
+        return acc;
+      }, {}),
+    };
+
+    const immunities = Object.entries(this.damage.immunities)
+      .filter(([damageType, value]) => value > 0)
+      .map(([damageType, value]) => `<span class="immunity">${labels[damageType]} ${value}</span>`);
+    const weaknesses = Object.entries(this.damage.weaknesses)
+      .filter(([damageType, value]) => value > 0)
+      .map(([damageType, value]) => `<span class="weakness">${labels[damageType]} ${value}</span>`);
+
+    const formatter = game.i18n.getListFormatter({ type: "unit" });
+    return {
+      immunities: formatter.format(immunities),
+      weaknesses: formatter.format(weaknesses),
+      labels,
+    };
+  }
 }

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -484,4 +484,40 @@ export default class BaseActorModel extends DrawSteelSystemModel {
       labels,
     };
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Constructs an object with the actor's movement types as well as all options available from CONFIG.Token.movement.actions.
+   * @param {boolean} [excludeWalk=false] Whether to include the Walk movement type.
+   * @returns {{canHover: boolean, list: string, options: FormSelectOption[]}}
+   * @protected
+   */
+  _getMovement(excludeWalk = false) {
+    const formatter = game.i18n.getListFormatter({ type: "unit" });
+    const actorMovement = this.movement;
+    const canHover = actorMovement.types.has("fly") || actorMovement.types.has("teleport");
+    const movementList = Array.from(actorMovement.types).map(m => {
+      let label = _loc(CONFIG.Token.movement.actions[m]?.label ?? m);
+      if ((m === "teleport") && (actorMovement.teleport !== actorMovement.value)) label += " " + actorMovement.teleport;
+      return label;
+    });
+
+    if (canHover && actorMovement.hover) movementList.push(_loc("DRAW_STEEL.Actor.base.FIELDS.movement.hover.label"));
+
+    if (excludeWalk) {
+      const walkIndex = movementList.indexOf(_loc(CONFIG.Token.movement.actions.walk.label));
+      movementList.splice(walkIndex, 1);
+    }
+
+    return {
+      canHover,
+      list: formatter.format(movementList),
+      options: Object.entries(CONFIG.Token.movement.actions)
+        .filter(([key, _action]) => ds.CONFIG.speedOptions.includes(key))
+        .map(([value, { label }]) => ({ value, label })),
+      show: !!this.movement.value,
+
+    };
+  }
 }

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -459,7 +459,6 @@ export default class BaseActorModel extends DrawSteelSystemModel {
   /**
    * Constructs an object with the formatted immunities and weaknesses with a list of damage labels.
    * @returns {{immunities: string, weaknesses: string, labels: Record<string, string>}}
-   * @protected
    */
   _getImmunitiesWeaknesses() {
     const labels = {
@@ -491,7 +490,6 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    * Constructs an object with the actor's movement types as well as all options available from CONFIG.Token.movement.actions.
    * @param {boolean} [excludeWalk=false] Whether to include the Walk movement type.
    * @returns {{canHover: boolean, list: string, options: FormSelectOption[]}}
-   * @protected
    */
   _getMovement(excludeWalk = false) {
     const formatter = game.i18n.getListFormatter({ type: "unit" });

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -180,6 +180,8 @@ export default class CreatureModel extends BaseActorModel {
     if (this.parent.statuses.has("restrained") && ["might", "agility"].includes(options.characteristic)) modifiers.banes += 1;
   }
 
+  /* ------------------------------------------------- */
+
   /**
      * Constructs a record of valid characteristics and their associated field.
      * @param {boolean} fromSource If true, use Actor's source data; else, use prepared data.

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -179,4 +179,21 @@ export default class CreatureModel extends BaseActorModel {
     // Restrained condition - might and agility tests take a bane
     if (this.parent.statuses.has("restrained") && ["might", "agility"].includes(options.characteristic)) modifiers.banes += 1;
   }
+
+  /**
+     * Constructs a record of valid characteristics and their associated field.
+     * @param {boolean} fromSource If true, use Actor's source data; else, use prepared data.
+     * @returns {Record<string, {field: NumberField, value: number}}
+     */
+  _getCharacteristics(fromSource) {
+    const data = fromSource ? this._source : this;
+    return Object.keys(ds.CONFIG.characteristics).reduce((obj, chc) => {
+      const value = foundry.utils.getProperty(data, `characteristics.${chc}.value`);
+      obj[chc] = {
+        field: this.schema.getField(["characteristics", chc, "value"]),
+        value: value ?? 0,
+      };
+      return obj;
+    }, {});
+  }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -211,7 +211,7 @@ export default class NPCModel extends CreatureModel {
     const context = {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
-      damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
+      damageIW: this._getImmunitiesWeaknesses(),
       monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -1,8 +1,7 @@
-import { systemID, systemPath } from "../../constants.mjs";
 import { requiredInteger, setOptions } from "../helpers.mjs";
+import { systemID, systemPath } from "../../constants.mjs";
 import CreatureModel from "./creature.mjs";
 import SourceModel from "../models/source.mjs";
-import { systemID } from "../../constants.mjs";
 
 /**
  * @import { DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -204,10 +204,11 @@ export default class NPCModel extends CreatureModel {
   async toEmbed(config, options) {
     // All NPCs are rendered inline
     config.inline = true;
-    console.log(config, options);
+    // console.log(config, options);
 
     const context = {
       actor: this.parent,
+      monsterKeywords: this.parent.sheet._getMonsterKeywords(),
       system: this,
       systemFields: this.schema.fields,
     };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -227,6 +227,13 @@ export default class NPCModel extends CreatureModel {
     return embed;
   }
 
+  /* ------------------------------------------------- */
+
+  /** @inheritdoc */
+  onEmbed(element) {
+    element.querySelector("a[data-action='openSheet']")?.addEventListener("click", () => this.parent.sheet.render({ force: true }));
+  }
+
   /* -------------------------------------------------- */
 
   /**

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -210,7 +210,7 @@ export default class NPCModel extends CreatureModel {
 
     const context = {
       actor: this.parent,
-      characteristics: this.parent.sheet._getCharacteristics(true),
+      characteristics: this._getCharacteristics(false),
       damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
       monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -206,13 +206,13 @@ export default class NPCModel extends CreatureModel {
     config.inline = true;
 
     const walkLabel = game.i18n.localize(CONFIG.Token.movement.actions.walk.label);
-    const walkRe = new RegExp(`${walkLabel}[,]?`, "i");
+    const walkRe = new RegExp(`${walkLabel}[,]?`);
 
     const context = {
       actor: this.parent,
       characteristics: this.parent.sheet._getCharacteristics(true),
       damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
-      monsterKeywords: this.parent.sheet._getMonsterKeywords(),
+      monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,
       systemFields: this.schema.fields,

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -225,7 +225,6 @@ export default class NPCModel extends CreatureModel {
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 
     return embed;
-
   }
 
   /* -------------------------------------------------- */
@@ -315,6 +314,6 @@ export default class NPCModel extends CreatureModel {
    */
   _getMonsterKeywords() {
     const monsterKeywords = ds.CONFIG.monsters.keywords;
-    return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(k => k);
+    return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(_ => _);
   }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -212,7 +212,7 @@ export default class NPCModel extends CreatureModel {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
       damageIW: this._getImmunitiesWeaknesses(),
-      monsterKeywords: this.parent.sheet._getMonsterKeywords().join(", "),
+      monsterKeywords: this._getMonsterKeywords().join(", "),
       movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,
       systemFields: this.schema.fields,
@@ -305,5 +305,16 @@ export default class NPCModel extends CreatureModel {
     /** @type {MaliceModel} */
     const malice = game.actors.malice;
     await game.settings.set(systemID, "malice", { value: malice.value + delta });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetches the printable string for the monster's keywords.
+   * @returns {string[]}
+   */
+  _getMonsterKeywords() {
+    const monsterKeywords = ds.CONFIG.monsters.keywords;
+    return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(k => k);
   }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -205,9 +205,6 @@ export default class NPCModel extends CreatureModel {
     // All NPCs are rendered inline
     config.inline = true;
 
-    const walkLabel = _loc(CONFIG.Token.movement.actions.walk.label);
-    const walkRe = new RegExp(`${walkLabel}[,]?`);
-
     const context = {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
@@ -216,6 +213,7 @@ export default class NPCModel extends CreatureModel {
       movement: this._getMovement(true).list,
       system: this,
       systemFields: this.schema.fields,
+      withCaptain: this._getWithCaptainDescription(),
     };
 
     const embed = document.createElement("div");
@@ -322,5 +320,19 @@ export default class NPCModel extends CreatureModel {
   _getMonsterKeywords() {
     const monsterKeywords = ds.CONFIG.monsters.keywords;
     return Array.from(this.monster.keywords).map(k => monsterKeywords[k]?.label).filter(_ => _);
+  }
+
+  /* ------------------------------------------------- */
+
+  /**
+   * Fetches the description for the "With Captain" effect.
+   * @returns {string|null} The inner HTML of the first element of the description.
+   *                        Null if no such effect exists.
+   */
+  _getWithCaptainDescription() {
+    const withCaptainAE = this.parent.effects.find(e => e.system.isWithCaptain);
+    let html = foundry.utils.parseHTML(withCaptainAE?.description);
+    if (html instanceof HTMLCollection) html = html[0];
+    return html?.innerHTML ?? null;
   }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -213,7 +213,7 @@ export default class NPCModel extends CreatureModel {
       characteristics: this._getCharacteristics(false),
       damageIW: this._getImmunitiesWeaknesses(),
       monsterKeywords: this._getMonsterKeywords().join(", "),
-      movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
+      movement: this._getMovement(true).list,
       system: this,
       systemFields: this.schema.fields,
     };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -213,11 +213,13 @@ export default class NPCModel extends CreatureModel {
       systemFields: this.schema.fields,
     };
 
-    const wrapper = document.createElement("div");
+    const embed = document.createElement("div");
 
-    wrapper.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+    embed.classList.add("draw-steel", "actor", "npc");
 
-    return wrapper;
+    embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+
+    return embed;
 
   }
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -205,10 +205,15 @@ export default class NPCModel extends CreatureModel {
     // All NPCs are rendered inline
     config.inline = true;
 
+    const walkLabel = game.i18n.localize(CONFIG.Token.movement.actions.walk.label);
+    const walkRe = new RegExp(`${walkLabel}[,]?`, "i");
+
     const context = {
       actor: this.parent,
       characteristics: this.parent.sheet._getCharacteristics(true),
+      damageIW: this.parent.sheet._getImmunitiesWeaknesses(),
       monsterKeywords: this.parent.sheet._getMonsterKeywords(),
+      movement: this.parent.sheet._getMovement().list.replace(walkRe, "").trim(),
       system: this,
       systemFields: this.schema.fields,
     };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -205,7 +205,7 @@ export default class NPCModel extends CreatureModel {
     // All NPCs are rendered inline
     config.inline = true;
 
-    const walkLabel = game.i18n.localize(CONFIG.Token.movement.actions.walk.label);
+    const walkLabel = _loc(CONFIG.Token.movement.actions.walk.label);
     const walkRe = new RegExp(`${walkLabel}[,]?`);
 
     const context = {
@@ -220,7 +220,7 @@ export default class NPCModel extends CreatureModel {
 
     const embed = document.createElement("div");
 
-    embed.classList.add("draw-steel", "actor", "npc");
+    embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -1,3 +1,4 @@
+import { systemID, systemPath } from "../../constants.mjs";
 import { requiredInteger, setOptions } from "../helpers.mjs";
 import CreatureModel from "./creature.mjs";
 import SourceModel from "../models/source.mjs";
@@ -196,6 +197,28 @@ export default class NPCModel extends CreatureModel {
     }
 
     return freeStrike;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async toEmbed(config, options) {
+    // All NPCs are rendered inline
+    config.inline = true;
+    console.log(config, options);
+
+    const context = {
+      actor: this.parent,
+      system: this,
+      systemFields: this.schema.fields,
+    };
+
+    const wrapper = document.createElement("div");
+
+    wrapper.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+
+    return wrapper;
+
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -204,10 +204,10 @@ export default class NPCModel extends CreatureModel {
   async toEmbed(config, options) {
     // All NPCs are rendered inline
     config.inline = true;
-    // console.log(config, options);
 
     const context = {
       actor: this.parent,
+      characteristics: this.parent.sheet._getCharacteristics(true),
       monsterKeywords: this.parent.sheet._getMonsterKeywords(),
       system: this,
       systemFields: this.schema.fields,

--- a/src/module/data/effect/base-effect.mjs
+++ b/src/module/data/effect/base-effect.mjs
@@ -50,6 +50,8 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
       }),
     });
 
+    schema.isWithCaptain = new fields.BooleanField({ initial: false });
+
     return schema;
   }
 

--- a/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Angulotl_Cleaver_G1fUng66ZtDXk6Ts.json
+++ b/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Angulotl_Cleaver_G1fUng66ZtDXk6Ts.json
@@ -752,7 +752,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Angulotl_Dart_R1CEitcfoGyEwRZY.json
+++ b/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Angulotl_Dart_R1CEitcfoGyEwRZY.json
@@ -755,7 +755,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Angulotl_Pollywog_UIerVsSyMb36Bm4D.json
+++ b/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Angulotl_Pollywog_UIerVsSyMb36Bm4D.json
@@ -771,7 +771,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Clawfish_rmkUHKgXlVPjsH25.json
+++ b/src/packs/monsters/Angulotl_VG4LRhUl5RB1EpzH/npc_Clawfish_rmkUHKgXlVPjsH25.json
@@ -809,7 +809,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Bugbears_IOJX0Gbij4nZLkvh/npc_Bugbear_Knightmare_BUM1285qoUoaorwL.json
+++ b/src/packs/monsters/Bugbears_IOJX0Gbij4nZLkvh/npc_Bugbear_Knightmare_BUM1285qoUoaorwL.json
@@ -748,7 +748,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Bugbears_IOJX0Gbij4nZLkvh/npc_Bugbear_Mob_1uTE9K7c8YUOVjhm.json
+++ b/src/packs/monsters/Bugbears_IOJX0Gbij4nZLkvh/npc_Bugbear_Mob_1uTE9K7c8YUOVjhm.json
@@ -703,7 +703,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Bugbears_IOJX0Gbij4nZLkvh/npc_Bugbear_Snare_YpvSj9tJzpiPSmLl.json
+++ b/src/packs/monsters/Bugbears_IOJX0Gbij4nZLkvh/npc_Bugbear_Snare_YpvSj9tJzpiPSmLl.json
@@ -617,7 +617,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
@@ -495,7 +495,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Grulqin_WwVzCeCSmWxzavYt.json
@@ -486,7 +486,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
@@ -574,7 +574,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Orliq_tE6gzFGlFDdSV0nT.json
@@ -583,7 +583,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
@@ -463,7 +463,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___2nd_Echelon_fgQNWiICJVzfSdZ8/npc_Wobalas_FlhenZoGvBLM5GOu.json
@@ -455,7 +455,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___3rd_Echelon_5gRevvAzCanqkRiw/npc_Soulraker_Scout_9q84XKVnHQ7xs4c8.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___3rd_Echelon_5gRevvAzCanqkRiw/npc_Soulraker_Scout_9q84XKVnHQ7xs4c8.json
@@ -519,7 +519,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___3rd_Echelon_5gRevvAzCanqkRiw/npc_Soulraker_Soldier_aw2Grj27aslTlO5f.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___3rd_Echelon_5gRevvAzCanqkRiw/npc_Soulraker_Soldier_aw2Grj27aslTlO5f.json
@@ -531,7 +531,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___3rd_Echelon_5gRevvAzCanqkRiw/npc_Soulraker_Stinger_2RBxd4qewHIvQ37X.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___3rd_Echelon_5gRevvAzCanqkRiw/npc_Soulraker_Stinger_2RBxd4qewHIvQ37X.json
@@ -495,7 +495,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Optacus_robfmNuhaVjRoZDP.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Optacus_robfmNuhaVjRoZDP.json
@@ -626,7 +626,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+4 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Optacus_robfmNuhaVjRoZDP.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Optacus_robfmNuhaVjRoZDP.json
@@ -618,7 +618,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Tyburaki_fSHdcO4q12wV8qHx.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Tyburaki_fSHdcO4q12wV8qHx.json
@@ -663,7 +663,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Tyburaki_fSHdcO4q12wV8qHx.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Tyburaki_fSHdcO4q12wV8qHx.json
@@ -671,7 +671,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+4 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Unguloid_i6Qy72aRK3ACgeht.json
+++ b/src/packs/monsters/Demons_PimL3ExIxSjDqzsY/Demons___4th_Echelon_YVkbVbuTCdEc4h7w/npc_Unguloid_i6Qy72aRK3ACgeht.json
@@ -669,7 +669,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Clerk_AmtQ7P6HKiyKS8UB.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Clerk_AmtQ7P6HKiyKS8UB.json
@@ -604,7 +604,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Clerk_AmtQ7P6HKiyKS8UB.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Clerk_AmtQ7P6HKiyKS8UB.json
@@ -596,7 +596,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Notary_MUGOwQFQQB69BCRY.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Notary_MUGOwQFQQB69BCRY.json
@@ -595,7 +595,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Notary_MUGOwQFQQB69BCRY.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Notary_MUGOwQFQQB69BCRY.json
@@ -587,7 +587,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Scrivener_uZXnJpMt8p9LuSBV.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Scrivener_uZXnJpMt8p9LuSBV.json
@@ -607,7 +607,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Scrivener_uZXnJpMt8p9LuSBV.json
+++ b/src/packs/monsters/Devils_0WyeafpcyJ7Gd58P/npc_Devil_Scrivener_uZXnJpMt8p9LuSBV.json
@@ -599,7 +599,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Axethrower_3HwFmtwoNKEFELHd.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Axethrower_3HwFmtwoNKEFELHd.json
@@ -440,7 +440,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Axethrower_3HwFmtwoNKEFELHd.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Axethrower_3HwFmtwoNKEFELHd.json
@@ -448,7 +448,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to Stamina</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Catchpole_D2bOQ1WeHPKrJzWa.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Catchpole_D2bOQ1WeHPKrJzWa.json
@@ -457,7 +457,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to Stamina</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Catchpole_D2bOQ1WeHPKrJzWa.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Catchpole_D2bOQ1WeHPKrJzWa.json
@@ -449,7 +449,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Hunter_yhGxrXcM6ixD9Bfr.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Hunter_yhGxrXcM6ixD9Bfr.json
@@ -495,7 +495,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+4 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Hunter_yhGxrXcM6ixD9Bfr.json
+++ b/src/packs/monsters/Dwarves_aym4mi5JvyLiP0uV/npc_Dwarf_Hunter_yhGxrXcM6ixD9Bfr.json
@@ -487,7 +487,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_Elemental_Mote_yYTmi4JwOnyA0w1s.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_Elemental_Mote_yYTmi4JwOnyA0w1s.json
@@ -586,7 +586,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_Elemental_Mote_yYTmi4JwOnyA0w1s.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_Elemental_Mote_yYTmi4JwOnyA0w1s.json
@@ -578,7 +578,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Dawn_Mage_bwvpJYeEjwKRG0kx.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Dawn_Mage_bwvpJYeEjwKRG0kx.json
@@ -498,7 +498,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Dawn_Mage_bwvpJYeEjwKRG0kx.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Dawn_Mage_bwvpJYeEjwKRG0kx.json
@@ -490,7 +490,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Quiver_Wwp3YDZcu2BFkqSl.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Quiver_Wwp3YDZcu2BFkqSl.json
@@ -492,7 +492,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Quiver_Wwp3YDZcu2BFkqSl.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_High_Elf_Quiver_Wwp3YDZcu2BFkqSl.json
@@ -484,7 +484,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_Soot_Crow_a44HNNYHX0iwwarq.json
+++ b/src/packs/monsters/Elves__High_Dj36vXEyn9vry4NO/npc_Soot_Crow_a44HNNYHX0iwwarq.json
@@ -489,7 +489,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Cloak_4gXhUvILnxgvZlK7.json
+++ b/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Cloak_4gXhUvILnxgvZlK7.json
@@ -666,7 +666,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Dusk_Mage_Ze3SRgILLoLf65WR.json
+++ b/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Dusk_Mage_Ze3SRgILLoLf65WR.json
@@ -712,7 +712,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Nightstrike_PAx9JyyXKstQ9un6.json
+++ b/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Nightstrike_PAx9JyyXKstQ9un6.json
@@ -669,7 +669,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Sniper_vRGtn3VtuIh1Ogfu.json
+++ b/src/packs/monsters/Elves__Shadow_ymabO4bZsx2dUz9f/npc_Shadow_Elf_Sniper_vRGtn3VtuIh1Ogfu.json
@@ -557,7 +557,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Lookout_yNSkx0BCKnepbb0W.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Lookout_yNSkx0BCKnepbb0W.json
@@ -677,7 +677,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Lookout_yNSkx0BCKnepbb0W.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Lookout_yNSkx0BCKnepbb0W.json
@@ -685,7 +685,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Runner_CONQBjqWcvi4c77X.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Runner_CONQBjqWcvi4c77X.json
@@ -646,7 +646,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Scout_qFslxQyHvY6xxv0Q.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Scout_qFslxQyHvY6xxv0Q.json
@@ -683,7 +683,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Yeoman_vR0BUQxowgWhDyVT.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Yeoman_vR0BUQxowgWhDyVT.json
@@ -687,7 +687,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Yeoman_vR0BUQxowgWhDyVT.json
+++ b/src/packs/monsters/Elves__Wode_Ji95GDWQ7qRIum3n/npc_Wode_Elf_Yeoman_vR0BUQxowgWhDyVT.json
@@ -695,7 +695,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+1 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Fire_Giant_Fireballer_sClSr0FWqYhfuJTG.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Fire_Giant_Fireballer_sClSr0FWqYhfuJTG.json
@@ -902,7 +902,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Fire_Giant_Fireballer_sClSr0FWqYhfuJTG.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Fire_Giant_Fireballer_sClSr0FWqYhfuJTG.json
@@ -910,7 +910,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Frost_Giant_Snowblaster_38EbGw84maEiWy3j.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Frost_Giant_Snowblaster_38EbGw84maEiWy3j.json
@@ -913,7 +913,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Frost_Giant_Snowblaster_38EbGw84maEiWy3j.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Frost_Giant_Snowblaster_38EbGw84maEiWy3j.json
@@ -905,7 +905,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Hill_Giant_Mosstooth_1ij88bUePtVGhGWw.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Hill_Giant_Mosstooth_1ij88bUePtVGhGWw.json
@@ -900,7 +900,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Hill_Giant_Mosstooth_1ij88bUePtVGhGWw.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Hill_Giant_Mosstooth_1ij88bUePtVGhGWw.json
@@ -908,7 +908,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Sand_Stone_Giant_hd854shZ53uki7UL.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Sand_Stone_Giant_hd854shZ53uki7UL.json
@@ -1029,7 +1029,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+6 bonus to Stamina</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Sand_Stone_Giant_hd854shZ53uki7UL.json
+++ b/src/packs/monsters/Giants_BPmj6b8KnRGx4nhs/npc_Sand_Stone_Giant_hd854shZ53uki7UL.json
@@ -1021,7 +1021,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Gnoll_6ZOnXQw3kIUDhVuS/npc_Gnoll_Wildling_Kc2sZy0gSk44lX4N.json
+++ b/src/packs/monsters/Gnoll_6ZOnXQw3kIUDhVuS/npc_Gnoll_Wildling_Kc2sZy0gSk44lX4N.json
@@ -679,7 +679,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Runner_Xw0gZCS09gdMjaw8.json
+++ b/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Runner_Xw0gZCS09gdMjaw8.json
@@ -645,7 +645,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Sniper_E637uEMv0INA5LPW.json
+++ b/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Sniper_E637uEMv0INA5LPW.json
@@ -655,7 +655,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Spinecleaver_Mdk2jvvw26BaR1HL.json
+++ b/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Goblin_Spinecleaver_Mdk2jvvw26BaR1HL.json
@@ -698,7 +698,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Skitterling_CtnlwvEcJb9YdZQ3.json
+++ b/src/packs/monsters/Goblins_iEPVvWezLlidfEbg/npc_Skitterling_CtnlwvEcJb9YdZQ3.json
@@ -766,7 +766,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Grilp_ApAzL8zLa66wphOB.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Grilp_ApAzL8zLa66wphOB.json
@@ -686,7 +686,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Grilp_ApAzL8zLa66wphOB.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Grilp_ApAzL8zLa66wphOB.json
@@ -678,7 +678,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Brandbearer_FznH1t5piglvUQiw.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Brandbearer_FznH1t5piglvUQiw.json
@@ -751,7 +751,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Lancer_0AEhObtt2bZuJNKr.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Lancer_0AEhObtt2bZuJNKr.json
@@ -713,7 +713,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Lancer_0AEhObtt2bZuJNKr.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Lancer_0AEhObtt2bZuJNKr.json
@@ -705,7 +705,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Recruit_ubQBS8oIMsfRK8du.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Recruit_ubQBS8oIMsfRK8du.json
@@ -695,7 +695,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+4 bonus to Stamina</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Recruit_ubQBS8oIMsfRK8du.json
+++ b/src/packs/monsters/Hobgoblins_8Qx5yD5cyOi0GkUy/npc_Hobgoblin_Recruit_ubQBS8oIMsfRK8du.json
@@ -687,7 +687,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Apprentice_Mage_WjcqXlH2CzC9vI7f.json
+++ b/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Apprentice_Mage_WjcqXlH2CzC9vI7f.json
@@ -514,7 +514,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Archer_DIT7gzYgU7pwjP4j.json
+++ b/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Archer_DIT7gzYgU7pwjP4j.json
@@ -528,7 +528,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Death_Acolyte_SH0LmY9NtWTp7oNV.json
+++ b/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Death_Acolyte_SH0LmY9NtWTp7oNV.json
@@ -479,7 +479,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Guard_3sZIJ1aJRhMF6iK5.json
+++ b/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Guard_3sZIJ1aJRhMF6iK5.json
@@ -486,7 +486,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Raider_wTq3vb6iy92uivRO.json
+++ b/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Raider_wTq3vb6iy92uivRO.json
@@ -489,7 +489,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Rogue_dhs3FHouwzVD0Acn.json
+++ b/src/packs/monsters/Humans_zBFE173ZFzlEPX1o/npc_Human_Rogue_dhs3FHouwzVD0Acn.json
@@ -491,7 +491,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Princeps_gWjAaDWAa6dtxBNa.json
+++ b/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Princeps_gWjAaDWAa6dtxBNa.json
@@ -584,7 +584,8 @@
         },
         "filters": {
           "keywords": []
-        }
+        },
+        "isWithCaptain": true
       },
       "start": {
         "time": 0,

--- a/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Sagittarion_A2IJElaA0cJlTTsX.json
+++ b/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Sagittarion_A2IJElaA0cJlTTsX.json
@@ -586,7 +586,8 @@
           "keywords": [
             "ranged"
           ]
-        }
+        },
+        "isWithCaptain": true
       },
       "start": {
         "time": 0,

--- a/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Tiro_7l9gYevMavIPZfkw.json
+++ b/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Tiro_7l9gYevMavIPZfkw.json
@@ -653,7 +653,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Tiro_7l9gYevMavIPZfkw.json
+++ b/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Tiro_7l9gYevMavIPZfkw.json
@@ -661,7 +661,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+1 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Veles_jCFtKlDWA1VRIanb.json
+++ b/src/packs/monsters/Kobolds_SWbDTDwNDPa3JlDQ/npc_Kobold_Veles_jCFtKlDWA1VRIanb.json
@@ -585,7 +585,8 @@
         },
         "filters": {
           "keywords": []
-        }
+        },
+        "isWithCaptain": true
       },
       "start": {
         "time": 0,

--- a/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Grunt_W67PiJGnmIc6WzPY.json
+++ b/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Grunt_W67PiJGnmIc6WzPY.json
@@ -653,7 +653,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Shellguard_JOyUIYLf6M8DLCAa.json
+++ b/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Shellguard_JOyUIYLf6M8DLCAa.json
@@ -649,7 +649,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Tonguer_7Yyc8rkABIIRqGvP.json
+++ b/src/packs/monsters/Lizardfolk_SUuKqERiLGfeX4ZI/npc_Lizardfolk_Tonguer_7Yyc8rkABIIRqGvP.json
@@ -740,7 +740,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Bully_7KbaTJ3urd1TCguP.json
+++ b/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Bully_7KbaTJ3urd1TCguP.json
@@ -741,7 +741,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Lackey_DaQEYF7pWREuafBC.json
+++ b/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Lackey_DaQEYF7pWREuafBC.json
@@ -792,7 +792,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Lackey_DaQEYF7pWREuafBC.json
+++ b/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Lackey_DaQEYF7pWREuafBC.json
@@ -783,7 +783,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Stampede_YOICAI5K97ZwsJu4.json
+++ b/src/packs/monsters/Minotaurs_4k38bNEZVVE6p4vF/npc_Minotaur_Stampede_YOICAI5K97ZwsJu4.json
@@ -822,7 +822,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Cyclops_1KvJeGOPiH0umRrb.json
+++ b/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Cyclops_1KvJeGOPiH0umRrb.json
@@ -865,7 +865,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Ogre_Blue_Blood_GfCJmfAMdlEutNaB.json
+++ b/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Ogre_Blue_Blood_GfCJmfAMdlEutNaB.json
@@ -844,7 +844,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Ogre_Tantrum_HNt4p9nPWlekoh0y.json
+++ b/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Ogre_Tantrum_HNt4p9nPWlekoh0y.json
@@ -804,7 +804,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Ogre_Tantrum_HNt4p9nPWlekoh0y.json
+++ b/src/packs/monsters/Ogre_mKoQH5eH9bOQmkFl/npc_Ogre_Tantrum_HNt4p9nPWlekoh0y.json
@@ -812,7 +812,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Mohler_My8y85XQkQHc0cqp.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Mohler_My8y85XQkQHc0cqp.json
@@ -930,7 +930,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Mohler_My8y85XQkQHc0cqp.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Mohler_My8y85XQkQHc0cqp.json
@@ -938,7 +938,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Blitzer_ZX7i3OxKuj1FPTqJ.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Blitzer_ZX7i3OxKuj1FPTqJ.json
@@ -823,7 +823,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Blitzer_ZX7i3OxKuj1FPTqJ.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Blitzer_ZX7i3OxKuj1FPTqJ.json
@@ -831,7 +831,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Bloodspark_3y2tRRGSXTCi59k3.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Bloodspark_3y2tRRGSXTCi59k3.json
@@ -842,7 +842,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Glorifier_MRtQiQWUQmy4rUYk.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Glorifier_MRtQiQWUQmy4rUYk.json
@@ -869,7 +869,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Glorifier_MRtQiQWUQmy4rUYk.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Glorifier_MRtQiQWUQmy4rUYk.json
@@ -877,7 +877,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Razor_EXcMJH79Q4vMPtm4.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Razor_EXcMJH79Q4vMPtm4.json
@@ -847,7 +847,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Razor_EXcMJH79Q4vMPtm4.json
+++ b/src/packs/monsters/Orc_y0titlZe5vQIjdy5/npc_Orc_Razor_EXcMJH79Q4vMPtm4.json
@@ -855,7 +855,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+1 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Mischiever_loKZoNvfv5OAZ6Vz.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Mischiever_loKZoNvfv5OAZ6Vz.json
@@ -562,7 +562,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Redeye_KwdPnQj8bc4JlTqB.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Redeye_KwdPnQj8bc4JlTqB.json
@@ -560,7 +560,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Scrapper_XB2mjnDsGqfefASD.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Scrapper_XB2mjnDsGqfefASD.json
@@ -606,7 +606,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Swiftpaw_5Y3a5k56mKlmygyf.json
+++ b/src/packs/monsters/Radenwights_DQYQ5rpRsohluWYD/npc_Radenwight_Swiftpaw_5Y3a5k56mKlmygyf.json
@@ -634,7 +634,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Time_Raider_9g4m05r5B3CZpEms/npc_Time_Raider_Archon_77lNsdTkalkPbwlS.json
+++ b/src/packs/monsters/Time_Raider_9g4m05r5B3CZpEms/npc_Time_Raider_Archon_77lNsdTkalkPbwlS.json
@@ -687,7 +687,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Time_Raider_9g4m05r5B3CZpEms/npc_Time_Raider_Myriad_pU91Jsq2kqf4Dino.json
+++ b/src/packs/monsters/Time_Raider_9g4m05r5B3CZpEms/npc_Time_Raider_Myriad_pU91Jsq2kqf4Dino.json
@@ -743,7 +743,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Crack_Trooper_GMOB9XRNF5Qe06sX.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Crack_Trooper_GMOB9XRNF5Qe06sX.json
@@ -681,7 +681,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Crack_Trooper_GMOB9XRNF5Qe06sX.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Crack_Trooper_GMOB9XRNF5Qe06sX.json
@@ -689,7 +689,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 bonus to Stamina</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Limbjumble_i41v0jngdDC1ymQ9.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Limbjumble_i41v0jngdDC1ymQ9.json
@@ -702,7 +702,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Ravager_ztXh9l817WlvXmvT.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Ravager_ztXh9l817WlvXmvT.json
@@ -679,7 +679,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Ravager_ztXh9l817WlvXmvT.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Ravager_ztXh9l817WlvXmvT.json
@@ -687,7 +687,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Whelp_5ZK1agQVKKCif3Fe.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Whelp_5ZK1agQVKKCif3Fe.json
@@ -735,7 +735,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Whelp_5ZK1agQVKKCif3Fe.json
+++ b/src/packs/monsters/Trolls_RvELgaTQ02GEjQb5/npc_Troll_Whelp_5ZK1agQVKKCif3Fe.json
@@ -743,7 +743,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Crawling_Claw_V8CFcw8SAUNkcm7P.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Crawling_Claw_V8CFcw8SAUNkcm7P.json
@@ -611,7 +611,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Decrepit_Skeleton_HTNu9LRNpFYtB5G6.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Decrepit_Skeleton_HTNu9LRNpFYtB5G6.json
@@ -707,7 +707,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Rotting_Zombie_2KiVCGcov7SmCkWU.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Rotting_Zombie_2KiVCGcov7SmCkWU.json
@@ -746,7 +746,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Shade_6HlLZCuKCPy73OCb.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___1st_Echelon_qZ8RbdImvXjWh2yn/npc_Shade_6HlLZCuKCPy73OCb.json
@@ -746,7 +746,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Fleshflayed_Shambler_Zombie_JfyGI3TIaslRZWku.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Fleshflayed_Shambler_Zombie_JfyGI3TIaslRZWku.json
@@ -535,7 +535,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Fleshflayed_Shambler_Zombie_JfyGI3TIaslRZWku.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Fleshflayed_Shambler_Zombie_JfyGI3TIaslRZWku.json
@@ -543,7 +543,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Ghoul_Craver_VosGGEvnrw3zCjdo.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Ghoul_Craver_VosGGEvnrw3zCjdo.json
@@ -524,7 +524,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Ghoul_Craver_VosGGEvnrw3zCjdo.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Ghoul_Craver_VosGGEvnrw3zCjdo.json
@@ -532,7 +532,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Hollowbone_Launcher_S1n2gG7RgdjoEdEq.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Hollowbone_Launcher_S1n2gG7RgdjoEdEq.json
@@ -525,7 +525,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Hollowbone_Launcher_S1n2gG7RgdjoEdEq.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___2nd_Echelon_bQgGaMhvhgZFC0kO/npc_Hollowbone_Launcher_S1n2gG7RgdjoEdEq.json
@@ -533,7 +533,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Blood_Starved_Vampire_pNA8H0vk4EDNq4UI.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Blood_Starved_Vampire_pNA8H0vk4EDNq4UI.json
@@ -582,7 +582,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Blood_Starved_Vampire_pNA8H0vk4EDNq4UI.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Blood_Starved_Vampire_pNA8H0vk4EDNq4UI.json
@@ -574,7 +574,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Faded_Echo_Spirit_FitPOtXzLdBcRHA3.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Faded_Echo_Spirit_FitPOtXzLdBcRHA3.json
@@ -537,7 +537,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Mummy_Rotwrap_eWQeCWuWYEL6N4QP.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Mummy_Rotwrap_eWQeCWuWYEL6N4QP.json
@@ -491,7 +491,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Mummy_Rotwrap_eWQeCWuWYEL6N4QP.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___3rd_Echelon_JsWXCN3PDasglLHA/npc_Mummy_Rotwrap_eWQeCWuWYEL6N4QP.json
@@ -499,7 +499,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 bonus to melee distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Giant_Shambler_Zombie_qWEKKDoeYujoJMka.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Giant_Shambler_Zombie_qWEKKDoeYujoJMka.json
@@ -468,7 +468,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "disabled": true,
       "duration": {

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Giant_Shambler_Zombie_qWEKKDoeYujoJMka.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Giant_Shambler_Zombie_qWEKKDoeYujoJMka.json
@@ -477,7 +477,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+4 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Skeleton_Knight_JHBj5JkfUDtwJgrd.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Skeleton_Knight_JHBj5JkfUDtwJgrd.json
@@ -490,7 +490,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Wraith_Skulker_OJqPjH9loU7WkSwc.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Wraith_Skulker_OJqPjH9loU7WkSwc.json
@@ -488,7 +488,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Wraith_Skulker_OJqPjH9loU7WkSwc.json
+++ b/src/packs/monsters/Undead_Awroz7YqtpURNlF5/Undead___4th_Echelon_z19jhkNzTzzZC18O/npc_Wraith_Skulker_OJqPjH9loU7WkSwc.json
@@ -496,7 +496,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Voiceless_Talkers_WbGTZNkr5MUzJ8bE/npc_Mindkiller_Whelp_yQU7ximKr0uPKYBx.json
+++ b/src/packs/monsters/Voiceless_Talkers_WbGTZNkr5MUzJ8bE/npc_Mindkiller_Whelp_yQU7ximKr0uPKYBx.json
@@ -593,7 +593,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/Voiceless_Talkers_WbGTZNkr5MUzJ8bE/npc_Mindkiller_Whelp_yQU7ximKr0uPKYBx.json
+++ b/src/packs/monsters/Voiceless_Talkers_WbGTZNkr5MUzJ8bE/npc_Mindkiller_Whelp_yQU7ximKr0uPKYBx.json
@@ -585,7 +585,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/Voiceless_Talkers_WbGTZNkr5MUzJ8bE/npc_Voiceless_Talker_Graywarper_rZBwcjgKNYVpsiDI.json
+++ b/src/packs/monsters/Voiceless_Talkers_WbGTZNkr5MUzJ8bE/npc_Voiceless_Talker_Graywarper_rZBwcjgKNYVpsiDI.json
@@ -533,7 +533,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Commando_9MiuXFcZ5VQYbqKz.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Commando_9MiuXFcZ5VQYbqKz.json
@@ -672,7 +672,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Conscript_vbinl6G2ypCaRjSh.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Conscript_vbinl6G2ypCaRjSh.json
@@ -668,7 +668,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Sharpshooter_HrovSrIU6dYZaTYS.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Sharpshooter_HrovSrIU6dYZaTYS.json
@@ -665,7 +665,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Tetherite_1UwUQqkYXpUhxwK5.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___1st_Echelon_DYl6Qljp14rd7e7s/npc_War_Dog_Tetherite_1UwUQqkYXpUhxwK5.json
@@ -703,7 +703,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_Sparkslinger_BytYfnmnAFznhzTo.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_Sparkslinger_BytYfnmnAFznhzTo.json
@@ -619,7 +619,8 @@
         "filters": {
           "keywords": []
         },
-        "changes": []
+        "changes": [],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_Sweeper_IC05elSdNd95PXyP.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_Sweeper_IC05elSdNd95PXyP.json
@@ -637,7 +637,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_War_Frog_PHcODKTlDPiohGMv.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_War_Frog_PHcODKTlDPiohGMv.json
@@ -607,7 +607,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+2 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_War_Frog_PHcODKTlDPiohGMv.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___2nd_Echelon_2PahuUicpywKbOM4/npc_War_Dog_War_Frog_PHcODKTlDPiohGMv.json
@@ -599,7 +599,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Draconite_jnVwcLPjPq7HHZyH.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Draconite_jnVwcLPjPq7HHZyH.json
@@ -713,7 +713,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Draconite_jnVwcLPjPq7HHZyH.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Draconite_jnVwcLPjPq7HHZyH.json
@@ -705,7 +705,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Saboteur_tXP76aQUowam6zex.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Saboteur_tXP76aQUowam6zex.json
@@ -643,7 +643,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+5 bonus to ranged distance</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Saboteur_tXP76aQUowam6zex.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Saboteur_tXP76aQUowam6zex.json
@@ -635,7 +635,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Shriketroop_1OJg0rMUwweHkKrH.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___3rd_Echelon_hv76ZwIjIugo1fhp/npc_War_Dog_Shriketroop_1OJg0rMUwweHkKrH.json
@@ -617,7 +617,8 @@
             "strike"
           ]
         },
-        "changes": []
+        "changes": [],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Blood_Jumper_bZbJK0AOYqKH7BFT.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Blood_Jumper_bZbJK0AOYqKH7BFT.json
@@ -506,7 +506,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+3 bonus to speed</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Blood_Jumper_bZbJK0AOYqKH7BFT.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Blood_Jumper_bZbJK0AOYqKH7BFT.json
@@ -498,7 +498,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Hunter_Killer_MprbVsOdVjIkopVr.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Hunter_Killer_MprbVsOdVjIkopVr.json
@@ -469,7 +469,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Hunter_Killer_MprbVsOdVjIkopVr.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Hunter_Killer_MprbVsOdVjIkopVr.json
@@ -477,7 +477,7 @@
         "expiry": null,
         "expired": false
       },
-      "description": "",
+      "description": "<p>+4 damage bonus to strikes</p>",
       "tint": "#ffffff",
       "transfer": false,
       "statuses": [],

--- a/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Socialite_ngHux8UJoI0DeVH5.json
+++ b/src/packs/monsters/War_Dogs_RKA1vCuIIGKGpRsZ/War_Dogs___4th_Echelon_oLU8ovgRlnjQCSRA/npc_War_Dog_Socialite_ngHux8UJoI0DeVH5.json
@@ -419,7 +419,8 @@
             "priority": null,
             "type": "add"
           }
-        ]
+        ],
+        "isWithCaptain": true
       },
       "duration": {
         "value": null,

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -50,7 +50,7 @@ document-embed, .item-embed {
     min-width: unset;
 
     background-image: linear-gradient(var(--color-statblock), transparent 5rem);
-    border-radius: 8px 8px 0px 0px ;
+    border-radius: 8px 8px 0px 0px;
 
     margin-inline: 1rem;
 
@@ -58,7 +58,7 @@ document-embed, .item-embed {
       display: flex;
       justify-content: space-between;
       gap: 8px;
-      font-size: 1.25em;
+      font-size: 1.125em;
       font-family: 'Newsreader', serif;
       border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
@@ -107,7 +107,7 @@ document-embed, .item-embed {
       .basic-stats {
         gap: 8px;
         justify-content: center;
-        font-size: 1.125rem;
+        font-size: 1rem;
         text-align: center;
         margin-block: 8px 0;
 
@@ -121,7 +121,7 @@ document-embed, .item-embed {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         align-items: center;
-        font-size: 1.125em;
+        font-size: 1em;
         padding-inline: 8px;
 
         div:nth-child(even) {
@@ -140,6 +140,8 @@ document-embed, .item-embed {
           align-items: center;
           justify-content: center;
           gap: 0.5ch;
+          font-size: 1.125em;
+
 
           .label::first-letter {
             font-family: 'Draw Steel Glyphs';

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -46,11 +46,33 @@ document-embed, .item-embed {
   }
 
   div.actor.npc {
+    --color-statblock: rgb(175, 175, 175);
+
+    background-image: linear-gradient(var(--color-statblock), transparent);
+    border-radius: 8px 8px 0px 0px ;
+    border-bottom: 1px solid gray;
+
     header {
+      display: flex;
+      justify-content: space-between;
+
+      font-family: 'Newsreader', serif;
+
+
+      padding-inline-end: 1rem;
 
       img {
-        flex: 0 0 150px;
-        width: 150px;
+        flex: 0 0 5rem;
+        width: 5rem;
+      }
+
+      .level-ev {
+        justify-content: center;
+        text-align: right;
+
+        .level {
+          font-weight: bold;
+        }
       }
     }
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -45,6 +45,8 @@ document-embed, .item-embed {
     }
   }
 
+  div.actor.npc {}
+
   /* Non-Actor/Item Embeds inside a Draw Steel application */
   .draw-steel & {
     .roll-table-embed {

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -81,11 +81,19 @@ document-embed, .item-embed {
     }
 
     section.stats {
+      gap: 8px;
+
+      .label {
+        font-weight: 600;
+      }
+
       .basic-stats {
         gap: 8px;
 
         font-size: 1.125rem;
         text-align: center;
+
+        margin-block: 8px 0;
 
         > div {
           display: flex;
@@ -96,8 +104,10 @@ document-embed, .item-embed {
       .secondary-stats {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
+        align-items: center;
+        font-size: 1.125em;
 
-        margin: 8px;
+        padding-inline: 8px;
 
         div:nth-child(even) {
           text-align: end;
@@ -113,22 +123,16 @@ document-embed, .item-embed {
           display: flex;
           align-items: center;
           justify-content: center;
-          gap: 8px;
+          gap: 0.5ch;
 
 
-          .label {
-            font-weight: 600;
-
-            &::first-letter {
+          .label::first-letter {
               font-family: 'Draw Steel Glyphs';
               font-weight: normal;
               letter-spacing: 1px;
             }
-          }
 
-          .value {
-            font-weight: normal;
-          }
+
 
         }
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -69,8 +69,17 @@ document-embed, .item-embed {
         }
 
         h2 {
-        font-size: 1.125em;
-            margin: 0;
+          font-size: 1.125em;
+          margin: 0;
+
+          a {
+            color: unset !important;
+
+          }
+
+          a:hover {
+            text-decoration: underline;
+          }
         }
       }
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -45,7 +45,21 @@ document-embed, .item-embed {
     }
   }
 
-  div.actor.npc {}
+  div.actor.npc {
+    header {
+
+      img {
+        flex: 0 0 150px;
+        width: 150px;
+      }
+    }
+
+    section {
+      .characteristics legend button {
+        display: none;
+      }
+    }
+  }
 
   /* Non-Actor/Item Embeds inside a Draw Steel application */
   .draw-steel & {

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -55,9 +55,9 @@ document-embed, .item-embed {
     header {
       display: flex;
       justify-content: space-between;
+      gap: 8px;
 
       font-family: 'Newsreader', serif;
-
 
       padding-inline-end: 1rem;
 
@@ -76,7 +76,18 @@ document-embed, .item-embed {
       }
     }
 
-    section {
+    section.stats {
+      .basic-stats {
+        gap: 8px;
+
+        font-size: 1.125rem;
+        text-align: center;
+
+        > div {
+          display: flex;
+          flex-direction: column;
+        }
+      }
       .characteristics legend button {
         display: none;
       }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -47,9 +47,12 @@ document-embed, .item-embed {
 
   div.actor.npc {
     --color-statblock: rgb(175, 175, 175);
+    min-width: unset;
 
     background-image: linear-gradient(var(--color-statblock), transparent 5rem);
     border-radius: 8px 8px 0px 0px ;
+
+    margin-inline: 1rem;
 
     header {
       display: flex;
@@ -64,6 +67,10 @@ document-embed, .item-embed {
         img {
           flex: 0 0 5rem;
           width: 5rem;
+        }
+
+        .name-keywords {
+          padding: 12px;
         }
 
         h2 {
@@ -99,6 +106,7 @@ document-embed, .item-embed {
 
       .basic-stats {
         gap: 8px;
+        justify-content: center;
         font-size: 1.125rem;
         text-align: center;
         margin-block: 8px 0;
@@ -123,6 +131,7 @@ document-embed, .item-embed {
 
       .characteristics {
         display: flex;
+        flex-wrap: wrap;
         justify-content: space-around;
         border-block: 1px solid gray;
 

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -74,7 +74,6 @@ document-embed, .item-embed {
 
           a {
             color: unset !important;
-
           }
 
           a:hover {
@@ -141,15 +140,11 @@ document-embed, .item-embed {
 
 
           .label::first-letter {
-              font-family: 'Draw Steel Glyphs';
-              font-weight: normal;
-              letter-spacing: 1px;
-            }
-
-
-
+            font-family: 'Draw Steel Glyphs';
+            font-weight: normal;
+            letter-spacing: 1px;
+          }
         }
-
       }
     }
 
@@ -188,7 +183,6 @@ document-embed, .item-embed {
     &.support {
       --color-statblock: #F4D8C2;
     }
-
   }
 
   /* Non-Actor/Item Embeds inside a Draw Steel application */

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -56,6 +56,7 @@ document-embed, .item-embed {
       justify-content: space-between;
       gap: 8px;
 
+      font-size: 1.25em;
       font-family: 'Newsreader', serif;
 
       border-bottom: 1px solid gray;
@@ -68,6 +69,7 @@ document-embed, .item-embed {
         }
 
         h2 {
+        font-size: 1.125em;
             margin: 0;
         }
       }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -61,14 +61,17 @@ document-embed, .item-embed {
       border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
-      img {
-        flex: 0 0 5rem;
-        width: 5rem;
+      .image-name-keywords {
+        img {
+          flex: 0 0 5rem;
+          width: 5rem;
+        }
+
+        h2 {
+            margin: 0;
+        }
       }
 
-      h2 {
-        margin: 0;
-      }
 
       .level-ev {
         justify-content: center;

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -48,7 +48,7 @@ document-embed, .item-embed {
   div.actor.npc {
     --color-statblock: rgb(175, 175, 175);
 
-    background-image: linear-gradient(var(--color-statblock), transparent);
+    background-image: linear-gradient(var(--color-statblock), transparent 5rem);
     border-radius: 8px 8px 0px 0px ;
 
     header {
@@ -143,6 +143,43 @@ document-embed, .item-embed {
 
       }
     }
+
+    &.ambusher {
+      --color-statblock: #F9DD63;
+    }
+
+    &.artillery {
+      --color-statblock: #CAC6DC;
+    }
+
+    &.brute {
+      --color-statblock: #9CBADF;
+    }
+
+    &.controller {
+      --color-statblock: #F5918F;
+    }
+
+    &.defender {
+      --color-statblock: #CEC9AA;
+    }
+
+    &.harrier {
+      --color-statblock: #E8C0C3;
+    }
+
+    &.hexer {
+      --color-statblock: #D8E1C3;
+    }
+
+    &.mount {
+      --color-statblock: #BADDEA;
+    }
+
+    &.support {
+      --color-statblock: #F4D8C2;
+    }
+
   }
 
   /* Non-Actor/Item Embeds inside a Draw Steel application */

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -50,7 +50,6 @@ document-embed, .item-embed {
 
     background-image: linear-gradient(var(--color-statblock), transparent);
     border-radius: 8px 8px 0px 0px ;
-    border-bottom: 1px solid gray;
 
     header {
       display: flex;
@@ -59,11 +58,16 @@ document-embed, .item-embed {
 
       font-family: 'Newsreader', serif;
 
+      border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
       img {
         flex: 0 0 5rem;
         width: 5rem;
+      }
+
+      h2 {
+        margin: 0;
       }
 
       .level-ev {
@@ -88,8 +92,46 @@ document-embed, .item-embed {
           flex-direction: column;
         }
       }
-      .characteristics legend button {
-        display: none;
+
+      .secondary-stats {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+
+        margin: 8px;
+
+        div:nth-child(even) {
+          text-align: end;
+        }
+      }
+
+      .characteristics {
+        display: flex;
+        justify-content: space-around;
+        border-block: 1px solid gray;
+
+        .characteristic {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+
+
+          .label {
+            font-weight: 600;
+
+            &::first-letter {
+              font-family: 'Draw Steel Glyphs';
+              font-weight: normal;
+              letter-spacing: 1px;
+            }
+          }
+
+          .value {
+            font-weight: normal;
+          }
+
+        }
+
       }
     }
   }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -55,10 +55,8 @@ document-embed, .item-embed {
       display: flex;
       justify-content: space-between;
       gap: 8px;
-
       font-size: 1.25em;
       font-family: 'Newsreader', serif;
-
       border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
@@ -82,7 +80,6 @@ document-embed, .item-embed {
         }
       }
 
-
       .level-ev {
         justify-content: center;
         text-align: right;
@@ -102,10 +99,8 @@ document-embed, .item-embed {
 
       .basic-stats {
         gap: 8px;
-
         font-size: 1.125rem;
         text-align: center;
-
         margin-block: 8px 0;
 
         > div {
@@ -119,7 +114,6 @@ document-embed, .item-embed {
         grid-template-columns: repeat(2, 1fr);
         align-items: center;
         font-size: 1.125em;
-
         padding-inline: 8px;
 
         div:nth-child(even) {
@@ -137,7 +131,6 @@ document-embed, .item-embed {
           align-items: center;
           justify-content: center;
           gap: 0.5ch;
-
 
           .label::first-letter {
             font-family: 'Draw Steel Glyphs';

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -110,12 +110,15 @@
 
   .resources {
     align-items: flex-start;
+    padding-bottom: 0;
+
     .form-group.stacked {
       flex-direction: column-reverse;
     }
 
     .resource {
       gap: 0.5rem;
+
       input[type=number] {
         width: 60px;
         flex: 0 0 50px;
@@ -132,11 +135,30 @@
     }
 
     .resource-label {
+      font-size: 1.1em;
       font-weight: 600;
       text-align: center;
-      display: flex;
-      justify-content: space-around;
       line-height: var(--input-height);
+
+      display: flex;
+      justify-content: center;
+
+      margin-bottom: 6px;
+    }
+
+
+    .resource-content {
+      align-items: center;
+
+      > * > .form-group {
+        display: flex;
+        flex-direction: column-reverse;
+        gap: 0px;
+
+        > .form-fields {
+          justify-content: center;
+        }
+      }
     }
 
     .resource-divider {
@@ -150,12 +172,30 @@
     }
   }
 
-  .free-strike {
-    flex: 0 0 120px;
+  fieldset.free-strike {
+    flex: 0 0 fit-content;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+
     .free-strike-body {
       text-align: center;
-      height: 100%;
       padding: 10px 0;
+      margin-inline: auto;
+    }
+  }
+
+  fieldset.with-captain {
+    flex: 0 0 fit-content;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+
+    > div {
+      display: flex;
+      align-items: center;
     }
   }
 

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,0 +1,3 @@
+{{log this}}
+<header></header>
+<section></section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,3 +1,24 @@
-{{log this}}
-<header></header>
-<section></section>
+<header class="flexrow">
+  <img src="{{actor.img}}" alt="{{actor.name}}">
+  <h1>
+    {{actor.name}}
+  </h1>
+  <dl>
+    <dt class="level">{{systemFields.monster.fields.level.label}}</dt>
+    <dd class="level"> {{system.level}}</dd>
+    <dt class="ev">{{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}</dt>
+    <dd class="ev">{{system.evLabel}}</dd>
+  </dl>
+  <div class="tags flexrow">
+    {{#each monsterKeywords as |keyword|}}
+    <div class="tag">{{keyword}}</div>
+    {{/each}}
+    {{!-- Organization/Role Tags --}}
+    {{#if system.monster.organizationLabel}}
+    <div class="tag">{{system.monster.organizationLabel}}</div>
+    {{/if}}
+    {{#if system.monster.roleLabel}}
+    <div class="tag">{{system.monster.roleLabel}}</div>
+    {{/if}}
+  </div>
+</header>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -78,13 +78,7 @@
     </div>
     <div class="movement">
       <span class="label">{{systemFields.movement.label}}:</span>
-      <span class="value">
-        {{#if movement}}
-        {{movement}}
-        {{else}}
-        —
-        {{/if}}
-      </span>
+      <span class="value">{{ifThen movement movement "—"}}</span>
     </div>
     <div class="with-captain">
       <span class="label">{{localize "With Captain"}}:</span>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -3,7 +3,7 @@
     <img src="{{actor.img}}" alt="{{actor.name}}">
     <div class="flexcol name-keywords">
       <h2 class="name">
-        <a data-link data-uuid="{{actor.uuid}}">{{actor.name}}</a>
+        <a data-action="openSheet">{{actor.name}}</a>
       </h2>
       <div class="keywords">
         {{monsterKeywords}}

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -59,11 +59,26 @@
     </div>
   </div>
 
-  <div class="immunities">
-
+  <div class="secondary-stats">
+    <div class="immunities">
+      <span class="label">{{systemFields.damage.fields.immunities.label}}:</span>
+    </div>
+    <div class="weakness">{{systemFields.damage.fields.weaknesses.label}}:</div>
+    <div class="movement">{{systemFields.movement.label}}:</div>
+    <div class="with-captain">{{localize "With Captain"}}:</div>
   </div>
 
-  <div class="characteristics">
+  <div class="characteristics flexrow">
+    {{#each characteristics as |chr key|}}
+    <div class="characteristic">
+      <div class="label">
+        {{chr.field.label}}
+      </div>
+      <div class="value">
+        {{numberFormat chr.value sign=true}}
+      </div>
+    </div>
+    {{/each}}
   </div>
 
 </section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,24 +1,36 @@
-<header class="flexrow">
-  <img src="{{actor.img}}" alt="{{actor.name}}">
-  <h1>
-    {{actor.name}}
-  </h1>
-  <dl>
-    <dt class="level">{{systemFields.monster.fields.level.label}}</dt>
-    <dd class="level"> {{system.level}}</dd>
-    <dt class="ev">{{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}</dt>
-    <dd class="ev">{{system.evLabel}}</dd>
-  </dl>
-  <div class="tags flexrow">
-    {{#each monsterKeywords as |keyword|}}
-    <div class="tag">{{keyword}}</div>
-    {{/each}}
-    {{!-- Organization/Role Tags --}}
-    {{#if system.monster.organizationLabel}}
-    <div class="tag">{{system.monster.organizationLabel}}</div>
-    {{/if}}
-    {{#if system.monster.roleLabel}}
-    <div class="tag">{{system.monster.roleLabel}}</div>
-    {{/if}}
+<header>
+  <div class="flexrow">
+    <img src="{{actor.img}}" alt="{{actor.name}}">
+    <div class="flexcol">
+      <h2>
+        {{actor.name}}
+      </h2>
+      <div class="tags flexrow">
+        {{#each monsterKeywords as |keyword|}}
+        <div class="tag">{{keyword}}{{#unless @last}},{{/unless}}</div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
+  <div class="flexcol level-ev">
+    <div class="level">
+      <span>
+        {{systemFields.monster.fields.level.label}}
+        {{system.level}}
+        <span class="tags">
+          {{!-- Organization/Role Tags --}}
+          {{#if system.monster.organizationLabel}}
+          <span class="tag">{{system.monster.organizationLabel}}</span>
+          {{/if}}
+          {{#if system.monster.roleLabel}}
+          <span class="tag">{{system.monster.roleLabel}}</span>
+          {{/if}}
+        </span>
+      </span>
+    </div>
+    <div class="ev">
+      {{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}
+      {{system.evLabel}}
+    </div>
   </div>
 </header>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -34,3 +34,36 @@
     </div>
   </div>
 </header>
+
+<section class="stats flexcol">
+  <div class="basic-stats flexrow">
+    <div class="size">
+      {{system.combat.size}}
+      <strong>{{systemFields.combat.fields.size.label}}</strong>
+    </div>
+    <div class="speed">
+      {{system.movement.value}}
+      <strong>{{localize "DRAW_STEEL.Actor.base.FIELDS.movement.value.label"}}</strong>
+    </div>
+    <div class="stamina">
+      {{system.stamina.max}}
+      <strong>{{systemFields.stamina.label}}</strong>
+    </div>
+    <div class="stability">
+      {{system.combat.stability}}
+      <strong>{{systemFields.combat.fields.stability.label}}</strong>
+    </div>
+    <div class="free-strike">
+      {{system.monster.freeStrike}}
+      <strong>{{systemFields.monster.fields.freeStrike.label}}</strong>
+    </div>
+  </div>
+
+  <div class="immunities">
+
+  </div>
+
+  <div class="characteristics">
+  </div>
+
+</section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -97,5 +97,4 @@
     </div>
     {{/each}}
   </div>
-
 </section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -81,7 +81,8 @@
       <span class="value">{{ifThen movement movement "—"}}</span>
     </div>
     <div class="with-captain">
-      <span class="label">{{localize "With Captain"}}:</span>
+      <span class="label">{{localize "DRAW_STEEL.ActiveEffect.WithCaptainEffects.embedLabel"}}:</span>
+      <span class="value">{{{ifThen withCaptain withCaptain "—"}}}</span>
     </div>
   </div>
 

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -61,14 +61,43 @@
 
   <div class="secondary-stats">
     <div class="immunities">
-      <span class="label">{{systemFields.damage.fields.immunities.label}}:</span>
+      <span class="label">
+        {{systemFields.damage.fields.immunities.label}}:
+      </span>
+      <span class="value">
+        {{#if damageIW.immunities}}
+        {{{damageIW.immunities}}}
+        {{else}}
+        —
+        {{/if}}
+      </span>
     </div>
-    <div class="weakness">{{systemFields.damage.fields.weaknesses.label}}:</div>
-    <div class="movement">{{systemFields.movement.label}}:</div>
-    <div class="with-captain">{{localize "With Captain"}}:</div>
+    <div class="weakness">
+      <span class="label">{{systemFields.damage.fields.weaknesses.label}}:</span>
+      <span class="value">
+        {{#if damageIW.weaknesses}}
+        {{{damageIW.weaknesses}}}
+        {{else}}
+        —
+        {{/if}}
+      </span>
+    </div>
+    <div class="movement">
+      <span class="label">{{systemFields.movement.label}}:</span>
+      <span class="value">
+        {{#if movement}}
+        {{movement}}
+        {{else}}
+        —
+        {{/if}}
+      </span>
+    </div>
+    <div class="with-captain">
+      <span class="label">{{localize "With Captain"}}:</span>
+    </div>
   </div>
 
-  <div class="characteristics flexrow">
+  <div class="characteristics">
     {{#each characteristics as |chr key|}}
     <div class="characteristic">
       <div class="label">

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -1,32 +1,26 @@
 <header>
-  <div class="flexrow">
+  <div class="flexrow image-name-keywords">
     <img src="{{actor.img}}" alt="{{actor.name}}">
-    <div class="flexcol">
-      <h2>
+    <div class="flexcol name-keywords">
+      <h2 class="name">
         {{actor.name}}
       </h2>
-      <div class="tags flexrow">
-        {{#each monsterKeywords as |keyword|}}
-        <div class="tag">{{keyword}}{{#unless @last}},{{/unless}}</div>
-        {{/each}}
+      <div class="keywords">
+        {{monsterKeywords}}
       </div>
     </div>
   </div>
   <div class="flexcol level-ev">
     <div class="level">
-      <span>
-        {{systemFields.monster.fields.level.label}}
-        {{system.level}}
-        <span class="tags">
-          {{!-- Organization/Role Tags --}}
-          {{#if system.monster.organizationLabel}}
-          <span class="tag">{{system.monster.organizationLabel}}</span>
-          {{/if}}
-          {{#if system.monster.roleLabel}}
-          <span class="tag">{{system.monster.roleLabel}}</span>
-          {{/if}}
-        </span>
-      </span>
+      {{systemFields.monster.fields.level.label}}
+      {{system.level}}
+      {{!-- Organization/Role Tags --}}
+      {{#if system.monster.organizationLabel}}
+      {{system.monster.organizationLabel}}
+      {{/if}}
+      {{#if system.monster.roleLabel}}
+      {{system.monster.roleLabel}}
+      {{/if}}
     </div>
     <div class="ev">
       {{localize "DRAW_STEEL.Actor.base.EVLabel.Label"}}

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -3,7 +3,7 @@
     <img src="{{actor.img}}" alt="{{actor.name}}">
     <div class="flexcol name-keywords">
       <h2 class="name">
-        {{actor.name}}
+        <a data-link data-uuid="{{actor.uuid}}">{{actor.name}}</a>
       </h2>
       <div class="keywords">
         {{monsterKeywords}}

--- a/templates/sheets/active-effect/details.hbs
+++ b/templates/sheets/active-effect/details.hbs
@@ -11,7 +11,10 @@
 
   {{#if isActorEffect}}
   {{formGroup fields.origin value=source.origin rootId=rootId disabled=true}}
+
+  {{#unless hideWithCaptainField}}
   {{formGroup systemFields.isWithCaptain value=source.system.isWithCaptain rootId=rootId}}
+  {{/unless}}
   {{/if}}
 
   {{#if isItemEffect}}

--- a/templates/sheets/active-effect/details.hbs
+++ b/templates/sheets/active-effect/details.hbs
@@ -11,7 +11,9 @@
 
   {{#if isActorEffect}}
   {{formGroup fields.origin value=source.origin rootId=rootId disabled=true}}
+  {{formGroup systemFields.isWithCaptain value=source.system.isWithCaptain rootId=rootId}}
   {{/if}}
+
   {{#if isItemEffect}}
   {{formGroup fields.transfer value=source.transfer rootId=rootId label=legacyTransfer.label hint=legacyTransfer.hint}}
   {{/if}}

--- a/templates/sheets/actor/npc-sheet/stats.hbs
+++ b/templates/sheets/actor/npc-sheet/stats.hbs
@@ -76,6 +76,15 @@
         {{/if}}
       </div>
     </fieldset>
+    {{#if withCaptain.exists}}
+    <fieldset class="with-captain">
+      <legend>{{localize "DRAW_STEEL.ActiveEffect.WithCaptainEffects.embedLabel"}}</legend>
+      <div>
+        <input type="checkbox" data-action="toggleWithCaptainEffect" data-effect-id="{{withCaptain.effectId}}" id="{{concat rootId "-withCaptainToggle"}}" {{checked withCaptain.effectEnabled}}>
+        <label for="{{concat rootId "-withCaptainToggle"}}">{{withCaptain.description}}</label>
+      </div>
+    </fieldset>
+    {{/if}}
   </div>
   {{> "systems/draw-steel/templates/sheets/actor/shared/partials/stats/characteristics.hbs"  editCharacteristics=(not isPlay)}}
   {{#if isPlay}}


### PR DESCRIPTION
**Note**: Leaving as draft until #1886 is merged, as this is based off of the branch in that one.

This MR does the following:

- Adds a `system.isWithCaptain` `boolean` field to `BaseEffectModel`. 
  - If this is `true` this will be the Effect from which the Document pulls "With Captain" data.
  - Only one Effect on an NPC can be designated as the "With Captain" effect (the input disappears from the UI when another AE on the same Actor has this marked `true`.
  
     <img width="1817" height="800" alt="image" src="https://github.com/user-attachments/assets/f345c3a9-d800-4ecb-878c-e546d30822ad" />

  - NPC `@Embeds` fill their "With Captain" section from the `innerHTML` of the first element of the description of the "With Captain" Effect. 
  
     <img width="620" height="233" alt="image" src="https://github.com/user-attachments/assets/f2bc3422-52a2-4141-9925-7e19e79f44f1" />

- Updates NPCs that were missing descriptions for their "With Captain" Effects.
- Adds a "With Captain" section on the NPC sheet, where the description of the "With Captain" effect is displayed and where the Effect can be directly toggled on/off.
  
  <img width="710" height="629" alt="image" src="https://github.com/user-attachments/assets/eaf91a5d-6cae-44df-9f1e-fd9044f44e44" />
  
  - As part of this, slightly adjusted the css for the "Resources" and "Free Strike" sections on the character sheet to make things consistent.

Questions: 

- Do non-NPC actors have "With Captain" effects? Currently everything is built off of the NPC model/sheet but I can move things around as necessary if other Actors would have this effect. 