### PR TITLE
Fixed 1.1 build issue where an un-grouped token would crash the canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,8 +133,8 @@ The latest version of Draw Steel is v14-exclusive. You can see the full v14 stab
 - Creature token sizes are now inferred from their actor sizes, so active effects targeting `system.combat.size.value` will also adjust token sizes automatically. (#1528)
 - Migrated roll modes to the new core message modes. (#1681)
 - Hard fixed the list of characteristics. (#1705)
-- Migrated `forced.pull` (etc.) to `forced.bonuses.pull`
 - Refactored various system methods to use new core methods to simplify logic and improve performance. (#1158, #1284, #1711)
+- Migrated `forced.pull` (etc.) to `forced.bonuses.pull`.
 
 ### Deprecated
 

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -116,17 +116,20 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
       return barData;
     }
 
+    const barMax = barData.max;
+    const barValue = barData.value;
+
     Object.defineProperties(barData, {
       max: {
         get: () => {
           const combatGroup = this.actor.system.combatGroup;
-          return combatGroup ? combatGroup.system.staminaMax : barData.max;
+          return combatGroup ? combatGroup.system.staminaMax : barMax;
         },
       },
       value: {
         get: () => {
           const combatGroup = this.actor.system.combatGroup;
-          return combatGroup ? combatGroup.system.staminaValue : barData.value;
+          return combatGroup ? combatGroup.system.staminaValue : barValue;
         },
       },
       minionStamina: {


### PR DESCRIPTION
Issue internal to 1.1 build due to me not quite realizing what was pass-by-value vs. pass-by-reference