### PR TITLE
Object resources displayed as column in edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Increased foundry minimum to 14.363.
 - Minions are no longer damaged by heal enrichers, instead a warning is issued that they cannot regain stamina or gain temporary stamina. (#1901)
 - Added missing showIcon field to the details page of the Active Effect Config sheet. (#1917)
 - Corrected instances where the "turn end" expiration would not match to the correct combatant.
+- Corrected object resource form displaying as a column instead of a row in edit mode. (#1955)
 
 ## 1.0.2
 

--- a/src/styles/system/applications/sheets/actor-sheet.css
+++ b/src/styles/system/applications/sheets/actor-sheet.css
@@ -152,7 +152,7 @@
     .resource-content {
       align-items: center;
 
-      > * > .form-group {
+      .form-group.paired {
         display: flex;
         flex-direction: column-reverse;
         gap: 0px;

--- a/templates/sheets/actor/object-sheet/stats.hbs
+++ b/templates/sheets/actor/object-sheet/stats.hbs
@@ -36,7 +36,7 @@
             </div>
           </div>
           {{else}}
-          <div class="form-group paired">
+          <div class="form-group">
             {{formGroup systemFields.stamina.fields.max value=systemSource.stamina.max dataset=datasets.isSource classes="paired"}}
             {{formGroup systemFields.object.fields.squareStamina value=systemSource.object.squareStamina dataset=datasets.isSource classes="paired"}}
           </div>


### PR DESCRIPTION
<img width="750" height="435" alt="image" src="https://github.com/user-attachments/assets/0d99d1a0-c0e4-44c1-930e-82ae3beb9bed" />

- I used more specific selectors for the `.form-group.paired` selectors, which are form item and labels typically.
- I corrected the `.hbs` file for the object actor form html to remove `.paired` from the class list of the div inside of `.resource-max`

<img width="422" height="121" alt="image" src="https://github.com/user-attachments/assets/2254c9de-43de-443d-b3d0-d64f11935a43" />
