### PR TITLE
Update incorrect before effects to after

### DIFF
--- a/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/5_Wrath_GOehKV6ApzuE7vxg/ability_Censored_W3ZzrWltpxY8CUq4.json
+++ b/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/5_Wrath_GOehKV6ApzuE7vxg/ability_Censored_W3ZzrWltpxY8CUq4.json
@@ -98,11 +98,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>When a target who is not a leader or solo creature is made winded by this ability, they are reduced to 0 Stamina.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -119,7 +119,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754757163297,

--- a/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/5_Wrath_GOehKV6ApzuE7vxg/ability_Purifying_Fire_4m5rgK9RH2QXg9S5.json
+++ b/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/5_Wrath_GOehKV6ApzuE7vxg/ability_Purifying_Fire_4m5rgK9RH2QXg9S5.json
@@ -151,11 +151,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>While the target has fire weakness from this ability, you can choose to have your abilities deal fire damage to the target instead of holy damage.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -350,7 +350,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754757295039,

--- a/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/Signature_jw6QFUSzLJXxDvsh/ability_Your_Allies_Cannot_Save_You__zMsvZ08yT9oEdp8h.json
+++ b/src/packs/abilities/Censor_JY7vFbefcnBYK2ly/Level_1_FHC1Vh9uhcEZnevR/Signature_jw6QFUSzLJXxDvsh/ability_Your_Allies_Cannot_Save_You__zMsvZ08yT9oEdp8h.json
@@ -98,11 +98,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>Each enemy adjacent to the target is pushed away from the target up to a number of squares equal to [[lookup @P]]{your Presence score}.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -119,7 +119,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754754835029,

--- a/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_1_Xal7kAbgEk4Qp8Kr/3_Piety_9uaH6cBSk3yky8QF/ability_Call_the_Thunder_Down_7IVmZMxN83iSbwJW.json
+++ b/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_1_Xal7kAbgEk4Qp8Kr/3_Piety_9uaH6cBSk3yky8QF/ability_Call_the_Thunder_Down_7IVmZMxN83iSbwJW.json
@@ -143,11 +143,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>You can push each willing ally in the area the same distance, ignoring stability.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -164,7 +164,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755646905053,

--- a/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_1_Xal7kAbgEk4Qp8Kr/3_Piety_9uaH6cBSk3yky8QF/ability_Violence_Will_Not_Aid_Thee_rI89b1iySJEyNHzO.json
+++ b/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_1_Xal7kAbgEk4Qp8Kr/3_Piety_9uaH6cBSk3yky8QF/ability_Violence_Will_Not_Aid_Thee_rI89b1iySJEyNHzO.json
@@ -98,11 +98,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>The first time on a turn that the target deals damage to another creature, the target of this ability takes [[/damage 1d10 lightning]] damage (save ends). [[/apply pl9ASgEnSqydKRPy]]</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -171,7 +171,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755646936818,

--- a/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_1_Xal7kAbgEk4Qp8Kr/Signature_tv6gR5r1UgtqsrGO/ability_Warrior_s_Prayer_uKmLk8ckvS3CGbEA.json
+++ b/src/packs/abilities/Conduit_5y6vuu4yT5kdzSLd/Level_1_Xal7kAbgEk4Qp8Kr/Signature_tv6gR5r1UgtqsrGO/ability_Warrior_s_Prayer_uKmLk8ckvS3CGbEA.json
@@ -98,11 +98,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>You or one ally within distance gains [[/heal @I temp]]{temporary Stamina} equal to your Intuition score. </p>",
-        "before": true,
+        "description": "<p>You or one ally within distance gains [[/heal @I temp]]{temporary Stamina} equal to your Intuition score.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -119,7 +119,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755646867295,

--- a/src/packs/abilities/Elementalist_s3OrDyyTAU3eflfS/Level_1_uQEzc7m0keaag6n9/5_Essence_LW3zVzW7kccwX5hb/ability_Instantaneous_Excavation_E0cV0XbapcjnWsPk.json
+++ b/src/packs/abilities/Elementalist_s3OrDyyTAU3eflfS/Level_1_uQEzc7m0keaag6n9/5_Essence_LW3zVzW7kccwX5hb/ability_Instantaneous_Excavation_E0cV0XbapcjnWsPk.json
@@ -95,14 +95,15 @@
         "img": null,
         "sort": 0
       },
-      "after00000000000": {
-        "_id": "after00000000000",
-        "type": "base",
-        "description": "<p><strong>Persistent 1</strong>: At the start of your turn, you open another hole, making a power roll against each creature who could fall into the hole when it opens without spending essence.</p>",
+      "SLt587FMtRUYvmZp": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0,
-        "before": false
+        "type": "persistent",
+        "_id": "SLt587FMtRUYvmZp",
+        "description": "<p>At the start of your turn, you open another hole, making a power roll against each creature who could fall into the hole when it opens without spending essence.</p>",
+        "before": false,
+        "essence": 1
       }
     }
   },
@@ -116,7 +117,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755743761655,

--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_Debilitating_Strike_t7b3Qy660mq5UraJ.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_Debilitating_Strike_t7b3Qy660mq5UraJ.json
@@ -143,11 +143,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>While slowed this way, the target takes 1 damage for every square they move, including from forced movement.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -218,7 +218,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760984543220,

--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_My_Turn__CeaCVhzY0k4mM6yW.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_My_Turn__CeaCVhzY0k4mM6yW.json
@@ -92,11 +92,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>You can spend a Recovery.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -113,7 +113,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760984915643,

--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_Rebounding_Storm_upZmq3xi8bvdborN.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_Rebounding_Storm_upZmq3xi8bvdborN.json
@@ -137,11 +137,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>When a target would end this forced movement by colliding with a creature or object, they take damage as usual, then are pushed the remaining distance away from the creature or object in the direction they came from. As long as forced movement remains, this effect continues if the target collides with another creature or object.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -158,7 +158,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760985358159,

--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_To_Stone__e4Qdxa9X7MxEbQZe.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_5_3rjowthk2sLr0aKm/9_Ferocity_XAgGWoa5fpF1jscs/ability_To_Stone__e4Qdxa9X7MxEbQZe.json
@@ -144,11 +144,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>While the target is slowed this way, any other effect that would make the target slowed instead makes them [[/apply Restrained]] by this ability. Additionally, a creature who fails the saving throw while restrained this way is [[/apply Petrified]] until they are given a supernatural cure or you choose to reverse the effect (no action required).</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -323,7 +323,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760985759500,

--- a/src/packs/abilities/Null_3CEvbkuuVzQlvD3a/Level_5_KHF0AZMuE6njeyr4/9_Discipline_0lo6u4VwDbg1GnmL/ability_Anticipating_Strike_544MjDEhUy8pwDnd.json
+++ b/src/packs/abilities/Null_3CEvbkuuVzQlvD3a/Level_5_KHF0AZMuE6njeyr4/9_Discipline_0lo6u4VwDbg1GnmL/ability_Anticipating_Strike_544MjDEhUy8pwDnd.json
@@ -144,11 +144,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>This strike resolves before the triggering movement or main action.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -165,7 +165,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760972835635,

--- a/src/packs/abilities/Null_3CEvbkuuVzQlvD3a/Level_5_KHF0AZMuE6njeyr4/9_Discipline_0lo6u4VwDbg1GnmL/ability_Iron_Grip_jeABSb6jLwPYdWqZ.json
+++ b/src/packs/abilities/Null_3CEvbkuuVzQlvD3a/Level_5_KHF0AZMuE6njeyr4/9_Discipline_0lo6u4VwDbg1GnmL/ability_Iron_Grip_jeABSb6jLwPYdWqZ.json
@@ -144,11 +144,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>While grabbed this way, the target takes a bane on the Escape Grab maneuver. Each time they use that maneuver, they take [[/damage 2*@A]]{damage} equal to twice your Agility score.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -219,7 +219,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760973272895,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Disorienting_Strike_fxdiH1SHqvKGcMYY.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Disorienting_Strike_fxdiH1SHqvKGcMYY.json
@@ -137,11 +137,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>You can shift into any square the target leaves when you slide them.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -158,7 +158,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754653203931,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Get_In_Get_Out_VwqbeNSv0ItsaaPD.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/3_Insight_vFbMXPTlF69DU7Bw/ability_Get_In_Get_Out_VwqbeNSv0ItsaaPD.json
@@ -92,11 +92,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>You can shift up to your speed, dividing that movement before or after your strike as desired.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -113,7 +113,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754653752887,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Gasping_in_Pain_avpi9kfzRK0B9YIk.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Gasping_in_Pain_avpi9kfzRK0B9YIk.json
@@ -128,11 +128,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>One ally within 5 squares of the target [[/surge 1]].</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -145,7 +145,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754652138162,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_I_Work_Better_Alone_ehA3Xd2YnARQszb2.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_I_Work_Better_Alone_ehA3Xd2YnARQszb2.json
@@ -92,11 +92,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>If the target has none of your allies adjacent to them, you [[/surge 1]] before making the power roll.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -112,7 +112,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754652139983,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Teamwork_Has_Its_Place_7iEVcJVYLoDe49Cs.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_Teamwork_Has_Its_Place_7iEVcJVYLoDe49Cs.json
@@ -91,11 +91,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>If any ally is adjacent to the target, you [[/surge 1]] before making the power roll.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -108,7 +108,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754652141402,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_You_Were_Watching_the_Wrong_One_JsIqJ0UsUSNJemm3.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_1_qFX1RI3AfCfQGG0r/Signature_vaDG7PoWBTXrSv3N/ability_You_Were_Watching_the_Wrong_One_JsIqJ0UsUSNJemm3.json
@@ -91,11 +91,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>As long as you have one or more allies within 5 squares of the target, [[/surge 1]]. If you are flanking the target when you use this ability, choose one ally who is flanking with you. That ally also [[/surge 1]].</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -111,7 +111,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1754652142658,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_5_BjOsqxBKpoGwrI8g/9_Insight_0xfBO0LMaZzI9DGX/ability_Shadowfall_wxzpnE9EDlFTxSGR.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_5_BjOsqxBKpoGwrI8g/9_Insight_0xfBO0LMaZzI9DGX/ability_Shadowfall_wxzpnE9EDlFTxSGR.json
@@ -92,11 +92,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>You disappear before making the power roll. After the power roll is resolved, you appear in the first unoccupied space at the far end of the line</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -113,7 +113,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760803550005,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_6_z97UrntTybKs668h/Black_Ashe_iHb7hZ3ns9oRJHEd/ability_Black_Ash_Eruption_kwESq3lD9bRcJuIv.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_6_z97UrntTybKs668h/Black_Ashe_iHb7hZ3ns9oRJHEd/ability_Black_Ash_Eruption_kwESq3lD9bRcJuIv.json
@@ -144,11 +144,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>A creature force moved by this ability must be moved straight upward.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -165,7 +165,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760835520556,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_9_AStJdCCglkEyF4Eu/Black_Ash_IieL73wShKOQGlAX/ability_Demon_Door_icka1SrvVDJfIwxJ.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_9_AStJdCCglkEyF4Eu/Black_Ash_IieL73wShKOQGlAX/ability_Demon_Door_icka1SrvVDJfIwxJ.json
@@ -144,11 +144,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>On a critical hit, the target is grabbed by the demon and pulled through the portal before it closes, never to be seen again.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -165,7 +165,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760927052929,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_9_AStJdCCglkEyF4Eu/Caustic_Alchemy_zMxluewCWxNAHGdI/ability_To_the_Stars_fIUYAa3ePYIrv17B.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_9_AStJdCCglkEyF4Eu/Caustic_Alchemy_zMxluewCWxNAHGdI/ability_To_the_Stars_fIUYAa3ePYIrv17B.json
@@ -149,11 +149,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>The ground beneath a 3-cube area around the target’s starting position is difficult terrain.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -170,7 +170,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760928425257,

--- a/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_9_AStJdCCglkEyF4Eu/Harlequin_Mask_dp8bxcxbx1eqK6wi/ability_It_Was_Me_All_Along_gliovmZRSu11VPWc.json
+++ b/src/packs/abilities/Shadow_ymzPghcR2SYV1TKr/Level_9_AStJdCCglkEyF4Eu/Harlequin_Mask_dp8bxcxbx1eqK6wi/ability_It_Was_Me_All_Along_gliovmZRSu11VPWc.json
@@ -92,11 +92,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>If you are disguised as a creature the target knew using your I’m No Threat ability, this ability deals extra [[/damage 3*@A]]{damage} equal to three times your Agility score.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -113,7 +113,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760929106706,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/3_Clarity_DDQszc7f2JZLgbRD/ability_Choke_5B3qFN4oAdjGzMFs.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/3_Clarity_DDQszc7f2JZLgbRD/ability_Choke_5B3qFN4oAdjGzMFs.json
@@ -144,11 +144,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>You can vertical pull the target up to 2 squares. If the target is made restrained by this ability, this forced movement ignores their stability.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -165,7 +165,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755872238967,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Entropic_Bolt_haewa4VaniBE64vR.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Entropic_Bolt_haewa4VaniBE64vR.json
@@ -150,14 +150,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>The target takes an extra [[/damage 1 corruption]] damage for each additional time they are targeted by this ability during the encounter.</p><p><strong>Strained:</strong> You [[/gain 1 heroic]]{gain 1 clarity} when you obtain a tier 2 or tier 3 outcome on the power roll.</p>",
-        "before": true,
+        "description": "<p>The target takes an extra [[/damage 1 corruption]] damage for each additional time they are targeted by this ability during the encounter.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "iZTiwRozAYr60dQ7": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "iZTiwRozAYr60dQ7",
+        "description": "<p>You [[/gain 1 heroic]]{gain 1 clarity} when you obtain a tier 2 or tier 3 outcome on the power roll.</p>",
+        "before": false
       }
     }
   },
@@ -171,7 +180,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842473508,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Hoarfrost_KEckumFe4KcYqnHI.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Hoarfrost_KEckumFe4KcYqnHI.json
@@ -150,14 +150,14 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> You are [[/apply slowed turn]] until the end of your next turn. Additionally, a target slowed by this ability is [[/apply restrained]] instead.</p>",
-        "before": true,
+      "PpJjGa08lpbCHfTU": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0
+        "type": "strained",
+        "_id": "PpJjGa08lpbCHfTU",
+        "description": "<p>You are [[/apply slowed turn]] until the end of your next turn. Additionally, a target slowed by this ability is [[/apply restrained]] instead.</p>",
+        "before": false
       }
     }
   },
@@ -171,7 +171,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842485202,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Incinerate_sLLVoTJajJMzcr75.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Incinerate_sLLVoTJajJMzcr75.json
@@ -100,14 +100,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>A column of fire remains in the area until the start of your next turn. Each enemy who enters the area for the first time in a combat round or starts their turn there takes [[/damage 2 fire]] damage.</p><p><strong>Strained:</strong> The size of the cube increases by 2, but the fire disappears at the end of your turn.</p>",
-        "before": true,
+        "description": "<p>A column of fire remains in the area until the start of your next turn. Each enemy who enters the area for the first time in a combat round or starts their turn there takes [[/damage 2 fire]] damage.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "pybjlOTGUPZI80eY": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "pybjlOTGUPZI80eY",
+        "description": "<p>The size of the cube increases by 2, but the fire disappears at the end of your turn.</p>",
+        "before": false
       }
     }
   },
@@ -121,7 +130,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842501449,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Kinetic_Grip_bqge7XzOD5nhoUWU.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Kinetic_Grip_bqge7XzOD5nhoUWU.json
@@ -140,14 +140,14 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> You must vertical push the target instead of sliding them.</p>",
-        "before": true,
+      "fVtrpLiQ3OLI12yH": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0
+        "type": "strained",
+        "_id": "fVtrpLiQ3OLI12yH",
+        "description": "<p>You must vertical push the target instead of sliding them.</p>",
+        "before": false
       }
     }
   },
@@ -161,7 +161,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842510410,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Kinetic_Pulse_dARXmI0O9neKftOj.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Kinetic_Pulse_dARXmI0O9neKftOj.json
@@ -141,14 +141,14 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> The size of the burst increases by 2, and you are [[/apply bleeding]] until the start of your next turn.</p>",
-        "before": true,
+      "GWyJoWfV4iWKgYlJ": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0
+        "type": "strained",
+        "_id": "GWyJoWfV4iWKgYlJ",
+        "description": "<p>The size of the burst increases by 2, and you are [[/apply bleeding]] until the start of your next turn.</p>",
+        "before": false
       }
     }
   },
@@ -162,7 +162,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842519401,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Materialize_TN62N2UfrSWzNall.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Materialize_TN62N2UfrSWzNall.json
@@ -93,14 +93,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>A worthless size 1M object drops onto the target to deal the damage, then rolls into an adjacent unoccupied space of your choice. The object is made of wood, stone, or metal (your choice).</p><p><strong>Strained:</strong> The object explodes after the damage is dealt, and each creature adjacent to the target takes [[/damage @R]]{damage} equal to your Reason score. You also take [[/damage @R]]{damage} equal to your Reason score that can’t be reduced in any way.</p>",
-        "before": true,
+        "description": "<p>A worthless size 1M object drops onto the target to deal the damage, then rolls into an adjacent unoccupied space of your choice. The object is made of wood, stone, or metal (your choice).</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "BhvfqoKfH8JyB7iC": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "BhvfqoKfH8JyB7iC",
+        "description": "<p>The object explodes after the damage is dealt, and each creature adjacent to the target takes [[/damage @R]]{damage} equal to your Reason score. You also take [[/damage @R]]{damage} equal to your Reason score that can’t be reduced in any way.</p>",
+        "before": false
       }
     }
   },
@@ -114,7 +123,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842526098,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Optic_Blast_9eXjhpEgsqkgc3Dq.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Optic_Blast_9eXjhpEgsqkgc3Dq.json
@@ -144,14 +144,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>When targeting an object with a solid reflective surface or a creature carrying or wearing such an object (such as a mirror, an unpainted metal shield, or shiny metal plate armor), you can target one additional creature or object within 3 squares of the first target.</p><p><strong>Strained:</strong> You [[/surge 1]] that you can use immediately, and you take [[/damage @R]]{damage} equal to your Reason score that can’t be reduced in any way.</p>",
-        "before": true,
+        "description": "<p>When targeting an object with a solid reflective surface or a creature carrying or wearing such an object (such as a mirror, an unpainted metal shield, or shiny metal plate armor), you can target one additional creature or object within 3 squares of the first target.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "ziGd8JmCum9kOqom": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "ziGd8JmCum9kOqom",
+        "description": "<p>You [[/surge 1]] that you can use immediately, and you take [[/damage @R]]{damage} equal to your Reason score that can’t be reduced in any way.</p>",
+        "before": false
       }
     }
   },
@@ -165,7 +174,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842536445,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Spirit_Sword_OK7FFzXmDaKn8nim.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_1_OwLGXyW6518i4S2O/Signature_Hua1VikI1490yY1R/ability_Spirit_Sword_OK7FFzXmDaKn8nim.json
@@ -93,14 +93,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>You [[/surge 1]].</p><p><strong>Strained:</strong> The target takes an extra [[/damage 3]] damage. You also take [[/damage 3]] damage that can’t be reduced in any way.</p>",
-        "before": true,
+        "description": "<p>You [[/surge 1]].</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "xr2VRgrhskstxRrc": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "xr2VRgrhskstxRrc",
+        "description": "<p>The target takes an extra [[/damage 3]] damage. You also take [[/damage 3]] damage that can’t be reduced in any way.</p>",
+        "before": false
       }
     }
   },
@@ -114,7 +123,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755842549254,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_3_GjOLZaTVh66SMIxK/ability_Force_Orbs_BisGVY188IKvnGFO.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_3_GjOLZaTVh66SMIxK/ability_Force_Orbs_BisGVY188IKvnGFO.json
@@ -174,13 +174,13 @@
         "img": null,
         "sort": 0
       },
-      "after00000000000": {
-        "_id": "after00000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> You create five orbs, and you are [[/apply weakened]] while you have any orbs active. </p>",
+      "O91aidu43iZyOiGt": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0,
+        "type": "strained",
+        "_id": "O91aidu43iZyOiGt",
+        "description": "<p>You create five orbs, and you are [[/apply weakened]] while you have any orbs active. </p>",
         "before": false
       }
     }
@@ -255,7 +255,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1756689409590,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_5_RI7V3oVlEpa7tjV3/ability_Hypersonic_iaCQ1GvXc721iT5U.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_5_RI7V3oVlEpa7tjV3/ability_Hypersonic_iaCQ1GvXc721iT5U.json
@@ -108,13 +108,13 @@
         "img": null,
         "sort": 0
       },
-      "after00000000000": {
-        "_id": "after00000000000",
-        "type": "base",
-        "description": "<p><strong>Strained</strong>: If you obtain a tier 2 outcome or better, you are [[/apply slowed turn]] until the end of your turn and each target is [[/apply slowed turn]] until the end of their turn.</p>",
+      "Ou3PpYqotaonGpPi": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0,
+        "type": "strained",
+        "_id": "Ou3PpYqotaonGpPi",
+        "description": "<p>If you obtain a tier 2 outcome or better, you are [[/apply slowed turn]] until the end of your turn and each target is [[/apply slowed turn]] until the end of their turn.</p>",
         "before": false
       }
     }
@@ -129,7 +129,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1760749175568,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Chronopathy_6J0q2pGNORhFbjHh/ability_Fate_eDMKIlAudmHd190J.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Chronopathy_6J0q2pGNORhFbjHh/ability_Fate_eDMKIlAudmHd190J.json
@@ -101,11 +101,20 @@
       "before0000000000": {
         "_id": "before0000000000",
         "type": "base",
-        "description": "<p>The target has [[/apply \"Damage Weakness 5\"]] until the end of your next turn. Whenever the target takes damage while they have this weakness, they are knocked [[/apply prone]].</p><p><strong>Strained</strong>: This ability gains the Strike keyword as the vision hurts the target’s psyche. You make a power roll, then are [[/apply weakened save]].</p>",
+        "description": "<p>The target has [[/apply \"Damage Weakness 5\"]] until the end of your next turn. Whenever the target takes damage while they have this weakness, they are knocked [[/apply prone]].</p>",
         "before": true,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "0Z8COXN94mhU8UDH": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "0Z8COXN94mhU8UDH",
+        "description": "<p>This ability gains the Strike keyword as the vision hurts the target’s psyche. You make a power roll, then are [[/apply weakened save]].</p>",
+        "before": true
       }
     }
   },
@@ -179,7 +188,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761072009911,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Chronopathy_6J0q2pGNORhFbjHh/ability_Stasis_Field_XCYnpWccsVaZaDMM.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Chronopathy_6J0q2pGNORhFbjHh/ability_Stasis_Field_XCYnpWccsVaZaDMM.json
@@ -111,11 +111,20 @@
       "before0000000000": {
         "_id": "before0000000000",
         "type": "base",
-        "description": "<p>The area is frozen in time until the start of your next turn. Each object in the area is restrained and can’t fall until the effect ends. Until the effect ends, creatures in the area who are reduced to 0 Stamina or would die stay alive, and objects in the area that are reduced to 0 Stamina remain undestroyed. Make a power roll that targets each enemy in the area.</p><p><strong>Strained:</strong> Any creature or object force moved in the area takes [[/damage 2*@scaling corruption scaling]]{2 corruption damage} for each square of the area they enter. Creatures and objects restrained in the area can be force moved. You are [[/apply restrained]] until the effect ends.</p>",
+        "description": "<p>The area is frozen in time until the start of your next turn. Each object in the area is restrained and can’t fall until the effect ends. Until the effect ends, creatures in the area who are reduced to 0 Stamina or would die stay alive, and objects in the area that are reduced to 0 Stamina remain undestroyed.</p><p>Make a power roll that targets each enemy in the area.</p>",
         "before": true,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "HLDh23wb6R58qggi": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "HLDh23wb6R58qggi",
+        "description": "<p>Any creature or object force moved in the area takes [[/damage 2*@scaling corruption scaling]]{2 corruption damage} for each square of the area they enter. Creatures and objects restrained in the area can be force moved. You are [[/apply restrained]] until the effect ends.</p>",
+        "before": false
       }
     }
   },
@@ -189,7 +198,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761073953525,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telekinesis_ukHd9vs5ZMvY8yfO/ability_Gravitic_Well_M0QI30cNWCZuvsVY.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telekinesis_ukHd9vs5ZMvY8yfO/ability_Gravitic_Well_M0QI30cNWCZuvsVY.json
@@ -144,14 +144,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>Targets closest to the center of the area are pulled first.</p><p><strong>Strained:</strong> The size of the area increases by 2. You also target yourself and each ally within distance.</p>",
-        "before": true,
+        "description": "<p>Targets closest to the center of the area are pulled first.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "Fxw06UaUWI8GIAzk": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "Fxw06UaUWI8GIAzk",
+        "description": "<p>The size of the area increases by 2. You also target yourself and each ally within distance.</p>",
+        "before": false
       }
     }
   },
@@ -165,7 +174,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761075837709,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telekinesis_ukHd9vs5ZMvY8yfO/ability_Greater_Kinetic_Grip_Yd9jRc4setB3igPQ.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telekinesis_ukHd9vs5ZMvY8yfO/ability_Greater_Kinetic_Grip_Yd9jRc4setB3igPQ.json
@@ -102,14 +102,14 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> The forced movement ignores stability. You take [[/damage 2d6]] damage and are [[/apply weakened save]].</p>",
-        "before": true,
+      "4QcJheqY0nfyM6Ck": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0
+        "type": "strained",
+        "_id": "4QcJheqY0nfyM6Ck",
+        "description": "<p>The forced movement ignores stability. You take [[/damage 2d6]] damage and are [[/apply weakened save]].</p>",
+        "before": false
       }
     }
   },
@@ -123,7 +123,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761076868533,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telepathy_xVL4LnjEmlBPeE4Q/ability_Synaptic_Conditioning_byRI3ZSQFvdKJc5D.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telepathy_xVL4LnjEmlBPeE4Q/ability_Synaptic_Conditioning_byRI3ZSQFvdKJc5D.json
@@ -129,14 +129,14 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> While the target is under this effect, you no longer consider your enemies to be your enemies when using your abilities and features.</p>",
-        "before": true,
+      "Jp58BgMiRHflb1Pj": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0
+        "type": "strained",
+        "_id": "Jp58BgMiRHflb1Pj",
+        "description": "<p>While the target is under this effect, you no longer consider your enemies to be your enemies when using your abilities and features.</p>",
+        "before": false
       }
     }
   },
@@ -150,7 +150,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761077739922,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telepathy_xVL4LnjEmlBPeE4Q/ability_Synaptic_Dissipation_Yjd3R9UBOR8q9xCb.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_6_bInvMSSXqbC6nCjz/Telepathy_xVL4LnjEmlBPeE4Q/ability_Synaptic_Dissipation_Yjd3R9UBOR8q9xCb.json
@@ -90,11 +90,20 @@
       "before0000000000": {
         "_id": "before0000000000",
         "type": "base",
-        "description": "<p>You target a number of creatures with this ability determined by the outcome of your power roll. You and your allies are [[/apply invisible]] to each target until the start of your next turn.</p><p><strong>Strained:</strong> The effect ends early if you take damage from an enemy’s ability.</p>",
+        "description": "<p>You target a number of creatures with this ability determined by the outcome of your power roll. You and your allies are [[/apply invisible]] to each target until the start of your next turn.</p>",
         "before": true,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "S8h9ugFCe793JQgg": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "S8h9ugFCe793JQgg",
+        "description": "<p>The effect ends early if you take damage from an enemy’s ability.</p>",
+        "before": false
       }
     }
   },
@@ -108,7 +117,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761078486147,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_8_qNF3sTx3kg7GPouS/11_Clarity_2Bsc4W8gkDQbJTOg/ability_Doubt_07fuK6yFfpbC2fAm.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_8_qNF3sTx3kg7GPouS/11_Clarity_2Bsc4W8gkDQbJTOg/ability_Doubt_07fuK6yFfpbC2fAm.json
@@ -144,14 +144,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>This ability gains an edge against a target with a soul. After you make the power roll, you or one ally within distance have a double edge on the next power roll you make before the end of the encounter.</p><p><strong>Strained:</strong> You feel dispirited until you finish a respite. If you obtain a tier 3 outcome on the power roll, you and the target each have [[/apply \"atsPk0jYryV6sL3q\"]] (save ends).</p>",
-        "before": true,
+        "description": "<p>This ability gains an edge against a target with a soul. After you make the power roll, you or one ally within distance have a double edge on the next power roll you make before the end of the encounter.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "rkKbOgV3eMpayl8n": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "rkKbOgV3eMpayl8n",
+        "description": "<p>You feel dispirited until you finish a respite. If you obtain a tier 3 outcome on the power roll, you and the target each have [[/apply atsPk0jYryV6sL3q save]].</p>",
+        "before": false
       }
     }
   },
@@ -279,7 +288,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761099654074,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_8_qNF3sTx3kg7GPouS/11_Clarity_2Bsc4W8gkDQbJTOg/ability_Mindwipe_tZP5aZyJ7TCcFby0.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_8_qNF3sTx3kg7GPouS/11_Clarity_2Bsc4W8gkDQbJTOg/ability_Mindwipe_tZP5aZyJ7TCcFby0.json
@@ -90,17 +90,17 @@
                 "characteristic": "reason",
                 "value": "@potency.weak"
               },
-              "display": ", the target takes a bane on their next power roll"
+              "display": "{{potency}}, the target takes a bane on their next power roll"
             },
             "tier2": {
-              "display": ", the target takes a bane on power rolls (save ends)",
+              "display": "{{potency}}, the target takes a bane on power rolls (save ends)",
               "potency": {
                 "value": "@potency.average",
                 "characteristic": ""
               }
             },
             "tier3": {
-              "display": ", the target has a double bane on power rolls (save ends)",
+              "display": "{{potency}}, the target has a double bane on power rolls (save ends)",
               "potency": {
                 "value": "@potency.strong",
                 "characteristic": ""
@@ -123,14 +123,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>The target can’t communicate with anyone until the end of the encounter.</p><p><strong>Strained:</strong> You take [[/damage 3d6]] damage.</p>",
-        "before": true,
+        "description": "<p>The target can’t communicate with anyone until the end of the encounter.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "QUoKmybWV4d7Ckcc": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "QUoKmybWV4d7Ckcc",
+        "description": "<p>You take [[/damage 3d6]] damage.</p>",
+        "before": false
       }
     }
   },
@@ -144,7 +153,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761100899354,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Chronopathy_p8upuwPpFr0mIVVc/ability_Acceleration_Field_kegHOFsovS7IsLDn.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Chronopathy_p8upuwPpFr0mIVVc/ability_Acceleration_Field_kegHOFsovS7IsLDn.json
@@ -152,11 +152,20 @@
       "before0000000000": {
         "_id": "before0000000000",
         "type": "base",
-        "description": "<p>Each target can use any main action available to them as a free triggered action, but they lose their main action on their next turn.</p><p><strong>Strained:</strong> Make a power roll that targets you and each enemy within distance.</p>",
+        "description": "<p>Each target can use any main action available to them as a free triggered action, but they lose their main action on their next turn.</p>",
         "before": true,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "hFiZ18mGe0r4U1cM": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "hFiZ18mGe0r4U1cM",
+        "description": "<p>Make a power roll that targets you and each enemy within distance.</p>",
+        "before": true
       }
     }
   },
@@ -170,7 +179,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761138561542,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Telekinesis_FpoeWWIOMZaPP3xb/ability_Fulcrum_RUy3V8JsgCX4bIUK.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Telekinesis_FpoeWWIOMZaPP3xb/ability_Fulcrum_RUy3V8JsgCX4bIUK.json
@@ -95,13 +95,13 @@
         "img": null,
         "sort": 0
       },
-      "after00000000000": {
-        "_id": "after00000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> You can choose to reduce the size of the burst by 2 (to a minimum of 1 burst) to give the forced movement distance a +2 bonus. You take half the total damage all targets take from forced movement.</p>",
+      "7YB2OU4ad3vsXNEp": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0,
+        "type": "strained",
+        "_id": "7YB2OU4ad3vsXNEp",
+        "description": "<p>You can choose to reduce the size of the burst by 2 (to a minimum of 1 burst) to give the forced movement distance a +2 bonus. You take half the total damage all targets take from forced movement.</p>",
         "before": false
       }
     }
@@ -116,7 +116,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761139775293,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Telepathy_nL97zYCyanwHuLOG/ability_Resonant_Mind_Spike_X4xf8oEFkYPJKUbn.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Telepathy_nL97zYCyanwHuLOG/ability_Resonant_Mind_Spike_X4xf8oEFkYPJKUbn.json
@@ -99,14 +99,23 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
-        "description": "<p>This ability ignores cover and concealment.</p><p><strong>Strained:</strong> The ability roll scores a critical hit on a natural 17 or higher. You take half the damage the target takes, and you can’t reduce this damage in any way.</p>",
-        "before": true,
+        "description": "<p>This ability ignores cover and concealment.</p>",
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
+      },
+      "tlMIaf25cpbFH857": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "strained",
+        "_id": "tlMIaf25cpbFH857",
+        "description": "<p>The ability roll scores a critical hit on a natural 17 or higher. You take half the damage the target takes, and you can’t reduce this damage in any way.</p>",
+        "before": false
       }
     }
   },
@@ -120,7 +129,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761140923207,

--- a/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Telepathy_nL97zYCyanwHuLOG/ability_Synaptic_Terror_zx0VmLuZpzXAWDnj.json
+++ b/src/packs/abilities/Talent_W4G9rOoBWQqffx2T/Level_9_qxHnrAeYnBKzD7Ci/Telepathy_nL97zYCyanwHuLOG/ability_Synaptic_Terror_zx0VmLuZpzXAWDnj.json
@@ -116,13 +116,13 @@
         "img": null,
         "sort": 0
       },
-      "after00000000000": {
-        "_id": "after00000000000",
-        "type": "base",
-        "description": "<p><strong>Strained:</strong> You can’t use this ability if doing so would cause you to have negative clarity.</p>",
+      "fetkoALs0k2ml1Dl": {
+        "sort": 100000,
         "name": "",
         "img": null,
-        "sort": 0,
+        "type": "strained",
+        "_id": "fetkoALs0k2ml1Dl",
+        "description": "<p>You can’t use this ability if doing so would cause you to have negative clarity.</p>",
         "before": false
       }
     }
@@ -137,7 +137,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761141230681,

--- a/src/packs/abilities/Troubadour_MbinHVcKZQ9kJlOA/Level_9_oiUQDKY9dWjIR3E7/Duelist_rP4FOCbgnSIutaW7/ability_Expert_Fencer_Tj0NR54WaIuhChEO.json
+++ b/src/packs/abilities/Troubadour_MbinHVcKZQ9kJlOA/Level_9_oiUQDKY9dWjIR3E7/Duelist_rP4FOCbgnSIutaW7/ability_Expert_Fencer_Tj0NR54WaIuhChEO.json
@@ -132,11 +132,11 @@
       "level": null
     },
     "effects": {
-      "before0000000000": {
-        "_id": "before0000000000",
+      "after00000000000": {
+        "_id": "after00000000000",
         "type": "base",
         "description": "<p>This ability can’t obtain better than a tier 2 outcome unless the target is at maximum distance. If you obtain a tier 3 outcome with a natural 17 or higher, you [[/surge 3]] that you can use immediately.</p>",
-        "before": true,
+        "before": false,
         "name": "",
         "img": null,
         "sort": 0
@@ -153,7 +153,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1761340812137,


### PR DESCRIPTION
Per our discord conversation, I noticed some effects were listed as before instead of after. Updated those and then corrected the UUID to match convention used when migrating.

Also found some strained effects not listed as strained effects while doing this and added those too.

This does not handle any potentially incorrect before/after effects inside of actors. Only base items in compendiums.