### PR TITLE
Update minion token bars to combat group health

### DIFF
--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -184,11 +184,12 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
 
   /** @inheritdoc */
   _draw(options = {}) {
+    super._draw(options);
+
     if (this.actor.system.combatGroups.size === 1) {
       this.document._prepareBars();
+      this.animate(this._getAnimationData(), { duration: 0 });
     }
-
-    super._draw(options);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -183,6 +183,17 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _draw(options = {}) {
+    if (this.actor.system.combatGroups.size === 1) {
+      this.document._prepareBars();
+    }
+
+    super._draw(options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   _drawBar(number, bar, data) {
     if (data.attribute !== "stamina") return super._drawBar(number, bar, data);
 

--- a/src/module/documents/combatant.mjs
+++ b/src/module/documents/combatant.mjs
@@ -81,6 +81,11 @@ export default class DrawSteelCombatant extends foundry.documents.Combatant {
    * Needed when the squad stamina changes or the combatant is added or removed from a squad to ensure correct stamina value and inputs are used.
    */
   refreshCombatant() {
+    if (this.actor.system.combatGroups.size === 1) {
+      this.token?._prepareBars();
+      this.token?.object?.animate(this.token?.object?._getAnimationData());
+    }
+
     this.token?.object?.renderFlags.set({ refreshBars: true });
     // refresh any rendered sheets but only if the current user has permission to have it rendered anyways
     if (this.actor?.sheet.isVisible) this.actor.sheet.render({ parts: ["stats"] });


### PR DESCRIPTION
- Properly animates minions health bars
- Updates bar attributes when drawing tokens for first time (not sure if token.system.combatGroup can be found any sooner than that?)

Solves #1872 