### PR TITLE
[#852] Added spend values to roll data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Increased foundry minimum to 14.363.
 - Abilities can now have any number of HTML sections, and they can have additional info. (#475)
   - This includes promoting the "spend" field to have an HTML entry. (#329)
   - Strained & Spend message parts only display if their conditions are fulfilled. (#676)
+  - Spend effects now provide the spend value as roll data under `@spend`. (#852)
 - Added `@Embed` support for NPC actors. (#901)
 - Added "Effect Origin" option to applied effects. When used, the duration of the effect is based on the *user* of the effect rather than the target. (#1260)
 - Item choice advancements can now specify "Ability" as an expansion option, allowing selection of non-core abilities. (#1420)

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -635,7 +635,10 @@ export default class AbilityModel extends BaseItemModel {
         };
 
         for (const damageEffect of this.power.effects.documentsByType.damage) {
-          const damageRoll = damageEffect.toDamageRoll(tierNumber, { damageSelection: fd.damage });
+          const damageRoll = damageEffect.toDamageRoll(tierNumber, {
+            damageSelection: fd.damage,
+            spend: Object.values(fd.spend),
+          });
           if (!damageRoll) continue;
           await damageRoll.evaluate();
           rollPart.rolls.push(damageRoll);

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -188,6 +188,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
    * @param {1 | 2 | 3} tier        The tier of this effects' data to fetch.
    * @param {object} [options]
    * @param {string} [options.damageSelection] Pick between this damage effect's multiple damage types.
+   * @param {number[]} [options.spend] Spend data from an ability configuration form.
    * @returns {DamageRoll | null} Returns null if there would be no damage from that tier.
    */
   toDamageRoll(tier, options = {}) {
@@ -204,7 +205,11 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
     // Extract ignoredImmunities from the damage effect
     const ignoredImmunities = Array.from(effectTier.ignoredImmunities);
 
-    return new DamageRoll(String(effectTier.value), this.item.getRollData(), {
+    const rollData = this.item.getRollData();
+
+    if (options.spend) rollData.spend = options.spend;
+
+    return new DamageRoll(String(effectTier.value), rollData, {
       flavor,
       type: damageType,
       ignoredImmunities,

--- a/src/packs/character-options/Complications_luKqW8QDTBJo5AM4/Granted_Items_UOufuPwHKuuE680F/ability_Psychic_Blast_sRaz23tsVW98uECZ.json
+++ b/src/packs/character-options/Complications_luKqW8QDTBJo5AM4/Granted_Items_UOufuPwHKuuE680F/ability_Psychic_Blast_sRaz23tsVW98uECZ.json
@@ -18,7 +18,7 @@
     ],
     "type": "main",
     "category": "heroic",
-    "resource": 1,
+    "resource": null,
     "trigger": "",
     "distance": {
       "type": "burst",
@@ -74,6 +74,48 @@
             }
           },
           "sort": 0
+        },
+        "53wOTDFqRetrKQwr": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "53wOTDFqRetrKQwr",
+          "damage": {
+            "tier1": {
+              "value": "min(@level, @spend.0)",
+              "types": [
+                "psychic"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "min(@level + @chr, @spend.0)",
+              "types": [
+                "psychic"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "@spend.0",
+              "types": [
+                "psychic"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
         }
       }
     },
@@ -89,7 +131,7 @@
         "description": "<p>Using this ability costs all your Heroic Resource.</p>",
         "name": "",
         "img": null,
-        "before": false
+        "before": true
       }
     },
     "prerequisites": {
@@ -111,7 +153,7 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.361",
+    "coreVersion": "14.363",
     "systemId": "draw-steel",
     "systemVersion": "1.1.0",
     "createdTime": 1755183156488,


### PR DESCRIPTION
It's not the prettiest solution *but* it's fully functional.

<img width="285" height="290" alt="image" src="https://github.com/user-attachments/assets/a28840b9-7b7b-4973-ad61-83b1112cd1b7" />

Closes #852