### PR TITLE
[#1982] Added Ancestry Malice ability category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@
 ### Added
 
 - New Player-Facing Compendium Content:
-  - Added Armor & Implement imbues to the Effects compendium
-- Added an "Ancestry Malice" category for abilities that are from a monster's ancestry, not from its unique statblock. Ancestry malice abilities are skipped in the actor embed unless the embed is supplied the `showAll=true` option.
+  - Added Armor, Implement, and Weapon imbues to the Effects compendium
+- Added an "Ancestry Malice" category for abilities that are from a monster's ancestry, not from its unique statblock. Ancestry malice abilities are skipped in the actor embed unless the embed is supplied the `showAll=true` option.  (#1982)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - New Player-Facing Compendium Content:
   - Added Armor & Implement imbues to the Effects compendium
-- Added an "Ancestry Malice" category for abilities which will be skipped by the embed. Using `showAllItems=true` in the embed call will include the abilities anyways.
+- Added an "Ancestry Malice" category for abilities that are from a monster's ancestry, not from its unique statblock. Ancestry malice abilities are skipped in the actor embed unless the embed is supplied the `showAll=true` option.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,16 @@
 
 ### Added
 
-- Setting the `draw-steel.embedDisplay.skip` flag to true marks a feature or ability not to be included in the parent actor embed. Using `showAllItems=true` in the embed call will include the item anyways. All ancestry-based monster malice abilities have been updated to have this flag.
+- New Player-Facing Compendium Content:
+  - Added Armor & Implement imbues to the Effects compendium
+- Added an "Ancestry Malice" category for abilities which will be skipped by the embed. Using `showAllItems=true` in the embed call will include the abilities anyways.
+
+### Changed
+
+- Updated Player-Facing Compendium Content:
+  - Updated Wodewalker Complication to use roll data instead of a fixed value. (#1988)
+  - Updated Revitalizing Ritual to provide an applied effect. (#1990)
+  - Updated the Adaptive Second Skin and Thief of Joy treasures to use roll data instead of fixed values.
 
 ### Removed
 
@@ -30,8 +39,11 @@
 
 ### Fixed
 
+- Player-Facing Compendium Data Fixes:
+  - Fixed typo in Paper Trappings treasure.
 - Potency enrichers now work again. (#1985)
 - Corrected handling of locked compendiums during system migration.
+- Corrected issue preventing project creation when the yield document is not provided.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ## 1.1.1
 
+### Added
+
+- Setting the `draw-steel.embedDisplay.skip` flag to true marks a feature or ability not to be included in the parent actor embed. Using `showAllItems=true` in the embed call will include the item anyways. All ancestry-based monster malice abilities have been updated to have this flag.
+
 ### Removed
 
 - Removed `system.spend` from AbilityModel (all spend data was migrated to `system.effects` in 1.1.0)

--- a/lang/en.json
+++ b/lang/en.json
@@ -1284,7 +1284,8 @@
           "Heroic": "Heroic Ability",
           "FreeStrike": "Free Strike",
           "Signature": "Signature Ability",
-          "Villain": "Villain Action"
+          "Villain": "Villain Action",
+          "MaliceAncestry": "Ancestry Malice Ability"
         },
         "Distance": {
           "Melee": "Melee",

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -23,7 +23,8 @@ This embed displays similarly as the statblocks in the book and contains the sam
   - "villain-action"
 - For Features, there isn't sufficient information in the data model to assign the icon using logic alone. Thus, Features default to using the "trait" (star) icon. If you wish to select the icon yourself, you must use the flag described above to override the icon.
 - In statblocks, some Features come at the beginning of the list, before Abilities, and others come at the end. Thus there is another flag option for Features, under the same namespace: `draw-steel.embedDisplay`, under the `displayAtEnd` property. This is a `Boolean` that exists on the Feature. Set it to `true` to put that Feature after the Abilities, rather than before. The order is otherwise retained.
-- You can set this flag on an item in Foundry via `item.setFlag("draw-steel", "embedDisplay", { iconOverride: "special", displayAtEnd: true  }`
+- You can set this flag on an item in Foundry via `item.setFlag("draw-steel", "embedDisplay", { iconOverride: "special", displayAtEnd: true  })`
+- Setting `embedDisplay.skip` to `true` will skip the item entirely unless you use `showAllItems=true` in the embed configuration (i.e. @Embed&ZeroWidthSpace;[uuid showAllItems=true])
 
 ## Item Embeds
 

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -24,7 +24,7 @@ This embed displays similarly as the statblocks in the book and contains the sam
 - For Features, there isn't sufficient information in the data model to assign the icon using logic alone. Thus, Features default to using the "trait" (star) icon. If you wish to select the icon yourself, you must use the flag described above to override the icon.
 - In statblocks, some Features come at the beginning of the list, before Abilities, and others come at the end. Thus there is another flag option for Features, under the same namespace: `draw-steel.embedDisplay`, under the `displayAtEnd` property. This is a `Boolean` that exists on the Feature. Set it to `true` to put that Feature after the Abilities, rather than before. The order is otherwise retained.
 - You can set this flag on an item in Foundry via `item.setFlag("draw-steel", "embedDisplay", { iconOverride: "special", displayAtEnd: true  })`
-- Abilities with the "Ancestry Malice" category will not be shown unless you use `showAllItems=true` in the embed configuration (i.e. @Embed&ZeroWidthSpace;[uuid showAllItems=true])
+- Abilities with the "Ancestry Malice" category will not be shown unless you use `showAll=true` in the embed configuration (i.e. @Embed&ZeroWidthSpace;[uuid showAll=true])
 
 ## Item Embeds
 

--- a/src/docs/Enrichers.md
+++ b/src/docs/Enrichers.md
@@ -24,7 +24,7 @@ This embed displays similarly as the statblocks in the book and contains the sam
 - For Features, there isn't sufficient information in the data model to assign the icon using logic alone. Thus, Features default to using the "trait" (star) icon. If you wish to select the icon yourself, you must use the flag described above to override the icon.
 - In statblocks, some Features come at the beginning of the list, before Abilities, and others come at the end. Thus there is another flag option for Features, under the same namespace: `draw-steel.embedDisplay`, under the `displayAtEnd` property. This is a `Boolean` that exists on the Feature. Set it to `true` to put that Feature after the Abilities, rather than before. The order is otherwise retained.
 - You can set this flag on an item in Foundry via `item.setFlag("draw-steel", "embedDisplay", { iconOverride: "special", displayAtEnd: true  })`
-- Setting `embedDisplay.skip` to `true` will skip the item entirely unless you use `showAllItems=true` in the embed configuration (i.e. @Embed&ZeroWidthSpace;[uuid showAllItems=true])
+- Abilities with the "Ancestry Malice" category will not be shown unless you use `showAllItems=true` in the embed configuration (i.e. @Embed&ZeroWidthSpace;[uuid showAllItems=true])
 
 ## Item Embeds
 

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1654,6 +1654,9 @@ const abilityCategories = {
   villain: {
     label: "DRAW_STEEL.Item.ability.Category.Villain",
   },
+  maliceAncestry: {
+    label: "DRAW_STEEL.Item.ability.Category.MaliceAncestry",
+  },
 };
 
 /**

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -264,7 +264,7 @@ export default class NPCModel extends CreatureModel {
     const abilityTypes = Object.keys(ds.CONFIG.abilities.types);
     return this.parent.items.documentsByType.ability
       // Ancestry malice do not show by default
-      .filter(i => config.showAllItems || (i.system.category !== "ancestryMalice"))
+      .filter(i => config.showAll || (i.system.category !== "ancestryMalice"))
       .sort((a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort);
   }
 

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -216,7 +216,7 @@ export default class NPCModel extends CreatureModel {
       actor: this.parent,
       characteristics: this._getCharacteristics(false),
       damageIW: this._getImmunitiesWeaknesses(),
-      itemEmbeds: await this._getItemEmbeds(),
+      itemEmbeds: await this._getItemEmbeds(config),
       monsterKeywords: this._getMonsterKeywords().join(", "),
       movement: this._getMovement(true).list,
       system: this,
@@ -237,11 +237,12 @@ export default class NPCModel extends CreatureModel {
 
   /**
    * Prepare embeds of Items for the NPC embed.
-   * @returns {Promise<DrawSteelItemEmbed[]>}
+   * @param {DocumentHTMLEmbedConfig} config  Configuration for embedding behavior.
+   * @returns {Promise<HTMLElement[]>}
    */
-  async _getItemEmbeds() {
-    const abilities = this._getOrderedAbilities();
-    const { startFeatures, endFeatures } = this._getOrderedFeatures();
+  async _getItemEmbeds(config) {
+    let abilities = this._getOrderedAbilities(config);
+    const { startFeatures, endFeatures } = this._getOrderedFeatures(config);
     const orderedItems = [...startFeatures, ...abilities, ...endFeatures];
 
     return Promise.all(orderedItems.map(async (item) => {
@@ -256,26 +257,30 @@ export default class NPCModel extends CreatureModel {
   /**
    * Orders Ability Items in the same order
    * as the keys in ds.CONFIG.abilities.types.
+   * @param {DocumentHTMLEmbedConfig} config  Configuration for embedding behavior.
    * @returns {DrawSteelItem[]}
    */
-  _getOrderedAbilities() {
+  _getOrderedAbilities(config) {
     const abilityTypes = Object.keys(ds.CONFIG.abilities.types);
-    return this.parent.items.documentsByType.ability.toSorted(
-      (a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort,
-    );
+    return this.parent.items.documentsByType.ability
+      .filter(i => config.showAllItems || !i.getFlag(systemID, "embedDisplay.skip"))
+      .sort((a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort);
   }
 
   /* -------------------------------------------------- */
 
   /**
    * Orders Feature Items via the `embedDisplay.displayAtEnd` flag.
+   * @param {DocumentHTMLEmbedConfig} config  Configuration for embedding behavior.
    * @returns {{ startFeatures: DrawSteelItem[], endFeatures: DrawSteelItem[] }}
    */
-  _getOrderedFeatures() {
-    const features = this.parent.items.documentsByType.feature.toSorted((a, b) => a.sort - b.sort);
+  _getOrderedFeatures(config) {
+    const features = this.parent.items.documentsByType.feature
+      .filter(i => config.showAllItems || !i.getFlag(systemID, "embedDisplay.skip"))
+      .sort((a, b) => a.sort - b.sort);
 
     const [ startFeatures, endFeatures ] = features.partition(f => {
-      return !!f.getFlag(ds.CONST.systemID, "embedDisplay.displayAtEnd");
+      return !!f.getFlag(systemID, "embedDisplay.displayAtEnd");
     });
     return { startFeatures, endFeatures };
   }

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -242,7 +242,7 @@ export default class NPCModel extends CreatureModel {
    */
   async _getItemEmbeds(config) {
     let abilities = this._getOrderedAbilities(config);
-    const { startFeatures, endFeatures } = this._getOrderedFeatures(config);
+    const { startFeatures, endFeatures } = this._getOrderedFeatures();
     const orderedItems = [...startFeatures, ...abilities, ...endFeatures];
 
     return Promise.all(orderedItems.map(async (item) => {
@@ -263,7 +263,8 @@ export default class NPCModel extends CreatureModel {
   _getOrderedAbilities(config) {
     const abilityTypes = Object.keys(ds.CONFIG.abilities.types);
     return this.parent.items.documentsByType.ability
-      .filter(i => config.showAllItems || !i.getFlag(systemID, "embedDisplay.skip"))
+      // Ancestry malice do not show by default
+      .filter(i => config.showAllItems || (i.system.category !== "ancestryMalice"))
       .sort((a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort);
   }
 
@@ -271,13 +272,10 @@ export default class NPCModel extends CreatureModel {
 
   /**
    * Orders Feature Items via the `embedDisplay.displayAtEnd` flag.
-   * @param {DocumentHTMLEmbedConfig} config  Configuration for embedding behavior.
    * @returns {{ startFeatures: DrawSteelItem[], endFeatures: DrawSteelItem[] }}
    */
-  _getOrderedFeatures(config) {
-    const features = this.parent.items.documentsByType.feature
-      .filter(i => config.showAllItems || !i.getFlag(systemID, "embedDisplay.skip"))
-      .sort((a, b) => a.sort - b.sort);
+  _getOrderedFeatures() {
+    const features = this.parent.items.documentsByType.feature.toSorted((a, b) => a.sort - b.sort);
 
     const [ startFeatures, endFeatures ] = features.partition(f => {
       return !!f.getFlag(systemID, "embedDisplay.displayAtEnd");

--- a/src/module/data/actor/npc.mjs
+++ b/src/module/data/actor/npc.mjs
@@ -264,7 +264,7 @@ export default class NPCModel extends CreatureModel {
     const abilityTypes = Object.keys(ds.CONFIG.abilities.types);
     return this.parent.items.documentsByType.ability
       // Ancestry malice do not show by default
-      .filter(i => config.showAll || (i.system.category !== "ancestryMalice"))
+      .filter(i => config.showAll || (i.system.category !== "maliceAncestry"))
       .sort((a, b) => abilityTypes.indexOf(a.system.type) - abilityTypes.indexOf(b.system.type) || a.sort - b.sort);
   }
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -343,7 +343,7 @@ export default class AbilityModel extends BaseItemModel {
    */
   getStatBlockIcon() {
     /** @type {EmbedDisplayFlags["iconOverride"]} */
-    const { iconOverride } = this.parent.getFlag(ds.CONST.systemID, "embedDisplay") ?? {};
+    const { iconOverride } = this.parent.getFlag(systemID, "embedDisplay") ?? {};
     if (iconOverride) return iconOverride;
 
     switch (this.type) {

--- a/src/module/documents/_types.d.ts
+++ b/src/module/documents/_types.d.ts
@@ -24,9 +24,9 @@ import {
   JournalEntryPage as JEPModels,
 } from "../data/_module.mjs";
 import { DrawSteelActiveEffect, DrawSteelCombatant, DrawSteelCombatantGroup, DrawSteelItem, DrawSteelJournalEntryPage, DrawSteelTokenDocument, DrawSteelWallDocument } from "./_module.mjs";
-import Collection from "@common/utils/collection.mjs";
-import { JournalEntryCategory } from "@client/documents/_module.mjs";
 import DrawSteelToken from "../canvas/placeables/token.mjs";
+import EmbeddedCollection from "@common/abstract/embedded-collection.mjs";
+import { JournalEntryCategory } from "@client/documents/_module.mjs";
 
 // Collator for the types
 type ActiveEffectModel = typeof ActiveEffectModels[keyof typeof ActiveEffectModels];
@@ -37,7 +37,7 @@ type CombatantGroupModel = typeof CombatantGroupModels[keyof typeof CombatantGro
 type JournalEntryPageModel = typeof JEPModels[keyof typeof JEPModels];
 
 type ClientDocument = ReturnType<typeof foundry.documents.abstract.ClientDocumentMixin>;
-type CanvasDocument = ReturnType<typeof foundry.documents.abstract.CanvasDocumentMixin>
+type CanvasDocument = ReturnType<typeof foundry.documents.abstract.CanvasDocumentMixin>;
 
 declare module "@client/documents/_module.mjs" {
   interface BaseActiveEffect<Model extends ActiveEffectModel = ActiveEffectModel> extends ActiveEffectData, InstanceType<ClientDocument> {
@@ -48,14 +48,14 @@ declare module "@client/documents/_module.mjs" {
   interface BaseActor<Model extends ActorModel = ActorModel> extends ActorData, InstanceType<ClientDocument> {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
-    items: Collection<string, DrawSteelItem>;
-    effects: Collection<string, DrawSteelActiveEffect>;
+    items: EmbeddedCollection<DrawSteelItem>;
+    effects: EmbeddedCollection<DrawSteelActiveEffect>;
   }
 
   interface BaseItem<Model extends ItemModel = ItemModel> extends ItemData, InstanceType<ClientDocument> {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
-    effects: Collection<string, DrawSteelActiveEffect>;
+    effects: EmbeddedCollection<DrawSteelActiveEffect>;
   }
   interface BaseChatMessage<Model extends MessageModel = MessageModel> extends ChatMessageData, InstanceType<ClientDocument> {
     type: Model["metadata"]["type"];
@@ -65,8 +65,8 @@ declare module "@client/documents/_module.mjs" {
   interface BaseCombat extends CombatData, InstanceType<ClientDocument> {
     type: "base";
     system: CombatModels.BaseCombatModel;
-    combatants: Collection<string, DrawSteelCombatant>;
-    groups: Collection<string, DrawSteelCombatantGroup>
+    combatants: EmbeddedCollection<DrawSteelCombatant>;
+    groups: EmbeddedCollection<DrawSteelCombatantGroup>
   }
 
   interface BaseCombatantGroup<Model extends CombatantGroupModel = CombatantGroupModel> extends CombatantGroupData, InstanceType<ClientDocument> {
@@ -80,8 +80,8 @@ declare module "@client/documents/_module.mjs" {
   }
 
   interface BaseJournalEntry extends JournalEntryData, InstanceType<ClientDocument> {
-    pages: Collection<string, DrawSteelJournalEntryPage>;
-    categories: Collection<string, JournalEntryCategory>;
+    pages: EmbeddedCollection<DrawSteelJournalEntryPage>;
+    categories: EmbeddedCollection<JournalEntryCategory>;
   }
 
   interface BaseJournalEntryPage<Model extends JournalEntryPageModel = JournalEntryPageModel> extends JournalEntryPageData, InstanceType<ClientDocument> {
@@ -90,11 +90,11 @@ declare module "@client/documents/_module.mjs" {
   }
 
   interface BaseScene extends SceneData, InstanceType<ClientDocument> {
-    tokens: Collection<string, DrawSteelTokenDocument>;
-    walls: Collection<string, DrawSteelWallDocument>;
+    tokens: EmbeddedCollection<DrawSteelTokenDocument>;
+    walls: EmbeddedCollection<DrawSteelWallDocument>;
   }
 
-  interface BaseToken extends TokenData, InstanceType<CanvasDocument>{
+  interface BaseToken extends TokenData, InstanceType<CanvasDocument> {
     object: DrawSteelToken;
   }
 


### PR DESCRIPTION
- Did some type updates now that EmbeddedCollection properly passes a generic back to Collection
- This allows us to better match the books, where ancestry-based malice abilities are displayed separately from the stat blocks.

Closes #1982