### PR TITLE
Standardized naming of CharacteristicAdvancement file

### DIFF
--- a/src/module/data/pseudo-documents/advancements/_module.mjs
+++ b/src/module/data/pseudo-documents/advancements/_module.mjs
@@ -1,5 +1,5 @@
 export { default as BaseAdvancement } from "./base-advancement.mjs";
-export { default as CharacteristicAdvancement } from "./characteristic.mjs";
+export { default as CharacteristicAdvancement } from "./characteristic-advancement.mjs";
 export { default as EffectGrantAdvancement } from "./effect-grant-advancement.mjs";
 export { default as ItemGrantAdvancement } from "./item-grant-advancement.mjs";
 export { default as LanguageAdvancement } from "./language-advancement.mjs";

--- a/src/module/data/pseudo-documents/advancements/_types.d.ts
+++ b/src/module/data/pseudo-documents/advancements/_types.d.ts
@@ -12,7 +12,7 @@ declare module "./base-advancement.mjs" {
   }
 }
 
-declare module "./characteristic.mjs" {
+declare module "./characteristic-advancement.mjs" {
   export default interface CharacteristicAdvancement {
     characteristics: Record<string, number>;
     max: number;

--- a/src/module/data/pseudo-documents/advancements/characteristic-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/characteristic-advancement.mjs
@@ -6,7 +6,6 @@ const { NumberField, TypedObjectField } = foundry.data.fields;
 
 /**
  * An advancement that applies a permanent adjustment to an actor's characteristics.
- * @abstract
  */
 export default class CharacteristicAdvancement extends BaseAdvancement {
   /** @inheritdoc */


### PR DESCRIPTION
The file for characteristic advancements did not conform to the standardized naming scheme. Also it was erroneously marked as abstract.