### PR TITLE
Fixed 1.1 migration

### DIFF
--- a/src/module/data/migrations.mjs
+++ b/src/module/data/migrations.mjs
@@ -234,7 +234,7 @@ async function version_1_1_migration() {
     console.log("Migrating document inside", pack.title);
     const wasLocked = pack.config.locked;
     if (wasLocked) await pack.configure({ locked: false });
-    if (pack.type === "Actor") {
+    if (pack.documentName === "Actor") {
       await pack.getDocuments();
       await migrateActorItems(pack);
     }


### PR DESCRIPTION
`pack.type` isn't a valid property, `pack.documentName` is