### PR TITLE
[#1915] Prevent unguided AEs outside of `flags`

### DIFF
--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -95,6 +95,14 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  static _applyChangeUnguided(targetDoc, change, changes, options = {}) {
+    if (!change.key || !(change.key.startsWith?.("flags."))) return;
+    super._applyChangeUnguided(targetDoc, change, changes, options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   _onCreate(data, options, userId) {
     super._onCreate(data, options, userId);
     if ((game.userId === userId) && this.modifiesActor && this.statuses.has("prone")) {

--- a/system.json
+++ b/system.json
@@ -165,7 +165,7 @@
   ],
   "version": "1.1.0",
   "compatibility": {
-    "minimum": "14.361",
+    "minimum": "14.363",
     "verified": "14",
     "maximum": "14"
   },


### PR DESCRIPTION
No AEs yet that target items, and no pseudo collections on actors, so this should be just fine as is.

Updated minimum version to 14.363 as it contains improvements specifically regarding TOF.

Closes #1915.