### PR TITLE
Fix non-AOE abilities not rolling

### DIFF
--- a/src/module/applications/apps/ability-configuration-dialog.mjs
+++ b/src/module/applications/apps/ability-configuration-dialog.mjs
@@ -251,7 +251,7 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
 
     Hooks.off("targetToken", this.#targetHook);
 
-    this.#region.delete();
+    if (this.#region) this.#region.delete();
 
     return config;
   }


### PR DESCRIPTION
When there's no `#region` in the ability config dialog, it errors out when calling delete.