### PR TITLE
Fix abilities with spends not rolling

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -637,7 +637,7 @@ export default class AbilityModel extends BaseItemModel {
         for (const damageEffect of this.power.effects.documentsByType.damage) {
           const damageRoll = damageEffect.toDamageRoll(tierNumber, {
             damageSelection: fd.damage,
-            spend: Object.values(fd.spend),
+            spend: Object.values(fd.spend ?? {}),
           });
           if (!damageRoll) continue;
           await damageRoll.evaluate();


### PR DESCRIPTION
When there's no spend effects `fd.spend` is undefined and so errors out. Looks like the nullish guarding was already being used in a different spot. Just missed here.