### PR TITLE
Forgot to remove spend despite migrating off of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ## 1.1.1
 
+### Removed
+
+- Removed `system.spend` from AbilityModel (all spend data was migrated to `system.effects` in 1.1.0)
+
 ### Fixed
 
 - Corrected handling of locked compendiums during system migration.

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -101,11 +101,6 @@ export default class AbilityModel extends BaseItemModel {
 
     schema.effects = new ds.data.fields.CollectionField(ds.data.pseudoDocuments.specialEffects.BaseSpecialEffect);
 
-    schema.spend = new fields.SchemaField({
-      value: new fields.NumberField({ integer: true }),
-      text: new fields.StringField({ required: true }),
-    });
-
     return schema;
   }
 


### PR DESCRIPTION
So... forgot to actually remove `system.spend` which is why it's still in the JSON data post-migration. Should be harmless with how the migration has been set up but after this is merged I'll do a compendium cleanup PR.