### PR TITLE
Add armor imbues

### DIFF
--- a/src/packs/abilities/Folder_Imbue_Abilities_QO11CRTmxkZAdUpB.json
+++ b/src/packs/abilities/Folder_Imbue_Abilities_QO11CRTmxkZAdUpB.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Imbue Abilities",
+  "color": null,
+  "sorting": "a",
+  "_id": "QO11CRTmxkZAdUpB",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784053014492,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!QO11CRTmxkZAdUpB"
+}

--- a/src/packs/abilities/Imbue_Abilities_QO11CRTmxkZAdUpB/ability_Dragon_s_Fire_dKIgDPPN5qIo4sXD.json
+++ b/src/packs/abilities/Imbue_Abilities_QO11CRTmxkZAdUpB/ability_Dragon_s_Fire_dKIgDPPN5qIo4sXD.json
@@ -1,0 +1,120 @@
+{
+  "folder": "QO11CRTmxkZAdUpB",
+  "name": "Dragon's Fire",
+  "type": "ability",
+  "_id": "dKIgDPPN5qIo4sXD",
+  "img": "icons/magic/fire/projectile-wave-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "dragons-fire",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You open your maw and unleash hell",
+    "keywords": [
+      "area",
+      "magic"
+    ],
+    "type": "main",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "line",
+      "primary": "5",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemy",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "might",
+          "agility",
+          "reason",
+          "intuition",
+          "presence"
+        ]
+      },
+      "effects": {
+        "UuYG5FI8HSq2IyVT": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "UuYG5FI8HSq2IyVT",
+          "damage": {
+            "tier1": {
+              "value": "5",
+              "types": [
+                "fire"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "8",
+              "types": [
+                "fire"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "11",
+              "types": [
+                "fire"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {},
+    "spend": {
+      "text": ""
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784053035735,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!dKIgDPPN5qIo4sXD"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Awe_9qJqVph1Jn1qsYIO.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Awe_9qJqVph1Jn1qsYIO.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Awe",
+  "type": "base",
+  "_id": "9qJqVph1Jn1qsYIO",
+  "img": "icons/skills/social/intimidation-impressing.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A lock of hair from a fey, taken in amicable bargain for Charming or in violence for Threatening",
+      "source": "Texts or lore in Khelt",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you start this project, choose either Charming or Threatening. If you choose Charming, you gain an edge on Presence tests made to win other creatures over or make a good impression. If you choose Threatening, you gain an edge on Presence tests made to intimidate, coerce, or bully.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049429736,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!9qJqVph1Jn1qsYIO"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Damage_Immunity_I_clFkDLc4oQbhaIvN.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Damage_Immunity_I_clFkDLc4oQbhaIvN.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Damage Immunity I",
+  "type": "base",
+  "_id": "clFkDLc4oQbhaIvN",
+  "img": "icons/magic/defensive/shield-barrier-flaming-pentagon-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Elemental sand left behind when an elemental enters Orden from Quintessence",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you start this project, select three damage types. You have immunity 5 to those damage types.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049607310,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!clFkDLc4oQbhaIvN"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Disguise_7DkrlU03EOtviym4.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Disguise_7DkrlU03EOtviym4.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Disguise",
+  "type": "base",
+  "_id": "7DkrlU03EOtviym4",
+  "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The blood of a lycanthrope",
+      "source": "Texts or lore in Khelt",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You can use a maneuver to cause this armor to take the form of any type of clothing that you have been in the presence of—a noble’s dress, a guard’s uniform, a cultist’s robes, and so forth. The armor loses none of its protective qualities while transformed into other clothing.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049661319,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!7DkrlU03EOtviym4"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Iridescent_x7FHbbyWrvEuR34U.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Iridescent_x7FHbbyWrvEuR34U.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Iridescent",
+  "type": "base",
+  "_id": "x7FHbbyWrvEuR34U",
+  "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Fur from a lightbender",
+      "source": "Texts or lore in Hyrallic",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you are the sole target of an ability, you can use a free triggered action to reveal that the ability was targeting an afterimage of you in the same space as you. The power roll for the ability is treated as an 11. You can’t use this enhancement again until you earn 1 or more Victories.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049704935,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!x7FHbbyWrvEuR34U"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Magic_Resistance_I_JvIG4XmL0LTkddEX.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Magic_Resistance_I_JvIG4XmL0LTkddEX.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Magic Resistance I",
+  "type": "base",
+  "_id": "JvIG4XmL0LTkddEX",
+  "img": "icons/magic/defensive/shield-barrier-glowing-triangle-blue-yellow.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A scale from a dragon",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your characteristic scores are treated as 1 higher (to a maximum of 2) for the purpose of resisting the potencies of magic abilities.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049755771,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!JvIG4XmL0LTkddEX"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Nettlebloom_8KX0Lp2UhfGJBDNJ.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Nettlebloom_8KX0Lp2UhfGJBDNJ.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Nettlebloom",
+  "type": "base",
+  "_id": "8KX0Lp2UhfGJBDNJ",
+  "img": "icons/magic/acid/projectile-bolts-salvo-green.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A rose from the magical hedge of a hag",
+      "source": "Texts or lore in Khelt",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you are grabbed by an adjacent creature, your armor sprouts toxic nettles. While that creature has you grabbed, they are weakened.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049979372,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!8KX0Lp2UhfGJBDNJ"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Phasing_I_FWNPzgZK2iEzDjrU.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Phasing_I_FWNPzgZK2iEzDjrU.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Phasing I",
+  "type": "base",
+  "_id": "FWNPzgZK2iEzDjrU",
+  "img": "icons/creatures/magical/spirit-undead-ghost-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Ichor from a destroyed wraith",
+      "source": "Texts or lore in Szetch",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 15
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Once per turn, you can move through 1 square of solid matter. If you end your turn inside solid matter, you are forced out into the space from which you entered it and you take [[/damage 5]] damage that can’t be reduced in any way.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050023684,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!FWNPzgZK2iEzDjrU"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Psionic_Resistance_I_W2XdjC0XxWCwDmFu.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Psionic_Resistance_I_W2XdjC0XxWCwDmFu.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Psionic Resistance I",
+  "type": "base",
+  "_id": "W2XdjC0XxWCwDmFu",
+  "img": "icons/magic/control/energy-stream-link-white.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Rare crystals that resonate with psionic energy, often found at sites of psionic experimentation",
+      "source": "Texts or lore in Voll",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your characteristic scores are treated as 1 higher (to a maximum of 2) for the purpose of resisting the potencies of psionic abilities.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050118162,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!W2XdjC0XxWCwDmFu"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Swift_VJqsEvDj7Ll84Z7z.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Swift_VJqsEvDj7Ll84Z7z.json
@@ -1,0 +1,64 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Swift",
+  "type": "base",
+  "_id": "VJqsEvDj7Ll84Z7z",
+  "img": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.movement.value",
+        "type": "add",
+        "value": 1,
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The feather of a falcon slain as it was diving",
+      "source": "Texts or lore in Yllyric",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You gain a +1 bonus to speed</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050518105,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!VJqsEvDj7Ll84Z7z"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Tempest_I_0gu9Fv1O5wWR7myM.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/1st_Level_Enhancements_SYvBVq7DlRpAzqcl/ActiveEffect_Tempest_I_0gu9Fv1O5wWR7myM.json
@@ -1,0 +1,56 @@
+{
+  "folder": "SYvBVq7DlRpAzqcl",
+  "name": "Tempest I",
+  "type": "base",
+  "_id": "0gu9Fv1O5wWR7myM",
+  "img": "icons/magic/lightning/bolt-forked-teal-purple.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A strip of starmetal struck by lightning",
+      "source": "Texts or lore in Ullorvic",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>As a maneuver, you infuse this armor with the essence of a storm. The first time an adjacent creature deals damage to you before the end of your next turn, they take [[/damage @chr lightning]]{lightning damage} equal to your highest characteristic score and you can push them 1 square.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050630788,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!0gu9Fv1O5wWR7myM"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Absorbtion_PkhLsBiCoWP8h474.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Absorbtion_PkhLsBiCoWP8h474.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Absorbtion",
+  "type": "base",
+  "_id": "PkhLsBiCoWP8h474",
+  "img": "icons/magic/defensive/barrier-shield-dome-deflect-teal.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A mirror blessed by a priest of a god of magic",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you are targeted by a magic or psionic ability that targets only one creature, you can use a free triggered action to cause this armor to absorb the ability after the ability’s effects resolve. While the armor has an ability absorbed, you can’t absorb another. You can use an absorbed ability as if you knew it, making power rolls for the ability using your choice of Reason, Intuition, or Presence. You don’t need to spend any Heroic Resource to activate the ability. Once you use the ability, the armor loses it, and you can absorb another.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050802699,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!PkhLsBiCoWP8h474"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Damage_Immunity_II_Y26DqU9fQJAhRg4H.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Damage_Immunity_II_Y26DqU9fQJAhRg4H.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Damage Immunity II",
+  "type": "base",
+  "_id": "Y26DqU9fQJAhRg4H",
+  "img": "icons/magic/defensive/shield-barrier-flaming-pentagon-red.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The essence of an elemental who is still alive",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>The damage immunity conveyed by the armor increases to 10.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050807809,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!Y26DqU9fQJAhRg4H"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Dragon_Soul_DrJvzz4V5hWAv1In.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Dragon_Soul_DrJvzz4V5hWAv1In.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Dragon Soul",
+  "type": "base",
+  "_id": "DrJvzz4V5hWAv1In",
+  "img": "icons/magic/fire/beam-strike-whip-red.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A scale from a dead dragon",
+      "source": "Texts or lore in Vastariax",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When another creature causes you to be winded or dying, you can use a free triggered action to cause the soul of a dragon to emerge from this armor and hurtle toward the creature. Make the following power roll against the creature.</p><p></p><p><strong>Power Roll + [[lookup @chr]]{Your Highest Characteristic}</strong></p><dl class=\"power-roll-display\"><dt class=\"tier1\"><p>!</p></dt><dd><p>[[/damage 8]] damage; push 3</p></dd><dt class=\"tier2\"><p>@</p></dt><dd><p>[[/damage 12]] damage; push 4;</p></dd><dt class=\"tier3\"><p>#</p></dt><dd><p>[[/damage 15]] damage; push 5</p></dd></dl>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050811386,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!DrJvzz4V5hWAv1In"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Levitating_J9K3VvkKJhtaKRcQ.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Levitating_J9K3VvkKJhtaKRcQ.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Levitating",
+  "type": "base",
+  "_id": "J9K3VvkKJhtaKRcQ",
+  "img": "icons/magic/control/debuff-energy-snare-purple-pink.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A palm-sized crystal grown in the subterranean lair of an overmind",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>On your turn, you can treat up to 5 consecutive squares of movement as flying movement. If you are still in midair at the end of your turn, you fall prone.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050818669,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!J9K3VvkKJhtaKRcQ"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Magic_Resistance_II_KuVc8w9WAJcYvxxT.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Magic_Resistance_II_KuVc8w9WAJcYvxxT.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Magic Resistance II",
+  "type": "base",
+  "_id": "KuVc8w9WAJcYvxxT",
+  "img": "icons/magic/defensive/shield-barrier-glowing-triangle-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A scale from a mature dragon",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your characteristic scores are treated as 2 higher (to a maximum of 3) for the purpose of resisting the potencies of magic abilities. This benefit replaces Magic Resistance I.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050824704,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!KuVc8w9WAJcYvxxT"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Phasing_II_jpBMwH0kfDqVld7u.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Phasing_II_jpBMwH0kfDqVld7u.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Phasing II",
+  "type": "base",
+  "_id": "jpBMwH0kfDqVld7u",
+  "img": "icons/creatures/magical/spirit-undead-horned-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The remnants of a slain ooze",
+      "source": "Texts or lore in Szetch",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you use the armor’s Phasing I enhancement, you can move through 3 squares of solid matter per turn.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050830145,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!jpBMwH0kfDqVld7u"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Psionic_Resistance_II_YDNGn7jTJal9tgWJ.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Psionic_Resistance_II_YDNGn7jTJal9tgWJ.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Psionic Resistance II",
+  "type": "base",
+  "_id": "YDNGn7jTJal9tgWJ",
+  "img": "icons/magic/control/energy-stream-link-teal.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A fresh crystalline scale from a gemstone dragon",
+      "source": "Texts or lore in Voll",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your characteristic scores are treated as 2 higher (to a maximum of 3) for the purpose of resisting the potencies of psionic abilities. This benefit replaces Psionic Resistance I.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050837016,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!YDNGn7jTJal9tgWJ"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Reactive_Hjtz1NmJCpXxqz01.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Reactive_Hjtz1NmJCpXxqz01.json
@@ -1,0 +1,64 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Reactive",
+  "type": "base",
+  "_id": "Hjtz1NmJCpXxqz01",
+  "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.damage.immunity.all",
+        "type": "add",
+        "value": 2,
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A complex, hand-engineered set of brass gears inscribed with runes in silver dust",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": "turnEnd",
+    "expired": false
+  },
+  "description": "<p>Whenever you take damage, you have damage immunity 2 until the end of your next turn after the triggering damage is resolved.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050839650,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!Hjtz1NmJCpXxqz01"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Second_Wind_6oNQoA1zG5xtq3Ux.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Second_Wind_6oNQoA1zG5xtq3Ux.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Second Wind",
+  "type": "base",
+  "_id": "6oNQoA1zG5xtq3Ux",
+  "img": "icons/magic/life/heart-cross-green.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The sweat of a troll",
+      "source": "Texts or lore in Kalliak",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you become winded, you can use a free triggered action to spend a Recovery.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050843515,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!6oNQoA1zG5xtq3Ux"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Shattering_HYkVWALaj28gvO0L.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Shattering_HYkVWALaj28gvO0L.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Shattering",
+  "type": "base",
+  "_id": "HYkVWALaj28gvO0L",
+  "img": "icons/magic/sonic/explosion-shock-wave-teal.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A pound of volcanic obsidian, formed naturally as a single piece",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever an enemy scores a critical hit against you, they take [[/damage 10 sonic]] damage.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050846589,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!HYkVWALaj28gvO0L"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Tempest_II_3GinMF9GKjKg9KI9.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/5th_Level_Enhancements_m2T7SybTqyi3IkGh/ActiveEffect_Tempest_II_3GinMF9GKjKg9KI9.json
@@ -1,0 +1,56 @@
+{
+  "folder": "m2T7SybTqyi3IkGh",
+  "name": "Tempest II",
+  "type": "base",
+  "_id": "3GinMF9GKjKg9KI9",
+  "img": "icons/magic/lightning/bolts-forked-large-teal-purple.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The armor must be laid out under a clear sky as a comet passes over",
+      "source": "Texts or lore in Ullorvic",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you use the armor’s Tempest I enhancement, the affected creature takes [[/damage 8 lightning]] damage and you push them up to 3 squares.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784050851504,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!3GinMF9GKjKg9KI9"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Devil_s_Bargain_xbTXlHYTKDThJVtc.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Devil_s_Bargain_xbTXlHYTKDThJVtc.json
@@ -1,0 +1,64 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Devil's Bargain",
+  "type": "base",
+  "_id": "xbTXlHYTKDThJVtc",
+  "img": "icons/magic/control/fear-fright-monster-grin-red-orange.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.movement.types",
+        "type": "add",
+        "value": "fly",
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The wing of an archdevil",
+      "source": "Texts or lore in Anjali",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You can fly. Additionally, if an effect would make you prone while flying, you can choose to not go prone by losing Stamina equal to the distance you would have fallen from becoming prone</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051054189,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!xbTXlHYTKDThJVtc"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Dragon_Soul_II_6YDJHkuyXVKXqfFo.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Dragon_Soul_II_6YDJHkuyXVKXqfFo.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Dragon Soul II",
+  "type": "base",
+  "_id": "6YDJHkuyXVKXqfFo",
+  "img": "icons/creatures/abilities/dragon-fire-breath-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "An offering of gems, coins, and art stolen from a dragon’s hoard, sacrificed in ritual fire",
+      "source": "Texts or lore in Vastariax",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>While you are winded, your head transforms into a dragon’s head and you have the following ability.</p><p></p><p>@Embed[Compendium.draw-steel.abilities.Item.dKIgDPPN5qIo4sXD]{Dragon's Fire}</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051050596,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!6YDJHkuyXVKXqfFo"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Invulnerable_RrWEAN8vdciX1c7z.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Invulnerable_RrWEAN8vdciX1c7z.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Invulnerable",
+  "type": "base",
+  "_id": "RrWEAN8vdciX1c7z",
+  "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Repurposed metal plates from a servok war engine",
+      "source": "Texts or lore in Rallarian",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When an ability roll made against you obtains a tier 1 outcome, you can ignore its damage and effects.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051047020,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!RrWEAN8vdciX1c7z"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Leyline_Walker_O4n5fZCNG8vlNNan.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Leyline_Walker_O4n5fZCNG8vlNNan.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Leyline Walker",
+  "type": "base",
+  "_id": "O4n5fZCNG8vlNNan",
+  "img": "icons/skills/movement/portal-silhouette-pink.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A cutting from an ethereal tree that manifests in the mundane world only once a year",
+      "source": "Texts or lore in Yllyric",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Once per turn as a move action, you can spend any amount of your movement to instead teleport that distance.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051042867,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!O4n5fZCNG8vlNNan"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Life_RiIRvrp9YgDfyiRO.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Life_RiIRvrp9YgDfyiRO.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Life",
+  "type": "base",
+  "_id": "RiIRvrp9YgDfyiRO",
+  "img": "icons/magic/life/heart-cross-strong-green.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The tear of a saint",
+      "source": "Texts or lore in High Kuric",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you would die, you can spend a Recovery to regain Stamina instead. If you have no Recoveries to spend, you die.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051038899,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!RiIRvrp9YgDfyiRO"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Magic_Resistance_III_AulQw9KHPqb0GYd1.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Magic_Resistance_III_AulQw9KHPqb0GYd1.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Magic Resistance III",
+  "type": "base",
+  "_id": "AulQw9KHPqb0GYd1",
+  "img": "icons/magic/defensive/shield-barrier-glowing-triangle-magenta.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A scale from an ancient dragon",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>The benefit of the armor’s Magic Resistance II enhancement extends to each ally within 3 squares of you.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051036547,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!AulQw9KHPqb0GYd1"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Phasing_III_d1lwghRDnrk51ViF.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Phasing_III_d1lwghRDnrk51ViF.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Phasing III",
+  "type": "base",
+  "_id": "d1lwghRDnrk51ViF",
+  "img": "icons/creatures/magical/spirit-undead-ghost-purple.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Perfectly clear glass from a house that disappeared into the Ethereal Plane",
+      "source": "Texts or lore in Szetch",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your movement doesn’t provoke opportunity attacks, and you can move through the space of any enemy as if they were an ally. You can’t end your turn in an enemy’s space.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051031423,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!d1lwghRDnrk51ViF"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Psionic_Resistance_III_W6FwCHcpqIMG6QPi.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Psionic_Resistance_III_W6FwCHcpqIMG6QPi.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Psionic Resistance III",
+  "type": "base",
+  "_id": "W6FwCHcpqIMG6QPi",
+  "img": "icons/magic/control/energy-stream-link-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The skull of a voiceless talker at least a century old",
+      "source": "Texts or lore in Voll",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>The benefit of the armor’s Psionic Resistance II enhancement extends to each ally within 3 squares of you.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051026190,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!W6FwCHcpqIMG6QPi"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Temporal_Flux_e9dpogjwJBpEekW1.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Temporal_Flux_e9dpogjwJBpEekW1.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Temporal Flux",
+  "type": "base",
+  "_id": "e9dpogjwJBpEekW1",
+  "img": "icons/magic/time/clock-spinning-gold-pink.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "An experimental temporal capacitor invented by the kuran’zoi",
+      "source": "Texts or lore in Voll",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you move out of a square, you can choose to leave an imprint behind that lasts until the end of the encounter, until your imprint takes 20 or more damage, or until you create a new imprint. The square is occupied by your imprint, and you can share that space with it.</p><p>On your turn, you can teleport to the imprint’s space as a free maneuver. When you are targeted by an ability, you can use a free triggered action to teleport to your imprint, and the power roll for the ability is an automatic tier 1 result.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051018712,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!e9dpogjwJBpEekW1"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Unbending_xFXgcxSmtUDQibIY.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/9th_Level_Enhancements_7fxhy1vmS95SoAkX/ActiveEffect_Unbending_xFXgcxSmtUDQibIY.json
@@ -1,0 +1,56 @@
+{
+  "folder": "7fxhy1vmS95SoAkX",
+  "name": "Unbending",
+  "type": "base",
+  "_id": "xFXgcxSmtUDQibIY",
+  "img": "icons/magic/defensive/shield-barrier-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A spearhead or other weapon broken off in the body of a stone giant, and ossified for a year or more",
+      "source": "Texts or lore in High Kuric",
+      "rollCharacteristic": [
+        "might",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "armor",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You can’t be subjected to forced movement unless you choose to be. Effects that ignore Stability also ignore this enhancement.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784051014790,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!xFXgcxSmtUDQibIY"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/Folder_1st_Level_Enhancements_SYvBVq7DlRpAzqcl.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/Folder_1st_Level_Enhancements_SYvBVq7DlRpAzqcl.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "eN4n9PMnd8MMNKoA",
+  "name": "1st-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "SYvBVq7DlRpAzqcl",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049388769,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!SYvBVq7DlRpAzqcl"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/Folder_5th_Level_Enhancements_m2T7SybTqyi3IkGh.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/Folder_5th_Level_Enhancements_m2T7SybTqyi3IkGh.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "eN4n9PMnd8MMNKoA",
+  "name": "5th-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "m2T7SybTqyi3IkGh",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049402993,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!m2T7SybTqyi3IkGh"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/Folder_9th_Level_Enhancements_7fxhy1vmS95SoAkX.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Armor_eN4n9PMnd8MMNKoA/Folder_9th_Level_Enhancements_7fxhy1vmS95SoAkX.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "eN4n9PMnd8MMNKoA",
+  "name": "9th-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "7fxhy1vmS95SoAkX",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784049412967,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!7fxhy1vmS95SoAkX"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/Folder_1st_Level_Enhancements_mAAYeJQwJ1uSvQDd.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/Folder_1st_Level_Enhancements_mAAYeJQwJ1uSvQDd.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "Q6Arn46SjeZosJn4",
+  "name": "1st-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "mAAYeJQwJ1uSvQDd",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784055070544,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!mAAYeJQwJ1uSvQDd"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/Folder_5th_Level_Enhancements_e462NGchDmoZEaAv.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/Folder_5th_Level_Enhancements_e462NGchDmoZEaAv.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "Q6Arn46SjeZosJn4",
+  "name": "5th-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "e462NGchDmoZEaAv",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784055078963,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!e462NGchDmoZEaAv"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/Folder_9th_Level_Enhancements_FrguB8NIFAPPKCf1.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/Folder_9th_Level_Enhancements_FrguB8NIFAPPKCf1.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "Q6Arn46SjeZosJn4",
+  "name": "9th-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "FrguB8NIFAPPKCf1",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784055086051,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!FrguB8NIFAPPKCf1"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Weapon_Sybb3vlDqvqmugHg/Folder_1st_Level_Enhancements_4kI4kB5hoFwNIQmQ.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Weapon_Sybb3vlDqvqmugHg/Folder_1st_Level_Enhancements_4kI4kB5hoFwNIQmQ.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "Sybb3vlDqvqmugHg",
+  "name": "1st-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "4kI4kB5hoFwNIQmQ",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784055100573,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!4kI4kB5hoFwNIQmQ"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Weapon_Sybb3vlDqvqmugHg/Folder_5th_Level_Enhancements_MHWKou3S66LDe9gA.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Weapon_Sybb3vlDqvqmugHg/Folder_5th_Level_Enhancements_MHWKou3S66LDe9gA.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "Sybb3vlDqvqmugHg",
+  "name": "5th-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "MHWKou3S66LDe9gA",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784055112647,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!MHWKou3S66LDe9gA"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Weapon_Sybb3vlDqvqmugHg/Folder_9th_Level_Enhancements_td54h74KX9zyJJnT.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Weapon_Sybb3vlDqvqmugHg/Folder_9th_Level_Enhancements_td54h74KX9zyJJnT.json
@@ -1,0 +1,23 @@
+{
+  "type": "ActiveEffect",
+  "folder": "Sybb3vlDqvqmugHg",
+  "name": "9th-Level Enhancements",
+  "color": null,
+  "sorting": "a",
+  "_id": "td54h74KX9zyJJnT",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784055118063,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!td54h74KX9zyJJnT"
+}


### PR DESCRIPTION
Adds the armor imbues in sub folders of 1st/5th/9th-Level Enhancements. I also added a folder in the Abilities compendium for "Imbue Abilities" for Dragon Soul II ability and the ones for Weapons later.