### PR TITLE
Add imbue implement AEs

### DIFF
--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Berserking_3i8dKeZERwi4mcyC.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Berserking_3i8dKeZERwi4mcyC.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Berserking",
+  "type": "base",
+  "_id": "3i8dKeZERwi4mcyC",
+  "img": "icons/creatures/abilities/bear-roar-bite-brown-green.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The tusk of a feral boar",
+      "source": "Texts or lore in Kalliak",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you damage a creature using a magic or psionic ability and obtain a tier 3 outcome, that creature must make an opportunity attack against their nearest ally if possible after the ability’s effects resolve. This strike deals extra damage equal to [[lookup \"max(@R, @I, @P)\" evaluate]]{the highest of your Reason, Intuition, or Presence scores}.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235953908,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!3i8dKeZERwi4mcyC"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Displacing_I_AvzOmAS0Ys5soowh.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Displacing_I_AvzOmAS0Ys5soowh.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Displacing I",
+  "type": "base",
+  "_id": "AvzOmAS0Ys5soowh",
+  "img": "icons/magic/control/debuff-energy-snare-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Slime from an ooze",
+      "source": "Texts or lore in Khelt",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you damage a creature using a magic or psionic ability and obtain a tier 3 outcome, you can teleport that creature up to 2 squares after the ability’s effects resolve. If the creature started on a horizontal surface, they must end on a horizontal surface.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235950370,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!AvzOmAS0Ys5soowh"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Elemental_FtqWaoiWVlRCrSPK.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Elemental_FtqWaoiWVlRCrSPK.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Elemental",
+  "type": "base",
+  "_id": "FtqWaoiWVlRCrSPK",
+  "img": "icons/magic/symbols/elements-air-earth-fire-water.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Ashes or other leavings from a natural disaster",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use an ability with the Air, Earth, Fire, Green, Rot, Void, or Water keyword, you can attune this implement to that element until the end of the encounter. While the implement is attuned, you gain an edge on power rolls with that elemental keyword. The implement can be attuned to only one element at a time.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235945973,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!FtqWaoiWVlRCrSPK"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Forceful_I_siITULb6w9N3gpX0.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Forceful_I_siITULb6w9N3gpX0.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Forceful I",
+  "type": "base",
+  "_id": "siITULb6w9N3gpX0",
+  "img": "icons/magic/control/energy-stream-link-spiral-white.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A lead slingstone that killed a giant",
+      "source": "Texts or lore in High Kuric",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use a magic or psionic ability to push or pull a creature, you can move that creature an additional 2 squares.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235943301,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!siITULb6w9N3gpX0"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Rat_Form_VUMxHYSO4AxmkCWV.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Rat_Form_VUMxHYSO4AxmkCWV.json
@@ -1,0 +1,85 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Rat Form",
+  "type": "base",
+  "_id": "VUMxHYSO4AxmkCWV",
+  "img": "icons/creatures/mammals/rodent-rat-green.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.combat.size.letter",
+        "type": "override",
+        "value": "T",
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.movement.value",
+        "type": "override",
+        "value": 5,
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.movement.types",
+        "type": "add",
+        "value": "climb",
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.characteristics.might.value",
+        "type": "override",
+        "value": -5,
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "One hundred rat pelts",
+      "source": "Texts or lore in Khamish",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": true,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>As a maneuver, you transform into a rat. Your equipment transforms with you. As a rat, you have speed 5 and can automatically climb at full speed while moving, your size is 1T, and you can see in the dark. You can speak and keep your skills while in rat form, but your Might is −5 and you lose all your regular abilities, features, and benefits. You can revert to your natural form as a maneuver, and do so automatically if you take any damage.</p><p></p><p>[[/apply VUMxHYSO4AxmkCWV]]</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235939708,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!VUMxHYSO4AxmkCWV"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Rejuvenating_I_JKKwQs0RSEhI1ly8.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Rejuvenating_I_JKKwQs0RSEhI1ly8.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Rejuvenating I",
+  "type": "base",
+  "_id": "JKKwQs0RSEhI1ly8",
+  "img": "icons/magic/symbols/runes-star-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A singing quartz crystal",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use an ability that costs 1 or more of your Heroic Resource, roll a [[/r d10]]. On a 9 or higher, you gain 1 Heroic Resource.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235936664,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!JKKwQs0RSEhI1ly8"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Seeking_JkJG7WC4LKyfie5R.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Seeking_JkJG7WC4LKyfie5R.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Seeking",
+  "type": "base",
+  "_id": "JkJG7WC4LKyfie5R",
+  "img": "icons/magic/perception/eye-tendrils-web-purple.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "An inch-long needle carved from a diamond",
+      "source": "Texts or lore in Caelian",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your ranged magic or psionic abilities gain a +2 distance bonus. Additionally, if you think the name of a specific creature, place, or object to the implement, the implement points toward that target, provided you are on the same world.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784237207150,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!JkJG7WC4LKyfie5R"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Thought_Sending_VDneNR7wRbVgvAns.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Thought_Sending_VDneNR7wRbVgvAns.json
@@ -1,0 +1,56 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Thought Sending",
+  "type": "base",
+  "_id": "VDneNR7wRbVgvAns",
+  "img": "icons/magic/holy/meditation-chi-focus-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The brain of a psionic creature",
+      "source": "Texts or lore in Variac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your ranged magic and psionic abilities gain a +2 distance bonus. Additionally, you can telepathically communicate with any willing creature who knows a language and whose name you know, provided they are on the same world as you. You must initiate the conversation, but once you do, the creature can respond until you end the conversation.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235932142,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!VDneNR7wRbVgvAns"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Warding_I_hHFdPGQgiMXRjmbs.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/1st_Level_Enhancements_mAAYeJQwJ1uSvQDd/ActiveEffect_Warding_I_hHFdPGQgiMXRjmbs.json
@@ -1,0 +1,64 @@
+{
+  "folder": "mAAYeJQwJ1uSvQDd",
+  "name": "Warding I",
+  "type": "base",
+  "_id": "hHFdPGQgiMXRjmbs",
+  "img": "icons/magic/life/heart-cross-strong-flame-blue.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.stamina.bonuses.treasure",
+        "type": "upgrade",
+        "value": 6,
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Three skulls from the same chimera",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>You gain a +6 bonus to Stamina.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235927380,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!hHFdPGQgiMXRjmbs"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Celerity_Z4UEe2nRQ3GDhAMe.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Celerity_Z4UEe2nRQ3GDhAMe.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Celerity",
+  "type": "base",
+  "_id": "Z4UEe2nRQ3GDhAMe",
+  "img": "icons/skills/movement/figure-running-gray.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A dire falcon’s beak",
+      "source": "Texts or lore in Khelt",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Immediately after using a magic or psionic ability that requires a main action, you can shift up to 3 squares, or you can use the Escape Grab maneuver as a free maneuver.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235896065,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!Z4UEe2nRQ3GDhAMe"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Celestine_6PJTdlhlrwQb4Alc.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Celestine_6PJTdlhlrwQb4Alc.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Celestine",
+  "type": "base",
+  "_id": "6PJTdlhlrwQb4Alc",
+  "img": "icons/magic/light/projectile-stars-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A still-warm piece of a meteorite",
+      "source": "Texts or lore in Ullorvic",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>As a main action, you conjure up to three stars, which hover in unoccupied squares of your choice within 5 squares of you. The stars remain in place, and disappear if you create more stars. When an enemy enters any star’s space, the star detonates and is destroyed, and the enemy takes [[/damage 10 fire]] damage. If you have line of effect to the enemy, you can also slide them 1 square. Otherwise, the enemy slides 1 square in a random direction.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235890229,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!6PJTdlhlrwQb4Alc"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Displacing_II_a4Bwlu6gxwIO3j9k.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Displacing_II_a4Bwlu6gxwIO3j9k.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Displacing II",
+  "type": "base",
+  "_id": "a4Bwlu6gxwIO3j9k",
+  "img": "icons/magic/control/debuff-energy-snare-green.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The wing of a pixie",
+      "source": "Texts or lore in Voll",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you use the implement’s Displacing I enhancement, you can teleport the creature up to 4 squares. Additionally, the creature takes a bane on their next power roll made before the end of their next turn.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235887432,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!a4Bwlu6gxwIO3j9k"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Erupting_I_kKb78oOv6mpjD8OC.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Erupting_I_kKb78oOv6mpjD8OC.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Erupting I",
+  "type": "base",
+  "_id": "kKb78oOv6mpjD8OC",
+  "img": "icons/magic/fire/explosion-fireball-medium-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Obsidian from an active volcano",
+      "source": "Texts or lore in Vastariax",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you damage a creature using a magic or psionic ability that targets only a single creature and obtain a tier 3 outcome, each enemy within 2 squares of the creature takes [[/damage 3 fire]] damage after the ability’s effects resolve</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235856130,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!kKb78oOv6mpjD8OC"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Forceful_II_zJZpOaDk3QWgLlW5.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Forceful_II_zJZpOaDk3QWgLlW5.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Forceful II",
+  "type": "base",
+  "_id": "zJZpOaDk3QWgLlW5",
+  "img": "icons/magic/control/energy-stream-link-spiral-teal.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A marble stone giant’s fingernail",
+      "source": "Texts or lore in High Kuric",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use a magic or psionic ability to push or pull a creature, you can move that creature an additional 3 squares. This replaces the benefit of Forceful I.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235922876,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!zJZpOaDk3QWgLlW5"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Hallucinatory_gc85rzcmDreUgLL2.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Hallucinatory_gc85rzcmDreUgLL2.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Hallucinatory",
+  "type": "base",
+  "_id": "gc85rzcmDreUgLL2",
+  "img": "icons/magic/control/silhouette-hold-beam-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A night hag’s hairpin",
+      "source": "Texts or lore in Variac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>As a maneuver, you create an area of sensory instability in a 2 aura centered on yourself. The area is difficult terrain for your enemies until the end of the encounter.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235861836,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!gc85rzcmDreUgLL2"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Lingering_I_LJrSxjwbqHPEgw92.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Lingering_I_LJrSxjwbqHPEgw92.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Lingering I",
+  "type": "base",
+  "_id": "LJrSxjwbqHPEgw92",
+  "img": "icons/magic/control/voodoo-doll-pain-damage-pink.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Slow-acting poison refined from rare fungi",
+      "source": "Texts or lore in Szetch",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you damage a creature using a magic or psionic ability and obtain a tier 3 outcome, that creature takes [[/damage 8]] damage at the start of your next turn.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235866755,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!LJrSxjwbqHPEgw92"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Rejuvenating_II_4zWY3xx3bnoZ4fPR.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Rejuvenating_II_4zWY3xx3bnoZ4fPR.json
@@ -1,0 +1,56 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Rejuvenating II",
+  "type": "base",
+  "_id": "4zWY3xx3bnoZ4fPR",
+  "img": "icons/magic/symbols/runes-star-magenta.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A still-growing bonsai tree at least 30 years old",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use an ability that costs 1 or more of your Heroic Resource, roll a [[/r d10]]. On an 8 or higher, you gain 1 Heroic Resource and you can spend a Recovery. This replaces the benefit of Rejuvenating I.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235852686,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!4zWY3xx3bnoZ4fPR"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Warding_II_O0oUOBALaVlSZFvh.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/5th_Level_Enhancements_e462NGchDmoZEaAv/ActiveEffect_Warding_II_O0oUOBALaVlSZFvh.json
@@ -1,0 +1,99 @@
+{
+  "folder": "e462NGchDmoZEaAv",
+  "name": "Warding II",
+  "type": "base",
+  "_id": "O0oUOBALaVlSZFvh",
+  "img": "icons/magic/life/heart-cross-strong-flame-green.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.stamina.bonuses.treasure",
+        "type": "upgrade",
+        "value": 12,
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.characteristics.might.resist",
+        "type": "add",
+        "value": 1,
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.characteristics.agility.resist",
+        "type": "add",
+        "value": 1,
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.characteristics.reason.resist",
+        "type": "add",
+        "value": 1,
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.characteristics.intuition.resist",
+        "type": "add",
+        "value": 1,
+        "phase": "initial",
+        "priority": null
+      },
+      {
+        "key": "system.characteristics.presence.resist",
+        "type": "add",
+        "value": 1,
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A metallic dragon’s horn",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>The Stamina bonus for the Warding I enhancement becomes +12. Additionally, your characteristic scores are treated as 1 higher for the purpose of resisting potencies.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235846032,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!O0oUOBALaVlSZFvh"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Anathema_BcyFtIDP5r4GByVy.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Anathema_BcyFtIDP5r4GByVy.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Anathema",
+  "type": "base",
+  "_id": "BcyFtIDP5r4GByVy",
+  "img": "icons/magic/unholy/strike-body-life-soul-purple.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "An olothec tentacle",
+      "source": "Texts or lore in Variac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you damage a creature using a magic or psionic ability and obtain a tier 3 outcome, that creature is also [[/apply weakened save]]. If the creature is within 10 squares when this weakened effect ends, you can use a free triggered action to make a free strike against them.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235841220,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!BcyFtIDP5r4GByVy"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Displacing_III_SCbciXCjHhjJpPkX.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Displacing_III_SCbciXCjHhjJpPkX.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Displacing III",
+  "type": "base",
+  "_id": "SCbciXCjHhjJpPkX",
+  "img": "icons/magic/control/debuff-energy-snare-purple-pink.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The keystone from a gate used for crossing between worlds",
+      "source": "Texts or lore in Voll",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>When you use the implement’s Displacing I enhancement, you can teleport the creature up to 5 squares. Additionally, the creature takes a bane on their next power roll made before the end of their next turn.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235838221,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!SCbciXCjHhjJpPkX"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Erupting_II_uXBTW4gCtsk7wNhu.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Erupting_II_uXBTW4gCtsk7wNhu.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Erupting II",
+  "type": "base",
+  "_id": "uXBTW4gCtsk7wNhu",
+  "img": "icons/magic/fire/explosion-fireball-large-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A sealed geode containing explosive gas",
+      "source": "Texts or lore in Vastariax",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>The fire damage dealt by the implement’s Erupting I enhancement increases to [[/damage 6 fire]].</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235830698,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!uXBTW4gCtsk7wNhu"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Forceful_III_D9sGtu05ZtRWFfZT.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Forceful_III_D9sGtu05ZtRWFfZT.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Forceful III",
+  "type": "base",
+  "_id": "D9sGtu05ZtRWFfZT",
+  "img": "icons/magic/control/energy-stream-link-spiral-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A scale from the kraken",
+      "source": "Texts or lore in High Kuric",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use a magic or psionic ability to push or pull a creature, you can move that creature an additional 3 squares and that movement can be vertical. This replaces the benefit of Forceful II.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235826874,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!D9sGtu05ZtRWFfZT"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Lingering_II_7WRoc88mVsNOQCUr.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Lingering_II_7WRoc88mVsNOQCUr.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Lingering II",
+  "type": "base",
+  "_id": "7WRoc88mVsNOQCUr",
+  "img": "icons/magic/control/voodoo-doll-pain-damage-red.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A venom gland from a mature dragon",
+      "source": "Texts or lore in Szetch",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you damage a creature using a magic or psionic ability and obtain a tier 3 outcome, that creature takes [[/damage 15]] damage at the start of your next turn. This replaces the benefit of Lingering I.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235822206,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!7WRoc88mVsNOQCUr"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Piercing_kSoaMfRMKTZnhHeV.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Piercing_kSoaMfRMKTZnhHeV.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Piercing",
+  "type": "base",
+  "_id": "kSoaMfRMKTZnhHeV",
+  "img": "icons/skills/movement/arrow-upward-blue.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Black iron harvested from a slain blood elemental",
+      "source": "Texts or lore in Anjali",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Your magic and psionic abilities ignore damage immunities.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235816616,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!kSoaMfRMKTZnhHeV"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Psionic_Siphon_H0vj0hF45n9XmlIv.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Psionic_Siphon_H0vj0hF45n9XmlIv.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Psionic Siphon",
+  "type": "base",
+  "_id": "H0vj0hF45n9XmlIv",
+  "img": "icons/magic/control/energy-stream-link-large-white.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "The frontal lobe of an overmind",
+      "source": "Texts or lore in Variac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Once per turn when you damage one or more creatures using a magic or psionic ability and obtain a tier 3 outcome, you gain Stamina equal to [[lookup @char]]{your highest characteristic score}, and one creature you damage takes an extra [[/damage 5]] damage.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235810173,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!H0vj0hF45n9XmlIv"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Rejuvenating_III_7eFTznIYPuAZbLu7.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Rejuvenating_III_7eFTznIYPuAZbLu7.json
@@ -1,0 +1,56 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Rejuvenating III",
+  "type": "base",
+  "_id": "7eFTznIYPuAZbLu7",
+  "img": "icons/magic/symbols/runes-star-orange.webp",
+  "system": {
+    "changes": [],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "A live flower that blooms only once a decade",
+      "source": "Texts or lore in The First Language",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Whenever you use an ability that costs 1 or more of your Heroic Resource, roll a [[/r d10]]. On a 7 or higher, you gain 1 Heroic Resource, and you or a creature of your choice within 3 squares can spend a Recovery. This replaces the benefit of Rejuvenating II.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235805486,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!7eFTznIYPuAZbLu7"
+}

--- a/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Warding_III_CwIrAwLC0O3kCOE5.json
+++ b/src/packs/effects/Imbue_Treasure_Ws6XI92L90DyBmi4/Imbue_Implement_Q6Arn46SjeZosJn4/9th_Level_Enhancements_FrguB8NIFAPPKCf1/ActiveEffect_Warding_III_CwIrAwLC0O3kCOE5.json
@@ -1,0 +1,64 @@
+{
+  "folder": "FrguB8NIFAPPKCf1",
+  "name": "Warding III",
+  "type": "base",
+  "_id": "CwIrAwLC0O3kCOE5",
+  "img": "icons/magic/life/heart-cross-strong-flame-purple-orange.webp",
+  "system": {
+    "changes": [
+      {
+        "key": "system.stamina.bonuses.treasure",
+        "type": "upgrade",
+        "value": 18,
+        "phase": "initial",
+        "priority": null
+      }
+    ],
+    "end": {
+      "roll": "1d10 + @combat.save.bonus"
+    },
+    "project": {
+      "prerequisites": "Heartwood from a two-century-old tree",
+      "source": "Texts or lore in Zaliac",
+      "rollCharacteristic": [
+        "agility",
+        "reason",
+        "intuition"
+      ],
+      "yield": {
+        "kind": "implement",
+        "amount": "1",
+        "display": ""
+      },
+      "goal": 150
+    }
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>The Stamina bonus for the Warding I enhancement becomes +18. Additionally, you and each ally within 3 squares of you has their characteristic scores treated as 1 higher for the purpose of resisting potencies. This replaces the benefit of Warding II.</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.364",
+    "systemId": "draw-steel",
+    "systemVersion": "1.1.0",
+    "createdTime": 1784235797317,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!effects!CwIrAwLC0O3kCOE5"
+}


### PR DESCRIPTION
There are a couple of these implements (Seeking and Thought Sending) that need to be ability modifiers, but it would require doing 2 AEs for them to do the magic OR psionic. So i've just left it as one base AE for now