### PR TITLE
[#1558] Add document type hints

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2465,6 +2465,31 @@
     "CombatantGroup": {
       "squad": "Squad"
     },
+    "HINTS": {
+      "Actor": {
+        "hero": "A player character, created and run by a player other than the Director.",
+        "npc": "A nonplayer character, usually created and run by the Director.",
+        "object": "A terrain object is an element placed in an encounter that alters tactics on the battlefield, allowing the Director to better theme an encounter.",
+        "party": "A collection of Heroes used for easy viewing of statistics and setting of hero tokens.",
+        "retainer": " A follower who adventures alongside a hero."
+      },
+      "Item": {
+        "ability": "Special main actions, maneuvers, and more that a creature can use to affect other creatures and objects, and the environment.",
+        "complication": "A dramatic narrative twist that deepens a hero's backstory and gives them a rules benefit and drawback. Complications are an optional rule.",
+        "culture": "The community in which a hero was raised.",
+        "feature": "A trait given by classes, ancestries, etc.",
+        "follower": "An NPC dedicated to helping a hero. Many of the actions of a follower are controlled by a player.",
+        "perk": "A feature available to all heroes that helps with exploration, investigation, negotiation, and more.",
+        "project": "A task a hero undertakes during one or more respite.",
+        "title": "A special reward that a hero can earn while adventuring, and which grants benefits or new abilities.",
+        "treasure": " A piece of supernatural equipment, from weapons and armor to implements and more."
+      },
+      "JournalEntryPage": {
+        "configuration": "An easy way to configure homebrew elements like languages and monster keywords.",
+        "reference": "An extensions of a text page that allows for rich tooltips.",
+        "tierOutcome": "A page for configuring reusable power roll outcomes that can be embedded."
+      }
+    },
     "Item": {
       "ability": "Ability",
       "ancestry": "Ancestry",

--- a/templates/sidebar/tabs/item/document-create.hbs
+++ b/templates/sidebar/tabs/item/document-create.hbs
@@ -17,6 +17,7 @@
         {{selectOptions types selected=type}}
       </select>
     </div>
+    <p class="hint">{{typeHint}}</p>
   </div>
   {{/if}}
 


### PR DESCRIPTION
Closes #1558 

Used the glossary where I could. DTOs didn't have a glossary entry, so pull the first sentence in their section of the book. Party, I kind of just made up and thought that was descriptive of what they do right now. Feature was another hard one, I struggled to think of a definition that didn't just say "feature".

Not sure if you wanted JournalEntryPage types done too, but figured might as well.