### PR TITLE
[#1875] Implemented & Improved NPC/Retainer Free strikes

### DIFF
--- a/src/module/applications/sheets/npc-sheet.mjs
+++ b/src/module/applications/sheets/npc-sheet.mjs
@@ -181,7 +181,7 @@ export default class DrawSteelNPCSheet extends DrawSteelActorSheet {
   /* -------------------------------------------------- */
 
   /**
-   * Perform a free strike using the NPC's stats against all of the user's targets.
+   * Perform a free strike.
    * @this DrawSteelNPCSheet
    * @param {PointerEvent} event   The originating click event.
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].

--- a/src/module/applications/sheets/retainer-sheet.mjs
+++ b/src/module/applications/sheets/retainer-sheet.mjs
@@ -13,6 +13,7 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
       updateSource: this.#updateSource,
       spendRecovery: this.#spendRecovery,
       editRetainerMetadata: this.#editRetainerMetadata,
+      freeStrike: this.#freeStrike,
     },
     position: {
       // Immunities and Weaknesses section is visible by default
@@ -120,4 +121,15 @@ export default class DrawSteelRetainerSheet extends DrawSteelActorSheet {
     this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform a free strike.
+   * @this DrawSteelNPCSheet
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #freeStrike(event, target) {
+    this.actor.system.performFreeStrike();
+  }
 }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -1,6 +1,8 @@
 import { requiredInteger, setOptions } from "../helpers.mjs";
 import { systemID, systemPath } from "../../constants.mjs";
 import CreatureModel from "./creature.mjs";
+import DamageRoll from "../../rolls/damage.mjs";
+import DrawSteelChatMessage from "../../documents/chat-message.mjs";
 import SourceModel from "../models/source.mjs";
 
 /**
@@ -238,6 +240,7 @@ export default class NPCModel extends CreatureModel {
 
   /**
    * Perform a free strike against one or more enemies.
+   * If the user is not a director, this creates a chat message with a damage roll.
    * @param {object} [options]
    * @param {DrawSteelActor[]} [options.targets]    Actors to apply the free strike damage to.
    *                                                Defaults to all current targets.
@@ -245,6 +248,30 @@ export default class NPCModel extends CreatureModel {
    * @returns {Promise<void>}
    */
   async performFreeStrike({ targets, configure = true } = {}) {
+    const freeStrike = this.freeStrike;
+    if (!game.user.isGM) {
+
+      const title = _loc("DRAW_STEEL.Actor.npc.FreeStrike.DialogTitle");
+
+      const roll = new DamageRoll(String(freeStrike.value), {
+        type: freeStrike.type,
+        flavor: ds.CONFIG.damageTypes[freeStrike.type]?.label,
+      });
+
+      await roll.evaluate();
+
+      await DrawSteelChatMessage.create({
+        title,
+        speaker: DrawSteelChatMessage.getSpeaker({ actor: this.parent }),
+        type: "standard",
+        "system.parts": [{
+          rolls: [roll],
+          flavor: title,
+          type: "roll",
+        }],
+        flags: { core: { canPopout: true } },
+      });
+    }
     if (!targets) {
       try {
         targets = game.user.targets.map(t => t.actor).filter(a => a?.system?.takeDamage).toObject();
@@ -257,7 +284,6 @@ export default class NPCModel extends CreatureModel {
       ui.notifications.error("DRAW_STEEL.Actor.npc.FreeStrike.NoTargets", { localize: true });
       return;
     }
-    const freeStrike = this.freeStrike;
 
     if (configure !== false) {
       const damageLabel = _loc("DRAW_STEEL.Actor.npc.FreeStrike.DialogHeader", {

--- a/src/module/data/actor/retainer.mjs
+++ b/src/module/data/actor/retainer.mjs
@@ -1,6 +1,8 @@
 
 import { requiredInteger, setOptions } from "../helpers.mjs";
 import CreatureModel from "./creature.mjs";
+import DamageRoll from "../../rolls/damage.mjs";
+import DrawSteelChatMessage from "../../documents/chat-message.mjs";
 import SourceModel from "../models/source.mjs";
 
 export default class RetainerModel extends CreatureModel {
@@ -110,5 +112,77 @@ export default class RetainerModel extends CreatureModel {
     await this.parent.update({ "system.recoveries.value": this.recoveries.value - 1 });
 
     return this.parent.modifyTokenAttribute("stamina", this.recoveries.recoveryValue, true);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetch the traits of this creature's free strike.
+   * The value is stored in `this.retainer.freeStrike`.
+   * @returns {import("./_types").FreeStrike}
+   */
+  get freeStrike() {
+    /** @type {DrawSteelItem & {system: AbilityModel}} */
+    const signature = this.parent.items.find(i => (i.type === "ability") && (i.system.category === "signature"));
+    /** @type {Set<string>} */
+    const keywords = signature ? new Set(["magic", "psionic", "weapon"]).intersection(signature.system.keywords) : new Set();
+
+    /** @type {DamagePowerRollEffect} */
+    const firstDamage = signature?.system.power.effects.find(e => e.type === "damage");
+
+    const freeStrike = {
+      value: this.retainer.freeStrike,
+      keywords: keywords.add("strike"),
+      type: firstDamage?.damage.tier1.types.first() ?? "",
+      range: {
+        melee: 1,
+        ranged: 5,
+      },
+    };
+    switch (signature?.system.distance.type) {
+      case "melee":
+        freeStrike.range.melee = Math.max(1, signature.system.distance.primary ?? 0);
+        break;
+      case "ranged":
+        freeStrike.range.ranged = Math.max(5, signature.system.distance.primary ?? 0);
+        break;
+      case "meleeRanged":
+        freeStrike.range.melee = Math.max(1, signature.system.distance.primary ?? 0);
+        freeStrike.range.ranged = Math.max(5, signature.system.distance.secondary ?? 0);
+        break;
+    }
+
+    return freeStrike;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create a chat message with the damage roll from this retainer.
+   * @returns {Promise<void>}
+   */
+  async performFreeStrike() {
+    const freeStrike = this.freeStrike;
+
+    const title = _loc("DRAW_STEEL.Actor.npc.FreeStrike.DialogTitle");
+
+    const roll = new DamageRoll(String(freeStrike.value), {
+      type: freeStrike.type,
+      flavor: ds.CONFIG.damageTypes[freeStrike.type]?.label,
+    });
+
+    await roll.evaluate();
+
+    await DrawSteelChatMessage.create({
+      title,
+      speaker: DrawSteelChatMessage.getSpeaker({ actor: this.parent }),
+      type: "standard",
+      "system.parts": [{
+        rolls: [roll],
+        flavor: title,
+        type: "roll",
+      }],
+      flags: { core: { canPopout: true } },
+    });
   }
 }

--- a/src/module/data/actor/retainer.mjs
+++ b/src/module/data/actor/retainer.mjs
@@ -123,12 +123,12 @@ export default class RetainerModel extends CreatureModel {
    */
   get freeStrike() {
     /** @type {DrawSteelItem & {system: AbilityModel}} */
-    const signature = this.parent.items.find(i => (i.type === "ability") && (i.system.category === "signature"));
+    const signature = this.parent.items.documentsByType.ability.find(item => item.system.category === "signature");
     /** @type {Set<string>} */
-    const keywords = signature ? new Set(["magic", "psionic", "weapon"]).intersection(signature.system.keywords) : new Set();
+    const keywords = new Set(["magic", "psionic", "weapon"]).intersection(signature?.system.keywords ?? new Set());
 
     /** @type {DamagePowerRollEffect} */
-    const firstDamage = signature?.system.power.effects.find(e => e.type === "damage");
+    const [firstDamage] = signature?.system.power.effects.documentsByType.damage;
 
     const freeStrike = {
       value: this.retainer.freeStrike,


### PR DESCRIPTION
1. Made it so NPC free strikes, when used by a player, create a message with a damage roll (since they don't have universal edit privilegse)
2. Implemented retainer free strikes as *just* a message with a damage roll

<img width="298" height="169" alt="image" src="https://github.com/user-attachments/assets/6b13f436-d943-4757-88a0-7087df110c94" />

Closes #1875