### PR TITLE
[#1260] Improvements to effect start handling

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -283,7 +283,8 @@
           "success": "Success"
         },
         "Properties": {
-          "stacking": "Stacking"
+          "stacking": "Stacking",
+          "originDuration": "Origin-based Duration"
         },
         "AddEffect": "Add Effect",
         "CreateCustomEffect": "Create Custom Effect",

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -108,6 +108,7 @@ The `[[/apply]]` enricher allows you to link status effects, either from an item
 - [&ZeroWidthSpace;[/apply slowed end=save]]: Apply Slowed (save ends).
 - [&ZeroWidthSpace;[/apply Judged]]: Apply Judged. This only works inside an item (e.g. an ability's Effect text) and matches the exact name from the item's effects. Multi-word names must be wrapped in quotation marks.
 - [&ZeroWidthSpace;[/apply Rage stacking=true]]: Apply "Rage" and allow stacking multiple copies of the effect.
+- [&ZeroWidthSpace;[/apply Fated originDuration=true end=turn]]: Apply "Fated" and set it to end at the next turn of the source actor (rather than the end of the target's next turn).
 - [&ZeroWidthSpace;[/apply xww2tw1knkZ9x4A3]]: Apply the effect with an ID of `xww2tw1knkZ9x4A3`. You can grab an effect's ID by right clicking the passport icon in the top right of the active effect config.
 - [&ZeroWidthSpace;[/apply Item.uU7qrouU5PlbLWIM.ActiveEffect.xww2tw1knkZ9x4A3]]: Apply an effect by UUID, which can be grabbed by left clicking the passport icon in the top right of the active effect config.. Unlike the ID and name matching, this allows referencing a custom active effect without being inside the parent's html fields.
 

--- a/src/docs/Power-Roll-Effects.md
+++ b/src/docs/Power-Roll-Effects.md
@@ -12,6 +12,10 @@ Damage effects allow specifying the damage amount (as a formula that takes both 
 
 Applied effects allow abilities to apply conditions to actors. This application is not fully automated; the owners of those actors must use the "Apply Effect" button to execute this. Each tier can have any number of effects, including both canonical status conditions as well as custom effects. The "Create Custom Effect" button will create a new ActiveEffect under the "Applied Effects" section of the item sheet; if you create a custom effect but no longer wish to use it, it must be fully deleted from the ability via its Effects tab.
 
+The "Stacking" property, if present, means that rather than keeping a single ID, a unique one will be created each time the effect is applied. This ensures that new instances will always be created when attempting to apply the effect.
+
+The "Origin Duration" property, if present, will tie to the effect's duration to the actor using the ability rather than the target. This is generally only relevant for turn-ends effects. For non-triggered abilities, a duration of 0 means "End of this turn" while a duration of 1 round means "End of your next turn".
+
 ## Forced Movement
 
 Forced Movement effects allow specifying the direction and distance of an ability that pushes, pulls, or slides. There is currently no automation for this feature; owners of the appropriate tokens must apply the position changes themselves.

--- a/src/module/applications/sheets/actor-sheet.mjs
+++ b/src/module/applications/sheets/actor-sheet.mjs
@@ -631,8 +631,11 @@ export default class DrawSteelActorSheet extends DSDocumentSheet {
           const effect = this._getEmbeddedDocument(target);
 
           await effect.update({
+            start: {
+              time: game.time.worldTime,
+              round: game.combat?.round ?? null,
+            },
             disabled: false,
-            start: DrawSteelActiveEffect.getEffectStart(),
             "duration.expired": false,
           });
         },

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -378,9 +378,13 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         },
         onClick: async (event, target) => {
           const effect = this._getEmbeddedDocument(target);
+
           await effect.update({
+            start: {
+              time: game.time.worldTime,
+              round: game.combat?.round ?? null,
+            },
             disabled: false,
-            start: DrawSteelActiveEffect.getEffectStart(),
             "duration.expired": false,
           });
         },

--- a/src/module/applications/ux/enrichers/apply-effect.mjs
+++ b/src/module/applications/ux/enrichers/apply-effect.mjs
@@ -38,6 +38,7 @@ export async function enricher(match, options) {
   if (parsedConfig.status) linkConfig.status = parsedConfig.status;
   if (parsedConfig.uuid) linkConfig.uuid = parsedConfig.uuid;
   if (parsedConfig.stacking) linkConfig.stacking = parsedConfig.stacking;
+  if (parsedConfig.originDuration) linkConfig.originDuration = parsedConfig.originDuration;
   if (options.relativeTo) linkConfig.origin = options.relativeTo.uuid;
 
   /** @type {DrawSteelItem} */
@@ -142,25 +143,30 @@ async function onClickAnchor() {
   // Only keep the initiative value if using the "alternative" (D&D style countdown) initiative.
   const keepInitiative = !game.combats.isDefaultInitiativeMode;
 
+  // Some abilities have durations tied to the origin rather than the target.
+  const origin = fromUuidSync(this.dataset.origin);
+  const originActor = origin?.documentName === "Actor" ? origin : origin?.actor;
+  let combatant = this.dataset.originDuration ? game.combat?.getCombatantsByActor(originActor)[0] ?? "" : null;
+
   for (const token of tokens) {
     const actor = token.actor;
     if (!actor) continue;
     else if (actors.has(actor)) continue;
     else actors.add(actor);
 
-    const combatant = game.combat?.getCombatantsByActor(actor)[0];
+    combatant ??= game.combat?.getCombatantsByActor(actor)[0];
 
     /** @type {ActiveEffectData} */
     const updates = {
+      start: DrawSteelActiveEffect.getEffectStart(),
       transfer: true,
       origin: this.dataset.origin,
     };
     if (this.dataset.end) updates.duration = { expiry: ds.CONFIG.effectEnds[this.dataset.end].expiryEvent };
-    if (combatant) updates.start = {
-      combatant,
-      initiative: keepInitiative ? combatant.initiative : null,
-      time: game.time.worldTime,
-    };
+    if (combatant) {
+      updates.start.combatant = combatant;
+      if (keepInitiative) updates.start.initiative = combatant.initiative;
+    }
     // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
     const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
 

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1787,6 +1787,9 @@ export const PowerRollEffect = {
       stacking: {
         label: "DRAW_STEEL.POWER_ROLL_EFFECT.APPLIED.Properties.stacking",
       },
+      originDuration: {
+        label: "DRAW_STEEL.POWER_ROLL_EFFECT.APPLIED.Properties.originDuration",
+      },
     },
   },
   forced: {

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -209,20 +209,23 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
     // Only keep the initiative value if using the "alternative" (D&D style countdown) initiative.
     const keepInitiative = !game.combats.isDefaultInitiativeMode;
 
+    // Some abilities have durations tied to the user of the ability, rather than the target.
+    let combatant = config.properties.has("originDuration") ? game.combat?.getCombatantsByActor(this.document.parent)[0] ?? "" : null;
+
     for (const actor of targetActors) {
-      const combatant = game.combat?.getCombatantsByActor(actor)[0];
+      combatant ??= game.combat?.getCombatantsByActor(actor)[0];
 
       /** @type {ActiveEffectData} */
       const updates = {
+        start: DrawSteelActiveEffect.getEffectStart(),
         transfer: true,
         origin: this.item.uuid,
       };
       if (config.end) updates.duration = { expiry: ds.CONFIG.effectEnds[config.end].expiryEvent };
-      if (combatant) updates.start = {
-        combatant,
-        initiative: keepInitiative ? combatant.initiative : null,
-        time: game.time.worldTime,
-      };
+      if (combatant) {
+        updates.start.combatant = combatant;
+        if (keepInitiative) updates.start.initiative = combatant.initiative;
+      }
       // can't updateSource => toObject due to `origin` field triggering a warning when it checks for relative uuid
       const createData = foundry.utils.mergeObject(tempEffect.toObject(), updates);
 

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -67,6 +67,24 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  static getEffectStart(combat = game.combat) {
+    if (!game.combats.isDefaultInitiativeMode) return super.getEffectStart(combat);
+    // In normal Draw Steel initiative, almost all abilities have a duration tied to the *target* rather than the *source* of an effect.
+    // It is therefore the responsibility of whatever is setting the duration to provide the correct combatant & turn.
+    if (!combat?.started) combat = null;
+    return {
+      time: game.time.worldTime,
+      combat: combat?.id ?? null,
+      combatant: null,
+      initiative: null,
+      round: combat?.round ?? null,
+      turn: null,
+    };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   async _preCreate(data, options, user) {
     const allowed = await super._preCreate(data, options, user);
     if (allowed === false) return false;

--- a/src/module/documents/actor.mjs
+++ b/src/module/documents/actor.mjs
@@ -210,7 +210,9 @@ export default class DrawSteelActor extends BaseDocumentMixin(foundry.documents.
     if (overlay) effect.updateSource({ "flags.core.overlay": true });
     if (effectEnd) {
       const expiry = ds.CONFIG.effectEnds[effectEnd].expiryEvent;
-      effect.updateSource({ duration: { expiry } });
+      const start = DrawSteelActiveEffect.getEffectStart();
+      start.combatant = game.combat?.getCombatantsByActor(this)[0];
+      effect.updateSource({ start, duration: { expiry } });
     }
     return DrawSteelActiveEffect.create(effect, { parent: this, keepId: true });
   }


### PR DESCRIPTION
- Some bug fixes/feature improvements to make sure the `combatant` is generally the actor on whom the effect is being created
- Adds a new PRE property for "Effect Origin" to handle when the appropriate combatant *should* be the source of the effect.

Closes #1260