### PR TITLE
[#1904] Fix choices not being limited in trait advancements.

### DIFF
--- a/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
@@ -116,12 +116,13 @@ export default class TraitAdvancement extends BaseAdvancement {
       const submit = dialog.element.querySelector(".form-footer [type=submit]");
       multiCheckbox.addEventListener("change", () => {
         for (const checkbox of multiCheckbox.querySelectorAll("input")) {
-          const disabled = !multiCheckbox.value.includes(checkbox.value) && (multiCheckbox.value.length >= chooseN);
-          multiCheckbox.disableOption(checkbox.value, disabled);
+          if (!multiCheckbox.value.includes(checkbox.value) && (multiCheckbox.value.length >= chooseN)) multiCheckbox._disabledOptions.add(checkbox.value);
+          else multiCheckbox._disabledOptions.delete(checkbox.value);
         }
         submit.disabled = multiCheckbox.value.length > chooseN;
       });
       multiCheckbox.dispatchEvent(new Event("change"));
+      multiCheckbox._refresh();
     }
 
     const selection = await ds.applications.api.DSDialog.input({

--- a/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/trait-advancement.mjs
@@ -115,7 +115,10 @@ export default class TraitAdvancement extends BaseAdvancement {
       const multiCheckbox = dialog.element.querySelector("multi-checkbox[name=choices]");
       const submit = dialog.element.querySelector(".form-footer [type=submit]");
       multiCheckbox.addEventListener("change", () => {
-        for (const checkbox of multiCheckbox.querySelectorAll("input")) checkbox.disabled = !multiCheckbox.value.includes(checkbox.value) && (multiCheckbox.value.length >= chooseN);
+        for (const checkbox of multiCheckbox.querySelectorAll("input")) {
+          const disabled = !multiCheckbox.value.includes(checkbox.value) && (multiCheckbox.value.length >= chooseN);
+          multiCheckbox.disableOption(checkbox.value, disabled);
+        }
         submit.disabled = multiCheckbox.value.length > chooseN;
       });
       multiCheckbox.dispatchEvent(new Event("change"));


### PR DESCRIPTION
Closes #1904 

I will note that everytime `disableOption` is called, the disabled status of all checkboxes is refreshed which means we're looping through the checkboxes n^2 times. We could only loop through only once, but it would require manually updating the the protected property `_disabledOptions`. Not sure how important this is on something that's not happening regularly.