### PR TITLE
[#311] Added freeform shape construction to objects

### DIFF
--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -14,7 +14,7 @@
 @import url("../src/styles/system/applications/apps/characteristic-input.css");
 @import url("../src/styles/system/applications/apps/defeated-minion-selection.css");
 @import url("../src/styles/system/applications/apps/monster-metadata.css");
-@import url("../src/styles/system/applications/apps/object-size-input.css");
+@import url("../src/styles/system/applications/apps/object-sizes-input.css");
 @import url("../src/styles/system/applications/apps/power-roll-dialog.css");
 @import url("../src/styles/system/applications/apps/saving-throw-dialog.css");
 @import url("../src/styles/system/applications/apps/targeted-condition-prompt.css");

--- a/css/draw-steel-system.css
+++ b/css/draw-steel-system.css
@@ -14,6 +14,7 @@
 @import url("../src/styles/system/applications/apps/characteristic-input.css");
 @import url("../src/styles/system/applications/apps/defeated-minion-selection.css");
 @import url("../src/styles/system/applications/apps/monster-metadata.css");
+@import url("../src/styles/system/applications/apps/object-size-input.css");
 @import url("../src/styles/system/applications/apps/power-roll-dialog.css");
 @import url("../src/styles/system/applications/apps/saving-throw-dialog.css");
 @import url("../src/styles/system/applications/apps/targeted-condition-prompt.css");

--- a/lang/en.json
+++ b/lang/en.json
@@ -612,6 +612,9 @@
               },
               "typical": {
                 "label": "Typical Space"
+              },
+              "shapes": {
+                "label": "Region Shapes"
               }
             },
             "stability": {
@@ -907,6 +910,9 @@
         },
         "ObjectMetadata": {
           "DialogTitle": "Update Object Metadata"
+        },
+        "ObjectSizes": {
+          "DialogTitle": "Update Object Sizes"
         }
       },
       "party": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -914,7 +914,12 @@
         "ObjectSizes": {
           "DialogTitle": "Update Object Sizes",
           "AddShape": "Add Region Shape",
-          "ShapeType": "Shape Type"
+          "ShapeType": "Shape Type",
+          "FIELDS": {
+            "count": {
+              "label": "Count"
+            }
+          }
         }
       },
       "party": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -915,6 +915,8 @@
           "DialogTitle": "Update Object Sizes",
           "AddShape": "Add Region Shape",
           "ShapeType": "Shape Type",
+          "PlaceShape": "Place Object Shapes",
+          "EditShapes": "Edit Object Shapes",
           "FIELDS": {
             "count": {
               "label": "Count"

--- a/lang/en.json
+++ b/lang/en.json
@@ -912,7 +912,9 @@
           "DialogTitle": "Update Object Metadata"
         },
         "ObjectSizes": {
-          "DialogTitle": "Update Object Sizes"
+          "DialogTitle": "Update Object Sizes",
+          "AddShape": "Add Region Shape",
+          "ShapeType": "Shape Type"
         }
       },
       "party": {

--- a/src/module/applications/apps/_module.mjs
+++ b/src/module/applications/apps/_module.mjs
@@ -5,6 +5,7 @@ export { default as CharacteristicInput } from "./characteristic-input.mjs";
 export { default as DocumentSourceInput } from "./document-source-input.mjs";
 export { default as MonsterMetadataInput } from "./monster-metadata-input.mjs";
 export { default as ObjectMetadataInput } from "./object-metadata-input.mjs";
+export { default as ObjectSizesInput } from "./object-sizes-input.mjs";
 export { default as PowerRollDialog } from "./power-roll-dialog.mjs";
 export { default as RetainerMetadataInput } from "./retainer-metadata-input.mjs";
 export { default as SavingThrowDialog } from "./saving-throw-dialog.mjs";

--- a/src/module/applications/apps/_types.d.ts
+++ b/src/module/applications/apps/_types.d.ts
@@ -1,4 +1,5 @@
 import { DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";
+import ObjectModel from "../../data/actor/object.mjs";
 
 interface PowerRollDialogModifiers {
   edges: number;
@@ -29,5 +30,11 @@ declare module "./characteristic-input.mjs" {
 declare module "./document-source-input.mjs" {
   export default interface DocumentSourceInput {
     document: DrawSteelActor | DrawSteelItem;
+  }
+}
+
+declare module "./object-sizes-input.mjs" {
+  export default interface ObjectSizesInput {
+    document: Omit<DrawSteelActor, "system"> & { system: ObjectModel };
   }
 }

--- a/src/module/applications/apps/object-sizes-input.mjs
+++ b/src/module/applications/apps/object-sizes-input.mjs
@@ -1,9 +1,6 @@
 import DocumentInput from "../api/document-input.mjs";
+import { TEMPLATE_TYPES } from "../../data/models/template-shapes.mjs";
 import { systemPath } from "../../constants.mjs";
-
-/**
- * @import { TEMPLATE_TYPES } from "../../data/models/template-shapes.mjs";
- */
 
 /**
  * Simple live-updating input for object sizes.
@@ -35,6 +32,7 @@ export default class ObjectSizesInput extends DocumentInput {
       template: systemPath("templates/apps/document-input/object-sizes-input.hbs"),
       templates: [
         systemPath("templates/apps/object-sizes/circle.hbs"),
+        systemPath("templates/apps/object-sizes/cone.hbs"),
         systemPath("templates/apps/object-sizes/emanation.hbs"),
         systemPath("templates/apps/object-sizes/line.hbs"),
         systemPath("templates/apps/object-sizes/rectangle.hbs"),
@@ -52,7 +50,7 @@ export default class ObjectSizesInput extends DocumentInput {
     const sizeModel = this.document.system.combat.size;
     context.sizeSource = sizeModel._source;
 
-    context.shapeContexts = sizeModel.shapes.map(shape => this._prepareShapeContext(shape));
+    context.shapeContexts = sizeModel.shapes.map((shape, idx) => this._prepareShapeContext(shape, idx));
 
     return context;
   }
@@ -69,6 +67,7 @@ export default class ObjectSizesInput extends DocumentInput {
     const gridInput = foundry.applications.fields.createNumberInput({
       id: `${inputConfig.rootId}-${field.fieldPath}-grid`, min: 0, step: "any", dataset: { units: "grid" },
       value: inputConfig.value,
+      name: inputConfig.name,
     });
     const gridLabel = document.createElement("label");
     gridLabel.setAttribute("for", gridInput.id);
@@ -81,11 +80,13 @@ export default class ObjectSizesInput extends DocumentInput {
   /**
    * Puts together rendering context for each shape.
    * @param {InstanceType<TEMPLATE_TYPES[keyof TEMPLATE_TYPES]>} shape
+   * @param {number} index
    * @returns {object}
    */
-  _prepareShapeContext(shape) {
+  _prepareShapeContext(shape, index) {
     const shapeContext = {
       shape,
+      name: shape.schema.fieldPath.replace(`element.${shape.type}`, index),
       rootId: this.id,
       fields: { ...shape.schema.fields },
       source: shape._source,
@@ -112,6 +113,19 @@ export default class ObjectSizesInput extends DocumentInput {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  _processFormData(event, form, formData) {
+    const fd = super._processFormData(event, form, formData);
+
+    const shapeData = this.document.system.combat.size.shapes;
+
+    Object.values(fd.system.combat.size.shapes).forEach((shape, idx) => shape.type = shapeData[idx].type);
+
+    return fd;
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Add a new shape.
    * @this ObjectSizesInput
@@ -123,19 +137,10 @@ export default class ObjectSizesInput extends DocumentInput {
 
     const { createFormGroup, createSelectInput } = foundry.applications.fields;
 
-    // curated from foundry.data.BaseShapeData.TYPES
-    const validShapes = [
-      "rectangle",
-      "circle",
-      "emanation",
-      "ring",
-      "line",
-    ];
-
     content.append(createFormGroup({
       label: "DRAW_STEEL.Actor.object.ObjectSizes.ShapeType",
       input: createSelectInput({
-        options: validShapes.map(key => ({
+        options: Object.keys(TEMPLATE_TYPES).map(key => ({
           value: key,
           label: _loc(`SHAPE.TYPES.${key}.name`),
         })),
@@ -171,8 +176,9 @@ export default class ObjectSizesInput extends DocumentInput {
       case "circle":
         shapeData.radius = 1;
         break;
-      case "ellipse":
-        shapeData.radiusX = shapeData.radiusY = 1;
+      case "cone":
+        shapeData.radius = 1;
+        shapeData.angle = 60;
         break;
       case "emanation":
         shapeData.radius = 1;

--- a/src/module/applications/apps/object-sizes-input.mjs
+++ b/src/module/applications/apps/object-sizes-input.mjs
@@ -2,6 +2,10 @@ import DocumentInput from "../api/document-input.mjs";
 import { systemPath } from "../../constants.mjs";
 
 /**
+ * @import { TEMPLATE_TYPES } from "../../data/models/template-shapes.mjs";
+ */
+
+/**
  * Simple live-updating input for object sizes.
  */
 export default class ObjectSizesInput extends DocumentInput {
@@ -14,11 +18,12 @@ export default class ObjectSizesInput extends DocumentInput {
       shapeRemoveAll: this.#shapeRemoveAll,
     },
     position: {
-      width: 500,
+      width: 400,
     },
     window: {
       title: "DRAW_STEEL.Actor.object.ObjectSizes.DialogTitle",
       icon: "fa-solid fa-shapes",
+      resizable: true,
     },
   };
 
@@ -34,6 +39,7 @@ export default class ObjectSizesInput extends DocumentInput {
         systemPath("templates/apps/object-sizes/line.hbs"),
         systemPath("templates/apps/object-sizes/rectangle.hbs"),
         systemPath("templates/apps/object-sizes/ring.hbs"),
+        systemPath("templates/apps/object-sizes/token.hbs"),
       ],
     },
   };
@@ -46,15 +52,62 @@ export default class ObjectSizesInput extends DocumentInput {
     const sizeModel = this.document.system.combat.size;
     context.sizeSource = sizeModel._source;
 
-    context.shapeContexts = sizeModel.shapes.map(shape => {
-      const fields = { ...shape.schema.fields };
-      delete fields.hole;
-      const shapeContext = { rootId: this.id };
-      foundry.applications.apps.ShapeConfig._prepareShapeContext(shapeContext, shape, fields);
-      return shapeContext;
-    });
+    context.shapeContexts = sizeModel.shapes.map(shape => this._prepareShapeContext(shape));
 
     return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create the dimension field.
+   * @param {DataField} field
+   * @param {FormInputConfig} inputConfig
+   * @returns {HTMLElement[]}
+   */
+  static #dimensionInput(field, inputConfig) {
+    const gridInput = foundry.applications.fields.createNumberInput({
+      id: `${inputConfig.rootId}-${field.fieldPath}-grid`, min: 0, step: "any", dataset: { units: "grid" },
+      value: inputConfig.value,
+    });
+    const gridLabel = document.createElement("label");
+    gridLabel.setAttribute("for", gridInput.id);
+    gridLabel.textContent = _loc("MEASUREMENT.GridUnits");
+    return [gridInput, gridLabel];
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Puts together rendering context for each shape.
+   * @param {InstanceType<TEMPLATE_TYPES[keyof TEMPLATE_TYPES]>} shape
+   * @returns {object}
+   */
+  _prepareShapeContext(shape) {
+    const shapeContext = {
+      shape,
+      rootId: this.id,
+      fields: { ...shape.schema.fields },
+      source: shape._source,
+      gridUnits: _loc("MEASUREMENT.GridUnits"),
+      dimensionInput: ObjectSizesInput.#dimensionInput,
+    };
+
+    delete shapeContext.fields.hole;
+
+    // Prepare base shape context for emanations
+    if (shape.type === "emanation") {
+      shapeContext.baseContext = {
+        rootId: shapeContext.rootId,
+        shape: shape.base,
+        fields: shapeContext.fields.base.types[shape.base.type].fields,
+        source: shape.base._source,
+        gridUnits: shapeContext.gridUnits,
+        dimensionInput: shapeContext.dimensionInput,
+      };
+    }
+
+    return shapeContext;
   }
 
   /* -------------------------------------------------- */
@@ -100,6 +153,8 @@ export default class ObjectSizesInput extends DocumentInput {
       },
     });
 
+    if (!fd) return;
+
     const objectSize = this.document.system.combat.size;
 
     const shapeData = {
@@ -122,7 +177,10 @@ export default class ObjectSizesInput extends DocumentInput {
       case "emanation":
         shapeData.radius = 1;
         shapeData.base = {
+          x: 0,
+          y: 0,
           type: "token",
+          shape: CONST.TOKEN_SHAPES.RECTANGLE_1,
           width: objectSize.value,
           height: objectSize.value,
         };

--- a/src/module/applications/apps/object-sizes-input.mjs
+++ b/src/module/applications/apps/object-sizes-input.mjs
@@ -8,6 +8,14 @@ export default class ObjectSizesInput extends DocumentInput {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     classes: ["object-sizes"],
+    actions: {
+      addShape: this.#addShape,
+      deleteShape: this.#deleteShape,
+      shapeRemoveAll: this.#shapeRemoveAll,
+    },
+    position: {
+      width: 500,
+    },
     window: {
       title: "DRAW_STEEL.Actor.object.ObjectSizes.DialogTitle",
       icon: "fa-solid fa-shapes",
@@ -20,6 +28,13 @@ export default class ObjectSizesInput extends DocumentInput {
   static PARTS = {
     body: {
       template: systemPath("templates/apps/document-input/object-sizes-input.hbs"),
+      templates: [
+        systemPath("templates/apps/object-sizes/circle.hbs"),
+        systemPath("templates/apps/object-sizes/emanation.hbs"),
+        systemPath("templates/apps/object-sizes/line.hbs"),
+        systemPath("templates/apps/object-sizes/rectangle.hbs"),
+        systemPath("templates/apps/object-sizes/ring.hbs"),
+      ],
     },
   };
 
@@ -28,15 +43,124 @@ export default class ObjectSizesInput extends DocumentInput {
   /** @inheritdoc */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    context.sizeSource = this.document.system.combat.size._source;
+    const sizeModel = this.document.system.combat.size;
+    context.sizeSource = sizeModel._source;
 
-    if ((context.sizeSource.shapes.length === 1) && !context.sizeSource.shapes[0].hole) {
-      const shape = context.sizeSource.shapes[0];
+    context.shapeContexts = sizeModel.shapes.map(shape => {
       const fields = { ...shape.schema.fields };
       delete fields.hole;
-      context.shapeContext = { rootId: this.id };
-      foundry.applications.apps.ShapeConfig._prepareShapeContext(context.shapeContext, shape, fields);
-    }
+      const shapeContext = { rootId: this.id };
+      foundry.applications.apps.ShapeConfig._prepareShapeContext(shapeContext, shape, fields);
+      return shapeContext;
+    });
+
     return context;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Add a new shape.
+   * @this ObjectSizesInput
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #addShape(event, target) {
+    const content = this.element.ownerDocument.createElement("div");
+
+    const { createFormGroup, createSelectInput } = foundry.applications.fields;
+
+    // curated from foundry.data.BaseShapeData.TYPES
+    const validShapes = [
+      "rectangle",
+      "circle",
+      "emanation",
+      "ring",
+      "line",
+    ];
+
+    content.append(createFormGroup({
+      label: "DRAW_STEEL.Actor.object.ObjectSizes.ShapeType",
+      input: createSelectInput({
+        options: validShapes.map(key => ({
+          value: key,
+          label: _loc(`SHAPE.TYPES.${key}.name`),
+        })),
+        name: "type",
+        sort: true,
+      }),
+      localize: true,
+    }));
+
+    const fd = await ds.applications.api.DSDialog.input({
+      content,
+      window: {
+        title: "DRAW_STEEL.Actor.object.ObjectSizes.AddShape",
+        icon: "fa-solid fa-shapes",
+      },
+    });
+
+    const objectSize = this.document.system.combat.size;
+
+    const shapeData = {
+      type: fd.type,
+      x: 0,
+      y: 0,
+      gridBased: true,
+    };
+
+    switch (fd.type) {
+      case "rectangle":
+        shapeData.width = shapeData.height = 1;
+        break;
+      case "circle":
+        shapeData.radius = 1;
+        break;
+      case "ellipse":
+        shapeData.radiusX = shapeData.radiusY = 1;
+        break;
+      case "emanation":
+        shapeData.radius = 1;
+        shapeData.base = {
+          type: "token",
+          width: objectSize.value,
+          height: objectSize.value,
+        };
+        break;
+      case "ring":
+        shapeData.radius = shapeData.innerWidth = shapeData.outerWidth = 1;
+        break;
+      case "line":
+        shapeData.length = shapeData.width = 1;
+        break;
+    }
+
+    await this.document.update({ "system.combat.size.shapes": objectSize._source.shapes.concat(shapeData) });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Delete a shape.
+   * @this ObjectSizesInput
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #deleteShape(event, target) {
+    const objectSize = this.document.system.combat.size;
+    const idx = target.closest("[data-shape-index]").dataset.shapeIndex;
+    await this.document.update({ "system.combat.size.shapes": objectSize._source.shapes.toSpliced(idx, 1) });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Delete all shapes.
+   * @this ObjectSizesInput
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #shapeRemoveAll(event, target) {
+    await this.document.update({ "system.combat.size.shapes": [] });
   }
 }

--- a/src/module/applications/apps/object-sizes-input.mjs
+++ b/src/module/applications/apps/object-sizes-input.mjs
@@ -1,0 +1,42 @@
+import DocumentInput from "../api/document-input.mjs";
+import { systemPath } from "../../constants.mjs";
+
+/**
+ * Simple live-updating input for object sizes.
+ */
+export default class ObjectSizesInput extends DocumentInput {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["object-sizes"],
+    window: {
+      title: "DRAW_STEEL.Actor.object.ObjectSizes.DialogTitle",
+      icon: "fa-solid fa-shapes",
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    body: {
+      template: systemPath("templates/apps/document-input/object-sizes-input.hbs"),
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.sizeSource = this.document.system.combat.size._source;
+
+    if ((context.sizeSource.shapes.length === 1) && !context.sizeSource.shapes[0].hole) {
+      const shape = context.sizeSource.shapes[0];
+      const fields = { ...shape.schema.fields };
+      delete fields.hole;
+      context.shapeContext = { rootId: this.id };
+      foundry.applications.apps.ShapeConfig._prepareShapeContext(context.shapeContext, shape, fields);
+    }
+    return context;
+  }
+}

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -1,4 +1,4 @@
-import { DocumentSourceInput, ObjectMetadataInput } from "../apps/_module.mjs";
+import { DocumentSourceInput, ObjectMetadataInput, ObjectSizesInput } from "../apps/_module.mjs";
 import DrawSteelActorSheet from "./actor-sheet.mjs";
 import { systemPath } from "../../constants.mjs";
 
@@ -12,6 +12,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
     actions: {
       updateSource: this.#updateSource,
       editObjectMetadata: this.#editObjectMetadata,
+      editShapes: this.#editShapes,
     },
     window: {
       controls: [{
@@ -96,5 +97,17 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    */
   static async #editObjectMetadata(event, target) {
     this.renderChild(new ObjectMetadataInput({ document: this.document }));
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Open a dialog to edit the object shapes.
+   * @this DrawSteelObjectSheet
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #editShapes(event, target) {
+    this.renderChild(new ObjectSizesInput({ document: this.document }));
   }
 }

--- a/src/module/applications/sheets/object-sheet.mjs
+++ b/src/module/applications/sheets/object-sheet.mjs
@@ -13,6 +13,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
       updateSource: this.#updateSource,
       editObjectMetadata: this.#editObjectMetadata,
       editShapes: this.#editShapes,
+      placeShapes: this.#placeShapes,
     },
     window: {
       controls: [{
@@ -84,7 +85,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #updateSource(event, target) {
-    this.renderChild(new DocumentSourceInput({ document: this.document }));
+    await this.renderChild(new DocumentSourceInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -96,7 +97,7 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editObjectMetadata(event, target) {
-    this.renderChild(new ObjectMetadataInput({ document: this.document }));
+    await this.renderChild(new ObjectMetadataInput({ document: this.document }));
   }
 
   /* -------------------------------------------------- */
@@ -108,6 +109,18 @@ export default class DrawSteelObjectSheet extends DrawSteelActorSheet {
    * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
    */
   static async #editShapes(event, target) {
-    this.renderChild(new ObjectSizesInput({ document: this.document }));
+    await this.renderChild(new ObjectSizesInput({ document: this.document }));
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Place the configured shapes.
+   * @this DrawSteelObjectSheet
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #placeShapes(event, target) {
+    await this.actor.system.combat.size.placeArea();
   }
 }

--- a/src/module/data/fields/_module.mjs
+++ b/src/module/data/fields/_module.mjs
@@ -4,3 +4,4 @@ export { default as FormulaField } from "./formula-field.mjs";
 export { default as LazyTypedSchemaField } from "./lazy-typed-schema-field.mjs";
 export { default as LocalDocumentField } from "./local-document-field.mjs";
 export { default as MembersField } from "./members-field.mjs";
+export { default as TemplateShapesField } from "./template-shapes-field.mjs";

--- a/src/module/data/fields/template-shapes-field.mjs
+++ b/src/module/data/fields/template-shapes-field.mjs
@@ -1,0 +1,30 @@
+import { TEMPLATE_TYPES } from "../models/template-shapes.mjs";
+
+/**
+ * @import {ArrayFieldOptions, DataFieldContext} from "@common/data/_types.mjs";
+ */
+
+/**
+ * A subclass of {@link foundry.data.fields.ArrayField} for template shapes.
+ */
+export default class TemplateShapesField extends foundry.data.fields.ArrayField {
+  /**
+   * @param {ArrayFieldOptions} [options]  Options which configure the behavior of the field.
+   * @param {DataFieldContext} [context]   Additional context which describes the field.
+   */
+  constructor(options, context) {
+    super(new foundry.data.fields.TypedSchemaField(TEMPLATE_TYPES), options, context);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  initialize(value, model, options = {}) {
+    if (!value) return value;
+    return value.map((v, i) => {
+      const shape = this.element.initialize(v, model, options);
+      shape._index = i;
+      return shape;
+    });
+  }
+}

--- a/src/module/data/models/_module.mjs
+++ b/src/module/data/models/_module.mjs
@@ -1,3 +1,4 @@
 export { default as ObjectSizeModel } from "./object-size.mjs";
 export { default as SizeModel } from "./size.mjs";
 export { default as SourceModel } from "./source.mjs";
+export * as shapes from "./template-shapes.mjs";

--- a/src/module/data/models/_types.d.ts
+++ b/src/module/data/models/_types.d.ts
@@ -1,7 +1,11 @@
+export {}
+
 declare module "./object-size.mjs" {
   export default interface ObjectSizeModel {
+    text: string;
     direction: string;
     typical: string;
+    shapes: Array<typeof foundry.data.BaseShapeData.TYPES[keyof typeof foundry.data.BaseShapeData.TYPES]>;
   }
 }
 

--- a/src/module/data/models/object-size.mjs
+++ b/src/module/data/models/object-size.mjs
@@ -53,10 +53,22 @@ export default class ObjectSizeModel extends SizeModel {
   placeArea(options = {}) {
     const object = this.parent.parent;
 
+    const distancePixels = canvas.grid.size / canvas.grid.distance;
+
     const data = {
-      shapes: this.shapes.reduce((shapeData, shape) => {
-        for (let i = 0; i < (shape.count ?? 1); i++) shapeData.push({ ...shape });
-        return shapeData;
+      shapes: this.shapes.reduce((shapes, shape) => {
+        const shapeData = shape.toObject();
+        shapeData.gridBased = true;
+        shapeData.x = 0;
+        shapeData.y = 0;
+        for (const key of shape.gridProperties) shapeData[key] *= distancePixels;
+        if (shapeData.base) {
+          shapeData.base.x = shapeData.base.y = 0;
+          shapeData.base.shape = CONST.TOKEN_SHAPES.RECTANGLE_1;
+        }
+        console.log(shapeData);
+        for (let i = 0; i < (shape.count ?? 1); i++) shapes.push(shapeData);
+        return shapes;
       }, []),
       name: object.name,
       color: game.user.color,

--- a/src/module/data/models/object-size.mjs
+++ b/src/module/data/models/object-size.mjs
@@ -1,4 +1,5 @@
 import SizeModel from "./size.mjs";
+import TemplateShapesField from "../fields/template-shapes-field.mjs";
 import { systemID } from "../../constants.mjs";
 
 const fields = foundry.data.fields;
@@ -15,7 +16,7 @@ export default class ObjectSizeModel extends SizeModel {
       text: new fields.StringField({ required: true }),
       direction: new fields.StringField({ required: true }),
       typical: new fields.StringField({ required: true }),
-      shapes: new fields.ShapesField(),
+      shapes: new TemplateShapesField(),
     });
 
     return schema;
@@ -53,7 +54,10 @@ export default class ObjectSizeModel extends SizeModel {
     const object = this.parent.parent;
 
     const data = {
-      shapes: this.shapes,
+      shapes: this.shapes.reduce((shapeData, shape) => {
+        for (let i = 0; i < (shape.count ?? 1); i++) shapeData.push({ ...shape });
+        return shapeData;
+      }, []),
       name: object.name,
       color: game.user.color,
       levels: [canvas.level.id],

--- a/src/module/data/models/object-size.mjs
+++ b/src/module/data/models/object-size.mjs
@@ -1,4 +1,5 @@
 import SizeModel from "./size.mjs";
+import { systemID } from "../../constants.mjs";
 
 const fields = foundry.data.fields;
 
@@ -14,6 +15,7 @@ export default class ObjectSizeModel extends SizeModel {
       text: new fields.StringField({ required: true }),
       direction: new fields.StringField({ required: true }),
       typical: new fields.StringField({ required: true }),
+      shapes: new fields.ShapesField(),
     });
 
     return schema;
@@ -34,5 +36,38 @@ export default class ObjectSizeModel extends SizeModel {
   /** @inheritdoc */
   toString() {
     return this.text || super.toString();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create a region based on this object's shapes data.
+   * @param {RegionPlacementOptions} [options={}] Options to forward to canvas.regions.placeRegion.
+   * @returns {Promise<RegionDocument>} The Region document that was placed or null if
+   *  - the placements of all shapes were skipped,
+   *  - the dismiss key was pressed,
+   *  - the game is paused and the user is not a GM, or
+   *  - the Region creation was rejected by preCreate.
+   */
+  placeArea(options = {}) {
+    const object = this.parent.parent;
+
+    const data = {
+      shapes: this.shapes,
+      name: object.name,
+      color: game.user.color,
+      levels: [canvas.level.id],
+      highlightMode: "coverage",
+      displayMeasurements: true,
+      visibility: CONST.REGION_VISIBILITY.OBSERVER,
+      ownership: { [game.user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
+      flags: {
+        [systemID]: {
+          objectSource: object.uuid,
+        },
+      },
+    };
+
+    return canvas.regions.placeRegion(data, options);
   }
 }

--- a/src/module/data/models/template-shapes.mjs
+++ b/src/module/data/models/template-shapes.mjs
@@ -25,6 +25,16 @@ export class RectangleTemplateData extends foundry.data.RectangleShapeData {
 
     return schema;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return ["height", "width"];
+  }
 }
 
 /* -------------------------------------------------- */
@@ -51,6 +61,16 @@ export class CircleTemplateData extends foundry.data.CircleShapeData {
     delete schema.gridBased;
 
     return schema;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return ["radius"];
   }
 }
 
@@ -83,6 +103,16 @@ export class EmanationTemplateData extends foundry.data.BaseShapeData {
 
     return schema;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return ["radius"];
+  }
 }
 
 /* -------------------------------------------------- */
@@ -109,6 +139,16 @@ export class ConeTemplateData extends foundry.data.ConeShapeData {
     delete schema.gridBased;
 
     return schema;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return ["radius"];
   }
 }
 
@@ -137,6 +177,16 @@ export class RingTemplateData extends foundry.data.RingShapeData {
 
     return schema;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return ["radius", "innerWidth", "outerWidth"];
+  }
 }
 
 /* -------------------------------------------------- */
@@ -163,6 +213,16 @@ export class LineTemplateData extends foundry.data.LineShapeData {
     delete schema.gridBased;
 
     return schema;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return ["length", "width"];
   }
 }
 
@@ -197,5 +257,15 @@ export class TokenTemplateData extends foundry.data.TokenShapeData {
     delete schema.shape;
 
     return schema;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Properties that need to be multiplied by grid pixels.
+   * @type {string[]}
+   */
+  get gridProperties() {
+    return [];
   }
 }

--- a/src/module/data/models/template-shapes.mjs
+++ b/src/module/data/models/template-shapes.mjs
@@ -1,0 +1,201 @@
+import { requiredInteger } from "../helpers.mjs";
+
+const { NumberField, TypedSchemaField } = foundry.data.fields;
+
+/**
+ * Data for a Rectangle that will be placed on the canvas.
+ */
+export class RectangleTemplateData extends foundry.data.RectangleShapeData {
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Actor.object.ObjectSizes");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.count = requiredInteger({ initial: 1, min: 1 });
+
+    // Don't need origin data
+    delete schema.x;
+    delete schema.y;
+    // Always grid-based
+    delete schema.gridBased;
+
+    return schema;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Data for a Circle that will be placed on the canvas.
+ */
+export class CircleTemplateData extends foundry.data.CircleShapeData {
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Actor.object.ObjectSizes");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.count = requiredInteger({ initial: 1, min: 1 });
+
+    // Don't need origin data
+    delete schema.x;
+    delete schema.y;
+    // Always grid-based
+    delete schema.gridBased;
+
+    return schema;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Data for an Emanation that will be placed on the canvas. This is always based on a Token.
+ */
+export class EmanationTemplateData extends foundry.data.BaseShapeData {
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = ["SHAPE.TYPES.emanation", "SHAPE.TYPES.base"];
+
+  /* -------------------------------------------------- */
+
+  static {
+    Object.defineProperty(this, "TYPE", { value: "emanation" });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.radius = new NumberField({ required: true, nullable: false, min: 0, initial: undefined });
+
+    schema.base = new TypedSchemaField({
+      token: TokenTemplateData,
+    });
+
+    return schema;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Data for a Cone that will be placed on the canvas.
+ */
+export class ConeTemplateData extends foundry.data.ConeShapeData {
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Actor.object.ObjectSizes");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.count = requiredInteger({ initial: 1, min: 1 });
+
+    // Don't need origin data
+    delete schema.x;
+    delete schema.y;
+    // Always grid-based
+    delete schema.gridBased;
+
+    return schema;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Data for a Ring that will be placed on the canvas.
+ */
+export class RingTemplateData extends foundry.data.RingShapeData {
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Actor.object.ObjectSizes");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.count = requiredInteger({ initial: 1, min: 1 });
+
+    // Don't need origin data
+    delete schema.x;
+    delete schema.y;
+    // Always grid-based
+    delete schema.gridBased;
+
+    return schema;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Data for a Line that will be placed on the canvas.
+ */
+export class LineTemplateData extends foundry.data.LineShapeData {
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.Actor.object.ObjectSizes");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    schema.count = requiredInteger({ initial: 1, min: 1 });
+
+    // Don't need origin data
+    delete schema.x;
+    delete schema.y;
+    // Always grid-based
+    delete schema.gridBased;
+
+    return schema;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Valid Draw Steel base shape template types.
+ */
+export const TEMPLATE_TYPES = {
+  rectangle: RectangleTemplateData,
+  circle: CircleTemplateData,
+  emanation: EmanationTemplateData,
+  cone: ConeTemplateData,
+  ring: RingTemplateData,
+  line: LineTemplateData,
+};
+
+/* -------------------------------------------------- */
+
+/**
+ * Data for a Token that will be placed on the canvas.
+ */
+export class TokenTemplateData extends foundry.data.TokenShapeData {
+  /** @inheritdoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+
+    // Don't need origin data
+    delete schema.x;
+    delete schema.y;
+    // Grid shape is assumed to be square/match current grid.
+    delete schema.shape;
+
+    return schema;
+  }
+}

--- a/src/styles/system/applications/apps/object-size-input.css
+++ b/src/styles/system/applications/apps/object-size-input.css
@@ -1,0 +1,9 @@
+.draw-steel.object-sizes {
+  .region-element-controls {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.25rem;
+  }
+}

--- a/src/styles/system/applications/apps/object-size-input.css
+++ b/src/styles/system/applications/apps/object-size-input.css
@@ -1,9 +1,0 @@
-.draw-steel.object-sizes {
-  .region-element-controls {
-    flex: none;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.25rem;
-  }
-}

--- a/src/styles/system/applications/apps/object-sizes-input.css
+++ b/src/styles/system/applications/apps/object-sizes-input.css
@@ -1,0 +1,22 @@
+.draw-steel.object-sizes {
+  min-width: 400px;
+
+  .window-content {
+    display: block;
+  }
+
+  [data-application-part="body"] {
+    max-height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
+
+  .shape-controls {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.25rem;
+  }
+}

--- a/templates/apps/document-input/object-sizes-input.hbs
+++ b/templates/apps/document-input/object-sizes-input.hbs
@@ -1,48 +1,24 @@
-<section class="flexcol">
+<section class="flexcol standard-form">
   <header class="region-element region-shape flexrow">
     <div class="region-element-name">{{localize "SHAPE.label"}}</div>
     <div class="region-element-controls">
       {{#if editable}}
+      <button type="button" class="ui-control icon fa-solid fa-plus" data-action="addShape" data-tooltip
+        aria-label="{{localize "DRAW_STEEL.Actor.object.ObjectSizes.AddShape"}}"></button>
       <button type="button" class="ui-control icon fa-solid fa-trash" data-action="shapeRemoveAll" data-tooltip
         aria-label="{{localize "SHAPE.ACTIONS.removeAll"}}"></button>
       {{/if}}
     </div>
   </header>
 
-  {{#if shapeContext}}
-
-  <fieldset class="region-element region-shape flexrow" data-shape-index="0" aria-label="{{localize "SHAPE.label"}} 0">
-    <legend>{{localize (concat "SHAPE.TYPES." shapeContext.shape.type ".name")}}</legend>
-    {{> (concat "templates/apps/shape-config/" shapeContext.shape.type ".hbs") shapeContext }}
+  {{!-- We expect fewer shapes than regions so we can afford to just have a long form if there's a few --}}
+  {{#each shapeContexts as |shapeContext i|}}
+  <fieldset class="region-element region-shape flexrow" data-shape-index="{{i}}" aria-label="{{localize "SHAPE.label"}} 0">
+    <legend>
+      {{localize (concat "SHAPE.TYPES." shapeContext.shape.type ".name")}}
+      <button type="button" class="icon fa-solid fa-trash" data-action="deleteShape"></button>
+    </legend>
+    {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shapeContext.shape.type ".hbs") shapeContext }}
   </fieldset>
-
-  {{else}}
-
-  <div class="standard-form scrollable">
-    {{#each sizeSource.shapes as |shape i|}}
-    <fieldset class="region-element region-shape flexrow" data-shape-index="{{i}}" aria-label="{{localize "SHAPE.label"}} {{i}}">
-      <span class="region-element-name">{{localize (concat "SHAPE.TYPES." shape.type ".name")}}</span>
-      <div class="region-element-controls">
-        {{#if ../editable}}
-        <a class="control fa-solid fa-edit fa-fw" data-action="shapeEdit" data-tooltip
-          aria-label="{{localize "SHAPE.ACTIONS.edit"}}"></a>
-        <a class="control {{#if shape.hole}}fa-regular{{else}}fa-solid{{/if}} fa-circle fa-fw"
-          data-action="shapeToggleHole" data-tooltip
-          aria-label="{{localize (ifThen shape.hole "SHAPE.ACTIONS.fillHole" "SHAPE.ACTIONS.makeHole") }}"
-        ></a>
-        <a class="control fa-solid fa-arrow-up fa-fw" data-action="shapeMoveUp" data-tooltip
-          aria-label="{{localize "SHAPE.ACTIONS.moveUp"}}"></a>
-        <a class="control fa-solid fa-arrow-down fa-fw" data-action="shapeMoveDown" data-tooltip
-          aria-label="{{localize "SHAPE.ACTIONS.moveDown"}}"></a>
-        <a class="control fa-solid fa-trash fa-fw" data-action="shapeRemove" data-tooltip
-          aria-label="{{localize "SHAPE.ACTIONS.remove"}}"></a>
-        {{else}}
-        <span class="{{#if shape.hole}}fa-regular{{else}}fa-solid{{/if}} fa-circle fa-fw"></span>
-        {{/if}}
-      </div>
-    </fieldset>
-    {{/each}}
-  </div>
-
-  {{/if}}
+  {{/each}}
 </section>

--- a/templates/apps/document-input/object-sizes-input.hbs
+++ b/templates/apps/document-input/object-sizes-input.hbs
@@ -1,0 +1,48 @@
+<section class="flexcol">
+  <header class="region-element region-shape flexrow">
+    <div class="region-element-name">{{localize "SHAPE.label"}}</div>
+    <div class="region-element-controls">
+      {{#if editable}}
+      <button type="button" class="ui-control icon fa-solid fa-trash" data-action="shapeRemoveAll" data-tooltip
+        aria-label="{{localize "SHAPE.ACTIONS.removeAll"}}"></button>
+      {{/if}}
+    </div>
+  </header>
+
+  {{#if shapeContext}}
+
+  <fieldset class="region-element region-shape flexrow" data-shape-index="0" aria-label="{{localize "SHAPE.label"}} 0">
+    <legend>{{localize (concat "SHAPE.TYPES." shapeContext.shape.type ".name")}}</legend>
+    {{> (concat "templates/apps/shape-config/" shapeContext.shape.type ".hbs") shapeContext }}
+  </fieldset>
+
+  {{else}}
+
+  <div class="standard-form scrollable">
+    {{#each sizeSource.shapes as |shape i|}}
+    <fieldset class="region-element region-shape flexrow" data-shape-index="{{i}}" aria-label="{{localize "SHAPE.label"}} {{i}}">
+      <span class="region-element-name">{{localize (concat "SHAPE.TYPES." shape.type ".name")}}</span>
+      <div class="region-element-controls">
+        {{#if ../editable}}
+        <a class="control fa-solid fa-edit fa-fw" data-action="shapeEdit" data-tooltip
+          aria-label="{{localize "SHAPE.ACTIONS.edit"}}"></a>
+        <a class="control {{#if shape.hole}}fa-regular{{else}}fa-solid{{/if}} fa-circle fa-fw"
+          data-action="shapeToggleHole" data-tooltip
+          aria-label="{{localize (ifThen shape.hole "SHAPE.ACTIONS.fillHole" "SHAPE.ACTIONS.makeHole") }}"
+        ></a>
+        <a class="control fa-solid fa-arrow-up fa-fw" data-action="shapeMoveUp" data-tooltip
+          aria-label="{{localize "SHAPE.ACTIONS.moveUp"}}"></a>
+        <a class="control fa-solid fa-arrow-down fa-fw" data-action="shapeMoveDown" data-tooltip
+          aria-label="{{localize "SHAPE.ACTIONS.moveDown"}}"></a>
+        <a class="control fa-solid fa-trash fa-fw" data-action="shapeRemove" data-tooltip
+          aria-label="{{localize "SHAPE.ACTIONS.remove"}}"></a>
+        {{else}}
+        <span class="{{#if shape.hole}}fa-regular{{else}}fa-solid{{/if}} fa-circle fa-fw"></span>
+        {{/if}}
+      </div>
+    </fieldset>
+    {{/each}}
+  </div>
+
+  {{/if}}
+</section>

--- a/templates/apps/document-input/object-sizes-input.hbs
+++ b/templates/apps/document-input/object-sizes-input.hbs
@@ -1,7 +1,7 @@
-<section class="flexcol standard-form">
-  <header class="region-element region-shape flexrow">
-    <div class="region-element-name">{{localize "SHAPE.label"}}</div>
-    <div class="region-element-controls">
+<section class="standard-form">
+  <header class="flexrow">
+    <div class="">{{localize "SHAPE.label"}}</div>
+    <div class="shape-controls">
       {{#if editable}}
       <button type="button" class="ui-control icon fa-solid fa-plus" data-action="addShape" data-tooltip
         aria-label="{{localize "DRAW_STEEL.Actor.object.ObjectSizes.AddShape"}}"></button>
@@ -12,6 +12,7 @@
   </header>
 
   {{!-- We expect fewer shapes than regions so we can afford to just have a long form if there's a few --}}
+  <div class="standard-form scrollable">
   {{#each shapeContexts as |shapeContext i|}}
   <fieldset class="region-element region-shape flexrow" data-shape-index="{{i}}" aria-label="{{localize "SHAPE.label"}} 0">
     <legend>
@@ -21,4 +22,5 @@
     {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shapeContext.shape.type ".hbs") shapeContext }}
   </fieldset>
   {{/each}}
+  </div>
 </section>

--- a/templates/apps/object-sizes/circle.hbs
+++ b/templates/apps/object-sizes/circle.hbs
@@ -1,9 +1,9 @@
-<section class="standard-form scrollable">
-    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+<section class="standard-form">
+  {{formField fields.count value=source.count classes="slim"}}
 
-    {{formField fields.gridBased value=source.gridBased rootId=rootId}}
+  {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{#if fields.hole}}
-    {{formField fields.hole value=source.hole rootId=rootId}}
-    {{/if}}
+  {{#if fields.hole}}
+  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{/if}}
 </section>

--- a/templates/apps/object-sizes/circle.hbs
+++ b/templates/apps/object-sizes/circle.hbs
@@ -1,0 +1,9 @@
+<section class="standard-form scrollable">
+    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{formField fields.gridBased value=source.gridBased rootId=rootId}}
+
+    {{#if fields.hole}}
+    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/circle.hbs
+++ b/templates/apps/object-sizes/circle.hbs
@@ -1,9 +1,9 @@
 <section class="standard-form">
-  {{formField fields.count value=source.count classes="slim"}}
+  {{formField fields.count name=(concat name ".count") value=source.count classes="slim"}}
 
-  {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
   {{#if fields.hole}}
-  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
   {{/if}}
 </section>

--- a/templates/apps/object-sizes/cone.hbs
+++ b/templates/apps/object-sizes/cone.hbs
@@ -1,0 +1,13 @@
+<section class="standard-form">
+    {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+
+    {{formField fields.angle name=(concat name ".angle") value=source.angle rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+
+    {{formField fields.rotation name=(concat name ".rotation") value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+
+    {{formField fields.curvature name=(concat name ".curvature") value=source.curvature rootId=rootId classes="slim" localize=true}}
+
+    {{#if fields.hole}}
+    {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/emanation.hbs
+++ b/templates/apps/object-sizes/emanation.hbs
@@ -1,0 +1,12 @@
+<section class="standard-form scrollable">
+    <fieldset>
+        <legend>{{localize "SHAPE.TYPES.emanation.FIELDS.base.label"}}: {{localize (concat "SHAPE.TYPES." shape.base.type ".name")}}</legend>
+        {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shape.base.type ".hbs") baseContext }}
+    </fieldset>
+
+    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{#if fields.hole}}
+    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/emanation.hbs
+++ b/templates/apps/object-sizes/emanation.hbs
@@ -4,9 +4,9 @@
         {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shape.base.type ".hbs") baseContext }}
     </fieldset>
 
-    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+    {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
     {{#if fields.hole}}
-    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
     {{/if}}
 </section>

--- a/templates/apps/object-sizes/emanation.hbs
+++ b/templates/apps/object-sizes/emanation.hbs
@@ -1,10 +1,10 @@
-<section class="standard-form scrollable">
+<section class="standard-form">
     <fieldset>
         <legend>{{localize "SHAPE.TYPES.emanation.FIELDS.base.label"}}: {{localize (concat "SHAPE.TYPES." shape.base.type ".name")}}</legend>
         {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shape.base.type ".hbs") baseContext }}
     </fieldset>
 
-    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
     {{#if fields.hole}}
     {{formField fields.hole value=source.hole rootId=rootId}}

--- a/templates/apps/object-sizes/line.hbs
+++ b/templates/apps/object-sizes/line.hbs
@@ -1,11 +1,13 @@
-<section class="standard-form scrollable">
-    {{formField fields.length value=source.length input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+<section class="standard-form">
+  {{formField fields.count value=source.count classes="slim"}}
 
-    {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+  {{formField fields.length value=source.length input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+  {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{#if fields.hole}}
-    {{formField fields.hole value=source.hole rootId=rootId}}
-    {{/if}}
+  {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+
+  {{#if fields.hole}}
+  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{/if}}
 </section>

--- a/templates/apps/object-sizes/line.hbs
+++ b/templates/apps/object-sizes/line.hbs
@@ -1,0 +1,11 @@
+<section class="standard-form scrollable">
+    {{formField fields.length value=source.length input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+
+    {{#if fields.hole}}
+    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/line.hbs
+++ b/templates/apps/object-sizes/line.hbs
@@ -1,13 +1,13 @@
 <section class="standard-form">
-  {{formField fields.count value=source.count classes="slim"}}
+  {{formField fields.count name=(concat name ".count") value=source.count classes="slim"}}
 
-  {{formField fields.length value=source.length input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.length name=(concat name ".length") value=source.length input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-  {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.width name=(concat name ".width") value=source.width input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-  {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+  {{formField fields.rotation name=(concat name ".rotation") value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
 
   {{#if fields.hole}}
-  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
   {{/if}}
 </section>

--- a/templates/apps/object-sizes/rectangle.hbs
+++ b/templates/apps/object-sizes/rectangle.hbs
@@ -1,21 +1,23 @@
-<section class="standard-form scrollable">
-    {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+<section class="standard-form">
+  {{formField fields.count value=source.count classes="slim"}}
 
-    {{formField fields.height value=source.height input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+  {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    <div class="form-group slim">
-        <label>{{localize "SHAPE.TYPES.rectangle.anchor.label"}}</label>
-        <div class="form-fields">
-            <label for="{{rootId}}-{{fields.anchorX.fieldPath}}">X</label>
-            {{formInput fields.anchorX value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
-            <label for="{{rootId}}-{{fields.anchorY.fieldPath}}">Y</label>
-            {{formInput fields.anchorY value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
-        </div>
-    </div>
+  {{formField fields.height value=source.height input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+  <div class="form-group slim">
+      <label>{{localize "SHAPE.TYPES.rectangle.anchor.label"}}</label>
+      <div class="form-fields">
+          <label for="{{rootId}}-{{fields.anchorX.fieldPath}}">X</label>
+          {{formInput fields.anchorX value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
+          <label for="{{rootId}}-{{fields.anchorY.fieldPath}}">Y</label>
+          {{formInput fields.anchorY value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
+      </div>
+  </div>
 
-    {{#if fields.hole}}
-    {{formField fields.hole value=source.hole rootId=rootId}}
-    {{/if}}
+  {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+
+  {{#if fields.hole}}
+  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{/if}}
 </section>

--- a/templates/apps/object-sizes/rectangle.hbs
+++ b/templates/apps/object-sizes/rectangle.hbs
@@ -1,23 +1,23 @@
 <section class="standard-form">
-  {{formField fields.count value=source.count classes="slim"}}
+  {{formField fields.count name=(concat name ".count") value=source.count classes="slim"}}
 
-  {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.width name=(concat name ".width") value=source.width input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-  {{formField fields.height value=source.height input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.height name=(concat name ".height") value=source.height input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
   <div class="form-group slim">
       <label>{{localize "SHAPE.TYPES.rectangle.anchor.label"}}</label>
       <div class="form-fields">
           <label for="{{rootId}}-{{fields.anchorX.fieldPath}}">X</label>
-          {{formInput fields.anchorX value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
+          {{formInput fields.anchorX name=(concat name ".anchorX") value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
           <label for="{{rootId}}-{{fields.anchorY.fieldPath}}">Y</label>
-          {{formInput fields.anchorY value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
+          {{formInput fields.anchorY name=(concat name ".anchorY") value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
       </div>
   </div>
 
-  {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+  {{formField fields.rotation name=(concat name ".rotation") value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
 
   {{#if fields.hole}}
-  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
   {{/if}}
 </section>

--- a/templates/apps/object-sizes/rectangle.hbs
+++ b/templates/apps/object-sizes/rectangle.hbs
@@ -1,0 +1,21 @@
+<section class="standard-form scrollable">
+    {{formField fields.width value=source.width input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{formField fields.height value=source.height input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    <div class="form-group slim">
+        <label>{{localize "SHAPE.TYPES.rectangle.anchor.label"}}</label>
+        <div class="form-fields">
+            <label for="{{rootId}}-{{fields.anchorX.fieldPath}}">X</label>
+            {{formInput fields.anchorX value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
+            <label for="{{rootId}}-{{fields.anchorY.fieldPath}}">Y</label>
+            {{formInput fields.anchorY value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
+        </div>
+    </div>
+
+    {{formField fields.rotation value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+
+    {{#if fields.hole}}
+    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/ring.hbs
+++ b/templates/apps/object-sizes/ring.hbs
@@ -1,11 +1,13 @@
-<section class="standard-form scrollable">
-    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+<section class="standard-form">
+  {{formField fields.count value=source.count classes="slim"}}
 
-    {{formField fields.innerWidth value=source.innerWidth input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+  {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{formField fields.outerWidth value=source.outerWidth input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+  {{formField fields.innerWidth value=source.innerWidth input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{#if fields.hole}}
-    {{formField fields.hole value=source.hole rootId=rootId}}
-    {{/if}}
+  {{formField fields.outerWidth value=source.outerWidth input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+
+  {{#if fields.hole}}
+  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{/if}}
 </section>

--- a/templates/apps/object-sizes/ring.hbs
+++ b/templates/apps/object-sizes/ring.hbs
@@ -1,13 +1,13 @@
 <section class="standard-form">
-  {{formField fields.count value=source.count classes="slim"}}
+  {{formField fields.count name=(concat name ".count") value=source.count classes="slim"}}
 
-  {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-  {{formField fields.innerWidth value=source.innerWidth input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.innerWidth name=(concat name ".innerWidth") value=source.innerWidth input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-  {{formField fields.outerWidth value=source.outerWidth input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.outerWidth name=(concat name ".outerWidth") value=source.outerWidth input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
   {{#if fields.hole}}
-  {{formField fields.hole value=source.hole rootId=rootId}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
   {{/if}}
 </section>

--- a/templates/apps/object-sizes/ring.hbs
+++ b/templates/apps/object-sizes/ring.hbs
@@ -1,0 +1,11 @@
+<section class="standard-form scrollable">
+    {{formField fields.radius value=source.radius input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{formField fields.innerWidth value=source.innerWidth input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{formField fields.outerWidth value=source.outerWidth input=dimensionInput grid=shape.grid classes="dimension-field" rootId=rootId}}
+
+    {{#if fields.hole}}
+    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/token.hbs
+++ b/templates/apps/object-sizes/token.hbs
@@ -1,0 +1,15 @@
+<section class="standard-form scrollable">
+    <div class="form-group slim">
+        <label>{{localize "SHAPE.TYPES.token.size.label"}} <span class="units">({{localize "MEASUREMENT.GridSpaces"}})</span></label>
+        <div class="form-fields slim">
+            <label for="{{rootId}}-token.width">X</label>
+            {{formInput fields.width value=source.width id=(concat rootId "-token.width")}}
+            <label for="{{rootId}}-token.height">Y</label>
+            {{formInput fields.height value=source.height id=(concat rootId "-token.height")}}
+        </div>
+    </div>
+
+    {{#if fields.hole}}
+    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{/if}}
+</section>

--- a/templates/apps/object-sizes/token.hbs
+++ b/templates/apps/object-sizes/token.hbs
@@ -3,13 +3,13 @@
         <label>{{localize "SHAPE.TYPES.token.size.label"}} <span class="units">({{localize "MEASUREMENT.GridSpaces"}})</span></label>
         <div class="form-fields slim">
             <label for="{{rootId}}-token.width">X</label>
-            {{formInput fields.width value=source.width id=(concat rootId "-token.width")}}
+            {{formInput fields.width name=(concat name ".base.width") value=source.width id=(concat rootId "-token.width")}}
             <label for="{{rootId}}-token.height">Y</label>
-            {{formInput fields.height value=source.height id=(concat rootId "-token.height")}}
+            {{formInput fields.height name=(concat name ".base.height") value=source.height id=(concat rootId "-token.height")}}
         </div>
     </div>
 
     {{#if fields.hole}}
-    {{formField fields.hole value=source.hole rootId=rootId}}
+    {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
     {{/if}}
 </section>

--- a/templates/sheets/actor/object-sheet/stats.hbs
+++ b/templates/sheets/actor/object-sheet/stats.hbs
@@ -85,6 +85,12 @@
     {{formGroup systemFields.combat.fields.size.fields.text value=systemSource.combat.size.text placeholder=system.combat.size.textPlaceholder}}
     {{formGroup systemFields.combat.fields.size.fields.direction value=systemSource.combat.size.direction}}
     {{formGroup systemFields.combat.fields.size.fields.typical value=systemSource.combat.size.typical}}
+    <div class="form-group">
+      <label>{{systemFields.combat.fields.size.fields.shapes.label}}</label>
+      <div class="form-fields">
+        <button class="icon fa-solid fa-gear" type="button" data-tooltip="" data-action="editShapes"></button>
+      </div>
+    </div>
   </fieldset>
   {{> "systems/draw-steel/templates/sheets/actor/shared/partials/stats/movement.hbs"}}
   {{/if}}

--- a/templates/sheets/actor/object-sheet/stats.hbs
+++ b/templates/sheets/actor/object-sheet/stats.hbs
@@ -52,6 +52,9 @@
       <span class="play">
         <strong>{{systemFields.combat.fields.size.label}}</strong> {{system.combat.size}}
       </span>
+      {{#if system.combat.size.shapes}}
+      <button class="icon fa-solid fa-ruler-combined" type="button" data-tooltip="DRAW_STEEL.Actor.object.ObjectSizes.PlaceShape" data-action="placeShapes"></button>
+      {{/if}}
       {{#if system.combat.size.typical}}
       <span class="play">
         <strong>{{systemFields.combat.fields.size.fields.typical.label}}</strong> {{system.combat.size.typical}}
@@ -88,7 +91,7 @@
     <div class="form-group">
       <label>{{systemFields.combat.fields.size.fields.shapes.label}}</label>
       <div class="form-fields">
-        <button class="icon fa-solid fa-gear" type="button" data-tooltip="" data-action="editShapes"></button>
+        <button class="icon fa-solid fa-gear" type="button" data-tooltip="DRAW_STEEL.Actor.object.ObjectSizes.EditShapes" data-action="editShapes"></button>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
This is the shapes-only half of #311, adding relatively freeform shape info to the ObjectSize model and then constructing a button to place those shapes. Adding in behavior construction can be done in the future when we've decided on a paradigm of how players interact with region behaviors.

This is distinct from ability construction because objects often have weird, bespoke shapes they're interacting with.

The three main parts of this PR are
- Adding shapes content to the ObjectSize data model (`src/module/data/models/object-size.mjs`)
- Variants of the existing Foundry shapes stripped of the origin info (`src/module/data/models/template-shapes.mjs`)
- The app to update that field (`src/module/applications/apps/object-sizes-input.mjs`)