### PR TITLE
Add Abilities and Features to NPC Embeds & other small tweaks

### DIFF
--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -227,7 +227,20 @@ export default class NPCModel extends CreatureModel {
 
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
-    // Prepare list of features and abilities (`ul`).
+    context.itemList = await this._getItemsList();
+
+    embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
+
+    return embed;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prepare the list of items for the NPC embed.
+   * @returns {Promise<string>}
+   */
+  async _getItemsList() {
     const abilities = this._getOrderedAbilities();
     const { startFeatures, endFeatures } = this._getOrderedFeatures();
     const orderedItems = [...startFeatures, ...abilities, ...endFeatures];
@@ -245,12 +258,10 @@ export default class NPCModel extends CreatureModel {
       itemList.append(li);
     }
 
-    context.itemList = itemList.outerHTML;
-
-    embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
-
-    return embed;
+    return itemList.outerHTML;
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Orders Ability Items in the same order
@@ -263,6 +274,8 @@ export default class NPCModel extends CreatureModel {
       (a, b) => keys.indexOf(a.system.type) - keys.indexOf(b.system.type),
     );
   }
+
+  /* -------------------------------------------------- */
 
   /**
    * Orders Feature Items via the `embedDisplay.displayAtEnd` flag.

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -216,6 +216,7 @@ export default class NPCModel extends CreatureModel {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
       damageIW: this._getImmunitiesWeaknesses(),
+      itemEmbeds: await this._getItemEmbeds(),
       monsterKeywords: this._getMonsterKeywords().join(", "),
       movement: this._getMovement(true).list,
       system: this,
@@ -227,8 +228,6 @@ export default class NPCModel extends CreatureModel {
 
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
-    context.itemList = await this._getItemsList();
-
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 
     return embed;
@@ -237,28 +236,19 @@ export default class NPCModel extends CreatureModel {
   /* -------------------------------------------------- */
 
   /**
-   * Prepare the list of items for the NPC embed.
-   * @returns {Promise<string>}
+   * Prepare embeds of Items for the NPC embed.
+   * @returns {Promise<DrawSteelItemEmbed[]>}
    */
-  async _getItemsList() {
+  async _getItemEmbeds() {
     const abilities = this._getOrderedAbilities();
     const { startFeatures, endFeatures } = this._getOrderedFeatures();
     const orderedItems = [...startFeatures, ...abilities, ...endFeatures];
 
-    const itemList = document.createElement("ul");
-    itemList.classList.add("abilities-list");
-    for (const item of orderedItems) {
-      const itemEmbed = await item.system.toEmbed({ includeName: true });
-      const li = document.createElement("li");
-      li.innerHTML = itemEmbed.outerHTML;
-
-      const itemIcon = item.system.getStatBlockIcon?.();
-      if (itemIcon) li.classList.add(itemIcon);
-
-      itemList.append(li);
-    }
-
-    return itemList.outerHTML;
+    return Promise.all(orderedItems.map(async (item) => {
+      const embed = await item.system.toEmbed({ includeName: true });
+      embed.icon = item.system.getStatBlockIcon?.();
+      return embed;
+    }));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -260,7 +260,7 @@ export default class NPCModel extends CreatureModel {
    */
   _getOrderedAbilities() {
     const abilityTypes = Object.keys(ds.CONFIG.abilities.types);
-    return this.parent.items.documentsByType.ability.sort(
+    return this.parent.items.documentsByType.ability.toSorted(
       (a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort,
     );
   }
@@ -272,9 +272,9 @@ export default class NPCModel extends CreatureModel {
    * @returns {{ startFeatures: DrawSteelItem[], endFeatures: DrawSteelItem[] }}
    */
   _getOrderedFeatures() {
-    const features = this.parent.items.documentsByType.feature.sort((a, b) => a.sort - b.sort);
+    const features = this.parent.items.documentsByType.feature.toSorted((a, b) => a.sort - b.sort);
 
-    const [ endFeatures, startFeatures ] = features.partition(f => {
+    const [ startFeatures, endFeatures ] = features.partition(f => {
       return !!f.getFlag(ds.CONST.systemID, "embedDisplay.displayAtEnd");
     });
     return { startFeatures, endFeatures };

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -228,7 +228,8 @@ export default class NPCModel extends CreatureModel {
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
     // Prepare list of features and abilities (`ul`).
-    const { ability: abilities, feature } = this.parent.items.documentsByType;
+    const { feature } = this.parent.items.documentsByType;
+    const abilities = this._getOrderedAbilities();
 
     const startFeatures = [];
     const endFeatures = [];
@@ -258,6 +259,18 @@ export default class NPCModel extends CreatureModel {
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 
     return embed;
+  }
+
+  /**
+   * Orders the Ability Items in the same order
+   * as the keys in ds.CONFIG.abilities.types.
+   * @returns {DrawSteelItem[]}
+   */
+  _getOrderedAbilities() {
+    const keys = Object.keys(ds.CONFIG.abilities.types);
+    return this.parent.items.documentsByType.ability.sort(
+      (a, b) => keys.indexOf(a.system.type) - keys.indexOf(b.system.type),
+    );
   }
 
   /* ------------------------------------------------- */

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -12,6 +12,7 @@ import enrichHTML from "../../utils/enrich-html.mjs";
  * @import { DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";
  * @import AbilityModel from "../item/ability.mjs";
  * @import { MaliceModel } from "../settings/_module.mjs";
+ * @import { EmbedDisplayFlags } from "../item/_types";
  * @import DamagePowerRollEffect from "../pseudo-documents/power-roll-effects/damage-effect.mjs";
  */
 
@@ -227,10 +228,21 @@ export default class NPCModel extends CreatureModel {
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
     // Prepare list of features and abilities (`ul`).
-    const { ability, feature } = this.parent.itemTypes;
+    const { ability: abilities, feature } = this.parent.items.documentsByType;
+
+    const startFeatures = [];
+    const endFeatures = [];
+    feature.forEach(f => {
+      /** @type {EmbedDisplayFlags} */
+      const flag = f.getFlag(ds.CONST.systemID, "embedDisplay");
+      if (flag?.displayAtEnd) endFeatures.push(f);
+      else startFeatures.push(f);
+    });
+    const orderedItems = [...startFeatures, ...abilities, ...endFeatures];
+
     const itemList = document.createElement("ul");
     itemList.classList.add("abilities-list");
-    for (const item of [...feature, ...ability]) {
+    for (const item of orderedItems) {
       const itemEmbed = await item.system.toEmbed({ includeName: true });
       const li = document.createElement("li");
       li.innerHTML = itemEmbed.outerHTML;

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -228,17 +228,8 @@ export default class NPCModel extends CreatureModel {
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
     // Prepare list of features and abilities (`ul`).
-    const { feature } = this.parent.items.documentsByType;
     const abilities = this._getOrderedAbilities();
-
-    const startFeatures = [];
-    const endFeatures = [];
-    feature.forEach(f => {
-      /** @type {EmbedDisplayFlags} */
-      const flag = f.getFlag(ds.CONST.systemID, "embedDisplay");
-      if (flag?.displayAtEnd) endFeatures.push(f);
-      else startFeatures.push(f);
-    });
+    const { startFeatures, endFeatures } = this._getOrderedFeatures();
     const orderedItems = [...startFeatures, ...abilities, ...endFeatures];
 
     const itemList = document.createElement("ul");
@@ -262,7 +253,7 @@ export default class NPCModel extends CreatureModel {
   }
 
   /**
-   * Orders the Ability Items in the same order
+   * Orders Ability Items in the same order
    * as the keys in ds.CONFIG.abilities.types.
    * @returns {DrawSteelItem[]}
    */
@@ -271,6 +262,24 @@ export default class NPCModel extends CreatureModel {
     return this.parent.items.documentsByType.ability.sort(
       (a, b) => keys.indexOf(a.system.type) - keys.indexOf(b.system.type),
     );
+  }
+
+  /**
+   * Orders Feature Items via the `embedDisplay.displayAtEnd` flag.
+   * @returns {{ startFeatures: DrawSteelItem[], endFeatures: DrawSteelItem[] }}
+   */
+  _getOrderedFeatures() {
+    const { feature } = this.parent.items.documentsByType;
+
+    const startFeatures = [];
+    const endFeatures = [];
+    feature.forEach(f => {
+      /** @type {EmbedDisplayFlags} */
+      const flag = f.getFlag(ds.CONST.systemID, "embedDisplay");
+      if (flag?.displayAtEnd) endFeatures.push(f);
+      else startFeatures.push(f);
+    });
+    return { startFeatures, endFeatures };
   }
 
   /* ------------------------------------------------- */

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -273,15 +273,9 @@ export default class NPCModel extends CreatureModel {
    */
   _getOrderedFeatures() {
     const features = this.parent.items.documentsByType.feature.sort((a, b) => a.sort - b.sort);
-    console.info("features", features);
 
-    const startFeatures = [];
-    const endFeatures = [];
-    features.forEach(f => {
-      /** @type {EmbedDisplayFlags} */
-      const flag = f.getFlag(ds.CONST.systemID, "embedDisplay");
-      if (flag?.displayAtEnd) endFeatures.push(f);
-      else startFeatures.push(f);
+    const [ endFeatures, startFeatures ] = features.partition(f => {
+      return !!f.getFlag(ds.CONST.systemID, "embedDisplay.displayAtEnd");
     });
     return { startFeatures, endFeatures };
   }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -259,9 +259,9 @@ export default class NPCModel extends CreatureModel {
    * @returns {DrawSteelItem[]}
    */
   _getOrderedAbilities() {
-    const keys = Object.keys(ds.CONFIG.abilities.types);
+    const abilityTypes = Object.keys(ds.CONFIG.abilities.types);
     return this.parent.items.documentsByType.ability.sort(
-      (a, b) => keys.indexOf(a.system.type) - keys.indexOf(b.system.type),
+      (a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort,
     );
   }
 
@@ -272,11 +272,12 @@ export default class NPCModel extends CreatureModel {
    * @returns {{ startFeatures: DrawSteelItem[], endFeatures: DrawSteelItem[] }}
    */
   _getOrderedFeatures() {
-    const { feature } = this.parent.items.documentsByType;
+    const features = this.parent.items.documentsByType.feature.sort((a, b) => a.sort - b.sort);
+    console.info("features", features);
 
     const startFeatures = [];
     const endFeatures = [];
-    feature.forEach(f => {
+    features.forEach(f => {
       /** @type {EmbedDisplayFlags} */
       const flag = f.getFlag(ds.CONST.systemID, "embedDisplay");
       if (flag?.displayAtEnd) endFeatures.push(f);

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -228,12 +228,16 @@ export default class NPCModel extends CreatureModel {
 
     // Prepare abilities list (`ul`).
     const abilities = this.parent.itemTypes.ability;
+    const features = this.parent.itemTypes.feature;
     const abilitiesList = document.createElement("ul");
     abilitiesList.classList.add("abilities-list");
     for (const ability of abilities) {
       const abilityEmbed = await ability.system.toEmbed({});
+      const abilityIcon = ability.system.getStatBlockIcon();
       const li = document.createElement("li");
       li.innerHTML = abilityEmbed.outerHTML;
+      li.classList.add(abilityIcon);
+
       abilitiesList.append(li);
     }
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -226,22 +226,22 @@ export default class NPCModel extends CreatureModel {
 
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
-    // Prepare abilities list (`ul`).
-    const abilities = this.parent.itemTypes.ability;
-    const features = this.parent.itemTypes.feature;
-    const abilitiesList = document.createElement("ul");
-    abilitiesList.classList.add("abilities-list");
-    for (const ability of abilities) {
-      const abilityEmbed = await ability.system.toEmbed({});
-      const abilityIcon = ability.system.getStatBlockIcon();
+    // Prepare list of features and abilities (`ul`).
+    const { ability, feature } = this.parent.itemTypes;
+    const itemList = document.createElement("ul");
+    itemList.classList.add("abilities-list");
+    for (const item of [...feature, ...ability]) {
+      const itemEmbed = await item.system.toEmbed({ includeName: true });
       const li = document.createElement("li");
-      li.innerHTML = abilityEmbed.outerHTML;
-      li.classList.add(abilityIcon);
+      li.innerHTML = itemEmbed.outerHTML;
 
-      abilitiesList.append(li);
+      const itemIcon = item.system.getStatBlockIcon?.();
+      if (itemIcon) li.classList.add(itemIcon);
+
+      itemList.append(li);
     }
 
-    context.abilitiesList = abilitiesList.outerHTML;
+    context.itemList = itemList.outerHTML;
 
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -226,6 +226,19 @@ export default class NPCModel extends CreatureModel {
 
     embed.classList.add("draw-steel", "actor", "npc", this.monster.role || "no-role");
 
+    // Prepare abilities list (`ul`).
+    const abilities = this.parent.itemTypes.ability;
+    const abilitiesList = document.createElement("ul");
+    abilitiesList.classList.add("abilities-list");
+    for (const ability of abilities) {
+      const abilityEmbed = await ability.system.toEmbed({});
+      const li = document.createElement("li");
+      li.innerHTML = abilityEmbed.outerHTML;
+      abilitiesList.append(li);
+    }
+
+    context.abilitiesList = abilitiesList.outerHTML;
+
     embed.innerHTML = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/actor/npc.hbs"), context);
 
     return embed;

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -17,6 +17,24 @@ export type ItemMetaData = Readonly<SubtypeMetadata & {
   detailsPartial?: string[];
 }>;
 
+/** Flags which control how embedded items are displayed. */
+export interface EmbedDisplayFlags {
+  /** Icon to override the default icon for the embedded item. */
+  readonly iconOverride?:
+    | "area"
+    | "burst"
+    | "melee"
+    | "meleeRanged"
+    | "ranged"
+    | "self"
+    | "special"
+    | "trait"
+    | "triggered-action"
+    | "villain-action";
+  /** Whether to display the embedded item at the end of the list. */
+  readonly displayAtEnd?: boolean;
+}
+
 declare module "./base-item.mjs" {
   export default interface BaseItemModel {
     parent: DrawSteelItem;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -339,39 +339,6 @@ export default class AbilityModel extends BaseItemModel {
     return embed;
   }
 
-  /**
-   * Logic to get the stat-block icon for use in the actor sheet.
-   * @returns {string}
-   */
-  getStatBlockIcon() {
-    console.info(this);
-    switch (this.type) {
-      case "villain":
-        return "villain-action";
-
-      case "triggered":
-      case "freeTriggered":
-        return "triggered-action";
-
-      default:
-        break;
-    }
-
-    switch (this.distance.type) {
-      case "cube":
-      case "line":
-      case "wall":
-        return "area";
-
-      case "aura":
-      case "burst":
-        return "burst";
-      //
-      default:
-        return this.distance.type;
-    }
-  }
-
   /* -------------------------------------------------- */
 
   /**

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -12,6 +12,7 @@ import enrichHTML from "../../utils/enrich-html.mjs";
  * @import { DocumentHTMLEmbedConfig, EnrichmentOptions } from "@client/applications/ux/text-editor.mjs";
  * @import { ApplicationConfiguration } from "@client/applications/_types.mjs";
  * @import { DatabaseCreateOperation } from "@common/abstract/_types.mjs";
+ * @import { EmbedDisplayFlags } from "./_types";
  * @import RegionDocument from "@client/documents/region.mjs";
  * @import { PowerRollModifiers } from "../../_types";
  * @import { PlaceAbilityOptions } from "./_types";
@@ -340,6 +341,42 @@ export default class AbilityModel extends BaseItemModel {
   }
 
   /* -------------------------------------------------- */
+
+  /**
+   * Logic to get the stat-block icon for use in Actor embed.
+   * @returns {EmbedDisplayFlags["iconOverride"]}
+   */
+  getStatBlockIcon() {
+    /** @type {EmbedDisplayFlags["iconOverride"]} */
+    const { iconOverride } = this.parent.getFlag(ds.CONST.systemID, "embedDisplay") ?? {};
+    if (iconOverride) return iconOverride;
+
+    switch (this.type) {
+      case "villain":
+        return "villain-action";
+
+      case "triggered":
+      case "freeTriggered":
+        return "triggered-action";
+
+      default:
+        break;
+    }
+
+    switch (this.distance.type) {
+      case "cube":
+      case "line":
+      case "wall":
+        return "area";
+
+      case "aura":
+      case "burst":
+        return "burst";
+
+      default:
+        return this.distance.type;
+    }
+  }
 
   /**
    * The formatted text strings for keywords, distance, and target for use in the ability embed and actor sheet.

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -339,6 +339,39 @@ export default class AbilityModel extends BaseItemModel {
     return embed;
   }
 
+  /**
+   * Logic to get the stat-block icon for use in the actor sheet.
+   * @returns {string}
+   */
+  getStatBlockIcon() {
+    console.info(this);
+    switch (this.type) {
+      case "villain":
+        return "villain-action";
+
+      case "triggered":
+      case "freeTriggered":
+        return "triggered-action";
+
+      default:
+        break;
+    }
+
+    switch (this.distance.type) {
+      case "cube":
+      case "line":
+      case "wall":
+        return "area";
+
+      case "aura":
+      case "burst":
+        return "burst";
+      //
+      default:
+        return this.distance.type;
+    }
+  }
+
   /* -------------------------------------------------- */
 
   /**

--- a/src/module/data/item/base-item.mjs
+++ b/src/module/data/item/base-item.mjs
@@ -149,7 +149,7 @@ export default class BaseItemModel extends DrawSteelSystemModel {
     if (!["feature", "ability"].includes(this.parent.type)) return null;
 
     /** @type {EmbedDisplayFlags["iconOverride"]} */
-    const iconOverride = this.parent.getFlag(ds.CONST.systemID, "iconOverride");
+    const { iconOverride } = this.parent.getFlag(ds.CONST.systemID, "embedDisplay") ?? {};
 
     if (this.parent.type === "feature") {
       return iconOverride ?? "trait"; // Default to `trait` icon for features.

--- a/src/module/data/item/base-item.mjs
+++ b/src/module/data/item/base-item.mjs
@@ -127,7 +127,7 @@ export default class BaseItemModel extends DrawSteelSystemModel {
     embed.classList.add("draw-steel", this.parent.type);
     if (config.includeName) {
       embed.innerHTML = `
-        <h5>${this.parent.name}</h5>
+        <h5 data-no-toc>${this.parent.name}</h5>
         ${enriched}
       `;
     } else {

--- a/src/module/data/item/base-item.mjs
+++ b/src/module/data/item/base-item.mjs
@@ -5,7 +5,6 @@ import { validateDSID } from "../helpers.mjs";
 
 /**
  * @import DrawSteelActor from "../../documents/actor.mjs"
- * @import { EmbedDisplayFlags } from "./_types";
  */
 
 const fields = foundry.data.fields;
@@ -136,52 +135,6 @@ export default class BaseItemModel extends DrawSteelSystemModel {
     }
 
     return embed;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * Logic to get the stat-block icon for use in Actor embed.
-   * Currently only applies to `feature` and `ability` items.
-   * @returns {string}
-   */
-  getStatBlockIcon() {
-    if (!["feature", "ability"].includes(this.parent.type)) return null;
-
-    /** @type {EmbedDisplayFlags["iconOverride"]} */
-    const { iconOverride } = this.parent.getFlag(ds.CONST.systemID, "embedDisplay") ?? {};
-
-    if (this.parent.type === "feature") {
-      return iconOverride ?? "trait"; // Default to `trait` icon for features.
-    }
-
-    if (iconOverride) return iconOverride;
-
-    switch (this.type) {
-      case "villain":
-        return "villain-action";
-
-      case "triggered":
-      case "freeTriggered":
-        return "triggered-action";
-
-      default:
-        break;
-    }
-
-    switch (this.distance.type) {
-      case "cube":
-      case "line":
-      case "wall":
-        return "area";
-
-      case "aura":
-      case "burst":
-        return "burst";
-
-      default:
-        return this.distance.type;
-    }
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/item/base-item.mjs
+++ b/src/module/data/item/base-item.mjs
@@ -3,7 +3,10 @@ import SourceModel from "../models/source.mjs";
 import enrichHTML from "../../utils/enrich-html.mjs";
 import { validateDSID } from "../helpers.mjs";
 
-/** @import DrawSteelActor from "../../documents/actor.mjs" */
+/**
+ * @import DrawSteelActor from "../../documents/actor.mjs"
+ * @import { EmbedDisplayFlags } from "./_types";
+ */
 
 const fields = foundry.data.fields;
 
@@ -123,9 +126,62 @@ export default class BaseItemModel extends DrawSteelSystemModel {
 
     const embed = document.createElement("div");
     embed.classList.add("draw-steel", this.parent.type);
-    embed.innerHTML = enriched;
+    if (config.includeName) {
+      embed.innerHTML = `
+        <h5>${this.parent.name}</h5>
+        ${enriched}
+      `;
+    } else {
+      embed.innerHTML = enriched;
+    }
 
     return embed;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Logic to get the stat-block icon for use in Actor embed.
+   * Currently only applies to `feature` and `ability` items.
+   * @returns {string}
+   */
+  getStatBlockIcon() {
+    if (!["feature", "ability"].includes(this.parent.type)) return null;
+
+    /** @type {EmbedDisplayFlags["iconOverride"]} */
+    const iconOverride = this.parent.getFlag(ds.CONST.systemID, "iconOverride");
+
+    if (this.parent.type === "feature") {
+      return iconOverride ?? "trait"; // Default to `trait` icon for features.
+    }
+
+    if (iconOverride) return iconOverride;
+
+    switch (this.type) {
+      case "villain":
+        return "villain-action";
+
+      case "triggered":
+      case "freeTriggered":
+        return "triggered-action";
+
+      default:
+        break;
+    }
+
+    switch (this.distance.type) {
+      case "cube":
+      case "line":
+      case "wall":
+        return "area";
+
+      case "aura":
+      case "burst":
+        return "burst";
+
+      default:
+        return this.distance.type;
+    }
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/item/feature.mjs
+++ b/src/module/data/item/feature.mjs
@@ -1,6 +1,9 @@
 import { setOptions, validateDSID } from "../helpers.mjs";
 import AdvancementModel from "./advancement.mjs";
 import { systemPath } from "../../constants.mjs";
+/**
+ * @import { EmbedDisplayFlags } from "./_types";
+ */
 
 /**
  * A data model directly representing class and monster features as well as the basis for ancestry traits, perks, and titles.
@@ -39,5 +42,17 @@ export default class FeatureModel extends AdvancementModel {
     });
 
     return schema;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Logic to get the stat-block icon for use in Actor embed.
+   * @returns {EmbedDisplayFlags["iconOverride"]}
+   */
+  getStatBlockIcon() {
+    /** @type {EmbedDisplayFlags["iconOverride"]} */
+    const { iconOverride } = this.parent.getFlag(ds.CONST.systemID, "embedDisplay") ?? {};
+    return iconOverride ?? "trait"; // Default to `trait` icon for features.
   }
 }

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -177,7 +177,7 @@ document-embed, .item-embed {
       }
     }
 
-    ul.abilities-list {
+    ul.item-embed-list {
       list-style: none;
 
       border-radius: inherit;

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -50,6 +50,7 @@ document-embed, .item-embed {
     min-width: unset;
 
     background-image: linear-gradient(var(--color-statblock), transparent 5rem);
+    box-shadow: 4px 4px 8px 2px oklch(from var(--color-statblock) 0.65 0.06 h / 0.5);
     border-radius: 8px;
 
     margin-inline: 1rem;
@@ -184,7 +185,62 @@ document-embed, .item-embed {
       margin-block-end: 0;
 
       li {
+        position: relative;
         margin-inline: 32px 4px;
+
+        --ability-icon: 't'; /* sword (default) */
+
+        &::before {
+          content: var(--ability-icon);
+          position: absolute;
+          top: -0.25em;
+          left: -24px;
+          font-size: 1.25em;
+          font-family: 'Draw Steel Glyphs';
+          font-weight: normal;
+        }
+
+        &.area::before {
+          --ability-icon: 'e'; /* 3x3 grid */
+        }
+
+        &.burst::before {
+          --ability-icon: 'b'; /* burst */
+        }
+
+        &.villain-action::before {
+          --ability-icon: 'd'; /* skull */
+        }
+
+        &.melee::before {
+          --ability-icon: 't'; /* sword */
+        }
+
+        &.ranged::before {
+          --ability-icon: 'g'; /* bow */
+        }
+
+        &.self::before {
+          --ability-icon: 'f'; /* person */
+        }
+
+        &.special::before {
+          --ability-icon: 'c'; /* concentric circle looking thing */
+        }
+
+        &.trait::before {
+          --ability-icon: '*'; /* star */
+        }
+
+        &.triggered-action::before {
+          --ability-icon: ')'; /* exclamation */
+          color: black;
+        }
+
+        &.meleeRanged::before {
+          --ability-icon: 'l'; /* sword/arrow */
+        }
+
 
         &:not(:last-child)::after {
           content: "";

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -234,7 +234,6 @@ document-embed, .item-embed {
 
         &.triggered-action::before {
           --ability-icon: ')'; /* exclamation */
-          color: black;
         }
 
         &.meleeRanged::before {
@@ -291,6 +290,11 @@ document-embed, .item-embed {
 
     &.mount {
       --color-statblock: #BADDEA;
+    }
+
+    &.no-role,
+    &.solo {
+      box-shadow:4px 4px 8px 2px var(--color-statblock);
     }
 
     &.support {

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -50,7 +50,7 @@ document-embed, .item-embed {
     min-width: unset;
 
     background-image: linear-gradient(var(--color-statblock), transparent 5rem);
-    border-radius: 8px 8px 0px 0px;
+    border-radius: 8px;
 
     margin-inline: 1rem;
 
@@ -60,7 +60,6 @@ document-embed, .item-embed {
       gap: 8px;
       font-size: 1.125em;
       font-family: 'Newsreader', serif;
-      border-bottom: 1px solid gray;
       padding-inline-end: 1rem;
 
       .image-name-keywords {
@@ -99,6 +98,20 @@ document-embed, .item-embed {
 
     section.stats {
       gap: 8px;
+
+      &:before {
+        content: "";
+        height: 15px;
+
+        background-image: url("/systems/draw-steel/assets/ui/continue.svg");
+        background-repeat: no-repeat;
+        background-size: 200%;
+        background-position: center;
+
+        margin-block: -8px;
+
+        filter: grayscale(0.8) brightness(0.2);
+      }
 
       .label {
         font-weight: 600;

--- a/src/styles/system/applications/components/embeds.css
+++ b/src/styles/system/applications/components/embeds.css
@@ -176,6 +176,35 @@ document-embed, .item-embed {
       }
     }
 
+    ul.abilities-list {
+      list-style: none;
+
+      border-radius: inherit;
+      padding-inline: 0;
+      margin-block-end: 0;
+
+      li {
+        margin-inline: 32px 4px;
+
+        &:not(:last-child)::after {
+          content: "";
+          display: block;
+          height: 15px;
+          width: calc(100% + 36px);
+          transform: translate(-32px, 0);
+
+          background-image: url("/systems/draw-steel/assets/ui/continue.svg");
+          background-repeat: no-repeat;
+          background-size: 200%;
+          background-position: center;
+
+          margin-bottom: 8px;
+
+          filter: grayscale(0.8) brightness(0.2);
+        }
+      }
+    }
+
     &.ambusher {
       --color-statblock: #F9DD63;
     }

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -86,4 +86,6 @@
     </div>
     {{/each}}
   </div>
+
+  {{{abilitiesList}}}
 </section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -87,5 +87,9 @@
     {{/each}}
   </div>
 
-  {{{itemList}}}
+  <ul class="item-embed-list">
+    {{#each itemEmbeds as |item|}}
+    <li class="{{item.icon}}">{{{item.outerHTML}}}</li>
+    {{/each}}
+  </ul>
 </section>

--- a/templates/embeds/actor/npc.hbs
+++ b/templates/embeds/actor/npc.hbs
@@ -87,5 +87,5 @@
     {{/each}}
   </div>
 
-  {{{abilitiesList}}}
+  {{{itemList}}}
 </section>


### PR DESCRIPTION
#### This PR does the following:

- Adds Features to the NPC Embeds
- Adds Abilities to the NPC Embeds
- Displays an icon for each feature/ability
  - For Abilities, there is a best-effort function to assign the icon that it corresponds with in the PDF's stat blocks. However, there are some abilities that seem to defy the central logic, and thus there is the option to add a flag to any Ability item. The flag exists under the namespace `"draw-steel.embedDisplay"` and is under the property `iconOverride` (a string literal). Set that to one of the following options to override the icon that is used:
    - "area"
    - "burst"
    - "melee"
    - "meleeRanged"
    - "ranged"
    - "self"
    - "special"
    - "trait"
    - "triggered-action"
    - "villain-action"
  - For Features, there isn't sufficient information in the data model to assign the icon using logic. Thus, you must use the flag described above to override the icon. Otherwise Features default to the `"trait"` (star) icon.
- In statblocks, some Features come at the beginning of the list, before Abilities, and others come at the end. Thus there is another flag option. This one also exists under the same namespace, `"draw-steel.embedDisplay"` under the `displayAtEnd` property. This is a `boolean` that exists on the Feature. Set it to `true` to put that Feature after Abilities. The order is otherwise retained.
- Other small tweaks:
  - Add box-shadow to npc embeds, with shadow that matches the color. I think it helps identify the NPC's organization when there are many abilities, and the user would have to scroll down.
  - Adds the horizontal-line/triangular separator to the embed.

<img width="586" height="684" alt="image" src="https://github.com/user-attachments/assets/482bea54-1d2c-470d-b4b5-5b70851d9899" />

#### To test:
1. Grab the attached `json` file [Crux_of_Fire](https://github.com/user-attachments/files/28431017/npc_Crux_of_Fire_65JYST23SoHMm6FN.json), and copy (overwrite) it in the directory: `src/packs/monsters/Elementals_hatSTUdV3EGvlnvE/`
2. Run `npm run build:packs` to build that monster into the compendium.
3. `@Embed` the above monster into a Journal Entry.
4. Notice that the Ability named "Split" has the `self` icon (when otherwise it would have the `special` icon. 
5. Notice that "Fickle and Free" Feature is listed at the end, rather than the beginning.

**Note:** This PR does *not* include any data entry. That is a lot to go through, with the many monsters and their many more Abilities/Features. That should be a separate task for a separate PR.

Closes #1916
