### PR TITLE
Guard against video token images causing errors in combatant group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,13 +71,15 @@ Increased foundry minimum to 14.364.
 - Player-Facing Compendium Data Fixes:
   - Corrected Back! to not have a forced movement in tier 1. (#1898)
   - Added in correct source data for several triggered actions granted by features. (#1935)
-  - Corrected Censor level 4 characteristic advancement to give Presence and not Reason. (##1968)
+  - Corrected Censor level 4 characteristic advancement to give Presence and not Reason. (#1968)
 - Director-Facing Compendium Data Fixes:
   - Corrected distance on Blackguard Villain Actions. (#1894)
   - Corrected forced movement effects on the Servok War Engine, Kobold Artifex, Ogre Tantrum, and Troll Whelp. (#1898)
+  - Corrected Omen Dragon Corrupting Breath test attribute. (#1977)
 - Minions are no longer damaged by heal enrichers, instead a warning is issued that they cannot regain stamina or gain temporary stamina. (#1901)
 - Added missing showIcon field to the details page of the Active Effect Config sheet. (#1917)
 - Corrected object resource form displaying as a column instead of a row in edit mode. (#1955)
+- Fixed error that could block combatant group creation if the included tokens used video files for images. (#1978)
 - Corrected instances where the "turn end" expiration would not match to the correct combatant.
 - Adventure documents with items now load properly.
 

--- a/src/module/documents/combatant-group.mjs
+++ b/src/module/documents/combatant-group.mjs
@@ -133,7 +133,9 @@ export default class DrawSteelCombatantGroup extends foundry.documents.Combatant
     const group = await this.create({
       type,
       name: tokens.every(t => t.actor?.name === actorName) ? actorName : this.defaultName({ type, parent: combat }),
-      img: tokens.every(t => t.texture.src === tokenImage) ? tokenImage : null,
+      img: foundry.data.validators.hasFileExtension(tokenImage, Object.keys(CONST.FILE_CATEGORIES.IMAGE))
+        ? tokens.every(t => t.texture.src === tokenImage) ? tokenImage : null
+        : null,
     }, { parent: combat });
     const updateData = combatants.map(c => ({ _id: c.id, group: group.id }));
     await combat.updateEmbeddedDocuments("Combatant", updateData);

--- a/src/module/documents/combatant-group.mjs
+++ b/src/module/documents/combatant-group.mjs
@@ -128,14 +128,12 @@ export default class DrawSteelCombatantGroup extends foundry.documents.Combatant
     await DrawSteelTokenDocument.createCombatants(tokens);
     const combatants = tokens.map(t => t.combatant);
     const actorName = tokens[0]?.actor.name;
-    const tokenImage = tokens[0].texture.src;
+    const tokenImage = tokens.find(t => foundry.data.validators.hasFileExtension(t.texture.src, Object.keys(CONST.FILE_CATEGORIES.IMAGE)));
     const type = tokens.some(t => t.actor?.system.isMinion) ? "squad" : "base";
     const group = await this.create({
       type,
       name: tokens.every(t => t.actor?.name === actorName) ? actorName : this.defaultName({ type, parent: combat }),
-      img: foundry.data.validators.hasFileExtension(tokenImage, Object.keys(CONST.FILE_CATEGORIES.IMAGE))
-        ? tokens.every(t => t.texture.src === tokenImage) ? tokenImage : null
-        : null,
+      img: tokens.every(t => t.texture.src === tokenImage) ? tokenImage : null,
     }, { parent: combat });
     const updateData = combatants.map(c => ({ _id: c.id, group: group.id }));
     await combat.updateEmbeddedDocuments("Combatant", updateData);

--- a/src/packs/monsters/Dragons_1xAB7dzxBYqdc7qX/npc_Omen_Dragon_QleCf10baxI9HlTG.json
+++ b/src/packs/monsters/Dragons_1xAB7dzxBYqdc7qX/npc_Omen_Dragon_QleCf10baxI9HlTG.json
@@ -305,7 +305,7 @@
           "roll": {
             "formula": "@chr",
             "characteristics": [
-              "presence"
+              "agility"
             ],
             "reactive": true
           },


### PR DESCRIPTION
Creating a combatant group from tokens can cause an issue with .webm files which are a legal extension for texture.src but not img