### PR TITLE
Fix padding for `description` in table `@Embeds`

### DIFF
--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -198,6 +198,10 @@ document-embed, .item-embed {
       thead {
         border: none;
         border-color: transparent;
+
+        th:has(.roll-table-embed-description) {
+          padding: 1rem 1rem 0.25rem 1rem !important;
+        }
       }
 
       th,


### PR DESCRIPTION
Small MR to adjust the padding when a table `@Embed` has a `description` included:

<img width="623" height="628" alt="image" src="https://github.com/user-attachments/assets/298cc546-6568-4f59-8090-81f2798e0120" />

To test:

1. Import an existing roll table and add a description to it. Use different styling for different parts of the description.
2. Add an `@Embed` with the `description` tag (e.g., `@Embed[RollTable.jjtM55JUzmW6TaG2 description]{Complications}`) to a Journal Entry. See https://github.com/foundryvtt/foundryvtt/issues/14310
3. Check that the description in the table embed looks nice, and retains the underlying styling.

Closes #1895