### PR TITLE
Fixed compendium lock status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
 ### Known Issues
 -->
 
+## 1.1.1
+
+### Fixed
+
+- Corrected handling of locked compendiums during system migration.
+
+
 ## 1.1.0
 
 Increased foundry minimum to 14.364.

--- a/src/module/data/migrations.mjs
+++ b/src/module/data/migrations.mjs
@@ -77,7 +77,7 @@ async function version_0_8_migration() {
   for (const pack of packsToMigrate) {
     console.log("Migrating document inside", pack.title);
     await pack.getDocuments();
-    const wasLocked = pack.config.locked;
+    const wasLocked = pack.locked;
     if (wasLocked) await pack.configure({ locked: false });
     await migrateType(pack, { pack: pack.collection });
     if (pack.documentName === "Actor") {
@@ -135,7 +135,7 @@ async function version_0_11_migration() {
   for (const pack of packsToMigrate) {
     console.log("Migrating document inside", pack.title);
     const docs = await pack.getDocuments();
-    const wasLocked = pack.config.locked;
+    const wasLocked = pack.locked;
     if (wasLocked) await pack.configure({ locked: false });
     for (const doc of docs) await migrateChanges(doc);
     if (wasLocked) await pack.configure({ locked: true });
@@ -186,7 +186,7 @@ async function version_1_0_migration() {
   for (const pack of packsToMigrate) {
     console.log("Migrating document inside", pack.title);
     const docs = await pack.getDocuments();
-    const wasLocked = pack.config.locked;
+    const wasLocked = pack.locked;
     if (wasLocked) await pack.configure({ locked: false });
     const operation = [];
     docs.forEach(doc => migrateEffectSystem(doc, operation));
@@ -232,7 +232,7 @@ async function version_1_1_migration() {
   const packsToMigrate = game.packs.filter(p => shouldMigrateCompendium(p, ["Actor", "Item"]));
   for (const pack of packsToMigrate) {
     console.log("Migrating document inside", pack.title);
-    const wasLocked = pack.config.locked;
+    const wasLocked = pack.locked;
     if (wasLocked) await pack.configure({ locked: false });
     if (pack.documentName === "Actor") {
       await pack.getDocuments();


### PR DESCRIPTION
I'm surprised this somehow hadn't come up before, but `pack.config.locked` can be undefined which is *not* the kind of falsey we want here.

Reproduction: Have a locked module compendium that has *never* been unlocked in this world.