### PR TITLE
[#1925] Item tooltips

### DIFF
--- a/src/module/data/item/base-item.mjs
+++ b/src/module/data/item/base-item.mjs
@@ -163,4 +163,14 @@ export default class BaseItemModel extends DrawSteelSystemModel {
    * @param {object} rollData   Pointer to the roll data object.
    */
   modifyRollData(rollData) {}
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create data for an enriched tooltip.
+   * @returns {Promise<HTMLElement[]>}
+   */
+  async richTooltip() {
+    return this.parent.toEmbed({ includeName: true, inline: true });
+  }
 }


### PR DESCRIPTION
Very simple implementation, need the `inline` so we get a `document-embed` and the default CSS functions. Open to iteration.