### PR TITLE
Extra token markers

### DIFF
--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -183,20 +183,17 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
-  _drawBar(number, bar, data) {
-    if (data.attribute !== "stamina") return super._drawBar(number, bar, data);
-
-    const staminaData = foundry.utils.getProperty(this, "document.actor.system.stamina");
-    const temp = staminaData?.temporary ?? 0;
-    const min = staminaData?.min ?? 0;
-    const stamina = Number(data.value) - temp;
+  _drawBar(index, bar, data) {
+    // specialized handling for thp & negative HP, not relevant for minion squads.
+    if ((data.attribute !== "stamina") || data.minionStamina) return super._drawBar(index, bar, data);
 
     // Creates a normalized range of 0 to (max stamina - min stamina) used for calculating the token bar percentage
     // Needed to handle actor's negative stamina
-    const totalStamina = data.max - min;
-    const adjustedValue = stamina - min;
+    const stamina = Number(data.value) - data.temporary;
+    const totalStamina = data.max - data.min;
+    const adjustedValue = stamina - data.min;
     const barPct = Math.clamp(adjustedValue, 0, totalStamina) / totalStamina;
-    const tempPct = Math.clamp(temp, 0, data.max) / data.max;
+    const tempPct = Math.clamp(data.temporary, 0, data.max) / data.max;
 
     // Determine sizing
     const { width, height } = this.document.getSize();
@@ -210,11 +207,11 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     let color;
     if (stamina >= 0) {
       const colorPct = Math.clamp(stamina, 0, data.max) / data.max;
-      if (number === 0) color = Color.fromRGB([1 - (colorPct / 2), colorPct, 0]);
+      if (index === 0) color = Color.fromRGB([1 - (colorPct / 2), colorPct, 0]);
       else color = Color.fromRGB([0.5 * colorPct, 0.7 * colorPct, 0.5 + (colorPct / 2)]);
     } else {
       const colorPct = Math.clamp(adjustedValue, 0, Math.abs(data.min)) / Math.abs(data.min);
-      if (number === 0) color = Color.fromRGB([colorPct + (1 - colorPct) * 0.2, 0, 0]);
+      if (index === 0) color = Color.fromRGB([colorPct + (1 - colorPct) * 0.2, 0, 0]);
       else color = Color.fromRGB([0, 0, 0.5 - ((1 - colorPct) * 0.4)]);
     }
 
@@ -225,13 +222,12 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     bar.beginFill(color, 1.0).drawRoundedRect(0, 0, barPct * bw, bh, 2 * s);
 
     // Draw the temp stamina
-    if (temp > 0) {
+    if (data.temporary > 0) {
       bar.beginFill(0x66CCFF, 1.0).drawRoundedRect(2 * s, 2 * s, (tempPct * bw) - (4 * s), bh - (4 * s), s);
     }
 
     // Set position
-    const posY = number === 0 ? height - bh : 0;
+    const posY = index === 0 ? height - bh : 0;
     bar.position.set(0, posY);
-    return true;
   }
 }

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -226,6 +226,16 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
       bar.beginFill(0x66CCFF, 1.0).drawRoundedRect(2 * s, 2 * s, (tempPct * bw) - (4 * s), bh - (4 * s), s);
     }
 
+    // Zero and winded markers
+
+    if (data.min < 0) {
+      const zeroMark = (0 - data.min) / totalStamina * bw;
+      bar.moveTo(zeroMark, 0).lineTo(zeroMark, bh);
+    }
+
+    const windedMark = (data.winded - data.min) / totalStamina * bw;
+    bar.moveTo(windedMark, 0).lineTo(windedMark, bh);
+
     // Set position
     const posY = index === 0 ? height - bh : 0;
     bar.position.set(0, posY);

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -227,12 +227,10 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
     }
 
     // Zero and winded markers
-
     if (data.min < 0) {
       const zeroMark = (0 - data.min) / totalStamina * bw;
       bar.moveTo(zeroMark, 0).lineTo(zeroMark, bh);
     }
-
     const windedMark = (data.winded - data.min) / totalStamina * bw;
     bar.moveTo(windedMark, 0).lineTo(windedMark, bh);
 

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -105,16 +105,34 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
 
     if (barData?.attribute !== "stamina") return barData;
 
-    barData.min = this.actor.system.stamina.min;
-    barData.value += this.actor.system.stamina.temporary || 0;
-
     // Set minion specific stamina bar data based on their combat squad
-    if (!this.actor.isMinion || (this.actor.system.combatGroups.size !== 1)) return barData;
+    if (!this.actor.isMinion) {
+      const staminaData = this.actor.system.stamina;
+      barData.min = staminaData.min ?? 0;
+      barData.value += staminaData.temporary || 0;
+      barData.temporary = staminaData.temporary;
+      barData.winded = staminaData.winded;
 
-    const combatGroup = this.actor.system.combatGroup;
-    barData.min = 0;
-    barData.max = combatGroup.system.staminaMax;
-    barData.value = combatGroup.system.staminaValue;
+      return barData;
+    }
+
+    Object.defineProperties(barData, {
+      max: {
+        get: () => {
+          const combatGroup = this.actor.system.combatGroup;
+          return combatGroup ? combatGroup.system.staminaMax : barData.max;
+        },
+      },
+      value: {
+        get: () => {
+          const combatGroup = this.actor.system.combatGroup;
+          return combatGroup ? combatGroup.system.staminaValue : barData.value;
+        },
+      },
+      minionStamina: {
+        value: true,
+      },
+    });
 
     return barData;
   }


### PR DESCRIPTION
Depends on #1937 for the updates to the passed `data`

<img width="581" height="254" alt="image" src="https://github.com/user-attachments/assets/861b97cc-b591-4c99-bc24-9c956eab8205" />

Adds a line at the 0 and winded marks.