### PR TITLE
Fix project creation when yield document is not provided

### DIFF
--- a/src/module/data/item/project.mjs
+++ b/src/module/data/item/project.mjs
@@ -89,7 +89,7 @@ export default class ProjectModel extends BaseItemModel {
     // If creating with a doment UUID, transfer the document's project data to the project item.
     const uuid = data.system?.yield?.document;
     const yieldDocument = await fromUuid(uuid);
-    if ((yieldDocument?.type === "treasure") || (yieldDocument.documentName === "ActiveEffect")) {
+    if (yieldDocument && ((yieldDocument.type === "treasure") || (yieldDocument.documentName === "ActiveEffect"))) {
       const { prerequisites, rollCharacteristic, goal, source } = yieldDocument.system.project;
       this.parent.updateSource({
         img: yieldDocument.img,


### PR DESCRIPTION
Optional chaining wasn't provided on the yieldDocument check for AE, so it would error out if creating a project without that.