### PR TITLE
[#584] Implemented Actor Choice Advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -76,6 +76,24 @@
           }
         }
       },
+      "ACTOR_CHOICE": {
+        "FIELDS": {
+          "chooseN": {
+            "label": "Choice",
+            "hint": "How many actors can be picked when this advancement is configured. If left blank or if the number is greater than the number of actors available, all the actors are selected.",
+            "placeholder": "Choose All"
+          },
+          "dsid": {
+            "label": "DSID",
+            "hint": "The DSID of the ability this is providing choices for"
+          },
+          "cost": {
+            "label": "Resource Cost",
+            "hint": "Leave blank for signature summons."
+          }
+        },
+        "SummonOption": "{name} ({count})"
+      },
       "CHARACTERISTIC": {
         "FIELDS": {
           "guaranteed": {
@@ -175,6 +193,7 @@
       "SHEET": {
         "requirements": "Requirements",
         "additional": "Additional",
+        "unknownActor": "Unknown Actor",
         "unknownItem": "Unknown Item",
         "unknownEffect": "Unknown Effect",
         "reconfigure": "Reconfigure Advancement",
@@ -184,7 +203,9 @@
         "cannotAddNewType": "You cannot add a new {type} to a character that already has one.",
         "restrictedType": "{type} items cannot be added as advancements.",
         "requirePack": "Granted documents must come from a compendium pack.",
-        "forbidParent": "Granted documents cannot be embedded in an actor."
+        "forbidParent": "Granted documents cannot be embedded in an actor.",
+        "restrictedTypeSummon": "{type} actors cannot be added as summon choices.",
+        "requirePackSummon": "Summonable Actors must come from a compendium pack."
       },
       "FillTrait": {
         "button": "Pick Unchosen {type}",
@@ -2522,9 +2543,11 @@
     },
     "Advancement": {
       "characteristic": "Characteristic Increase",
+      "companion": "Companion",
       "effectGrant": "Effect Grant",
       "itemGrant": "Item Grant",
       "skill": "Skill",
+      "summon": "Summon Choice",
       "language": "Language"
     },
     "ChatMessage": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -85,7 +85,7 @@
           },
           "dsid": {
             "label": "DSID",
-            "hint": "The DSID of the ability this is providing choices for"
+            "hint": "The DSID of the ability this is providing choices for."
           },
           "cost": {
             "label": "Resource Cost",

--- a/src/module/applications/apps/advancement/_module.mjs
+++ b/src/module/applications/apps/advancement/_module.mjs
@@ -1,3 +1,4 @@
+export { default as ActorChoiceConfigurationDialog } from "./actor-choice-configuration-dialog.mjs";
 export { default as ChainConfigurationDialog } from "./chain-configuration-dialog.mjs";
 export { default as EffectGrantConfigurationDialog } from "./effect-grant-configuration-dialog.mjs";
 export { default as FillLanguageDialog } from "./fill-trait-dialog.mjs";

--- a/src/module/applications/apps/advancement/actor-choice-configuration-dialog.mjs
+++ b/src/module/applications/apps/advancement/actor-choice-configuration-dialog.mjs
@@ -97,7 +97,7 @@ export default class ActorChoiceConfigurationDialog extends DSApplication {
   /* -------------------------------------------------- */
 
   /**
-   * Total choices made\.
+   * Total choices made.
    * @type {number}
    */
   get totalChosen() {

--- a/src/module/applications/apps/advancement/actor-choice-configuration-dialog.mjs
+++ b/src/module/applications/apps/advancement/actor-choice-configuration-dialog.mjs
@@ -3,27 +3,27 @@ import enrichHTML from "../../../utils/enrich-html.mjs";
 import { systemPath } from "../../../constants.mjs";
 
 /**
- * @import DrawSteelActiveEffect from "../../../documents/active-effect.mjs";
+ * @import DrawSteelActor from "../../../documents/actor.mjs";
  * @import AdvancementNode from "../../../utils/advancement/node.mjs";
- * @import EffectGrantAdvancement from "../../../data/pseudo-documents/advancements/effect-grant-advancement.mjs";
+ * @import ActorChoiceAdvancement from "../../../data/pseudo-documents/advancements/actor-choice-advancement.mjs";
  * @import { ApplicationConfiguration, ApplicationRenderOptions } from "@client/applications/_types.mjs";
  */
 
 /**
- * @typedef EffectGrantConfigurationOptions
+ * @typedef ActorChoiceConfigurationOptions
  * @property {AdvancementNode} node   The node to configure.
  */
 
 /**
- * An application that controls the configuration of an effect grant advancement.
+ * An application that controls the configuration of an actor choice advancement.
  */
-export default class EffectGrantConfigurationDialog extends DSApplication {
+export default class ActorChoiceConfigurationDialog extends DSApplication {
   /**
-   * @param {ApplicationConfiguration & EffectGrantConfigurationOptions} options
+   * @param {ApplicationConfiguration & ActorChoiceConfigurationOptions} options
    */
   constructor({ node, ...options }) {
-    if (!(node.advancement?.type === "effectGrant")) {
-      throw new Error("An effect grant configuration dialog must be passed an AdvancementNode with an Effect Grant.");
+    if (!(node.advancement?.isActorChoice)) {
+      throw new Error("An actor choice configuration dialog must be passed an AdvancementNode with an Actor Choice.");
     }
     super(options);
     this.#node = node;
@@ -44,7 +44,7 @@ export default class EffectGrantConfigurationDialog extends DSApplication {
   /** @inheritdoc */
   static PARTS = {
     body: {
-      template: systemPath("templates/apps/advancement/effect-grant-configuration-dialog/body.hbs"),
+      template: systemPath("templates/apps/advancement/actor-choice-configuration-dialog/body.hbs"),
     },
     footer: {
       template: "templates/generic/form-footer.hbs",
@@ -55,7 +55,7 @@ export default class EffectGrantConfigurationDialog extends DSApplication {
 
   /**
    * The advancement being configured.
-   * @type {EffectGrantAdvancement}
+   * @type {ActorChoiceAdvancement}
    */
   get advancement() {
     return this.#node.advancement;
@@ -76,13 +76,13 @@ export default class EffectGrantConfigurationDialog extends DSApplication {
   /* -------------------------------------------------- */
 
   /**
-   * Cached reference to the effects this can be configuring. Constructed during the first run of _prepareContext.
-   * @type {Set<DrawSteelActiveEffect>}
+   * Cached reference to the actors this can be configuring. Constructed during the first run of _prepareContext.
+   * @type {Set<DrawSteelActor>}
    */
-  #effects;
+  #actors;
   // eslint-disable-next-line @jsdoc/require-jsdoc
-  get effects() {
-    return this.#effects;
+  get actors() {
+    return this.#actors;
   }
 
   /* -------------------------------------------------- */
@@ -97,7 +97,7 @@ export default class EffectGrantConfigurationDialog extends DSApplication {
   /* -------------------------------------------------- */
 
   /**
-   * Total choices made.
+   * Total choices made\.
    * @type {number}
    */
   get totalChosen() {
@@ -118,10 +118,10 @@ export default class EffectGrantConfigurationDialog extends DSApplication {
   /** @inheritdoc */
   async _prepareContext(options) {
     if (options.isFirstRender) {
-      this.#effects = new Set(Object.values(this.node.choices).map(choice => choice.effect));
+      this.#actors = new Set(Object.values(this.node.choices).map(choice => choice.actor));
 
-      this.effects.forEach(effect => {
-        if (this.node.selected[effect.uuid]) this.chosen.add(effect.uuid);
+      this.actors.forEach(actor => {
+        if (this.node.selected[actor.uuid]) this.chosen.add(actor.uuid);
       });
     }
 
@@ -168,7 +168,7 @@ export default class EffectGrantConfigurationDialog extends DSApplication {
 
     const totalChosen = this.totalChosen;
 
-    context.effects = this.effects.map(e => {
+    context.actors = this.actors.map(e => {
       const chosen = this.chosen.has(e.uuid) || (this.advancement.chooseN == null);
       const disabled = !chosen && (totalChosen >= this.advancement.chooseN);
       return {

--- a/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
@@ -15,6 +15,7 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     actions: {
+      deletePoolActor: AdvancementSheet.#deletePoolDocument,
       deletePoolEffect: AdvancementSheet.#deletePoolDocument,
       deletePoolItem: AdvancementSheet.#deletePoolDocument,
     },

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2042,6 +2042,12 @@ export const Advancement = {
     itemTypes: new Set(["class", "title"]),
     documentClass: pseudoDocuments.advancements.CharacteristicAdvancement,
   },
+  companion: {
+    label: "TYPES.Advancement.companion",
+    defaultImage: "icons/svg/pawprint.svg",
+    itemTypes: new Set(["class"]),
+    documentClass: pseudoDocuments.advancements.CompanionChoiceAdvancement,
+  },
   itemGrant: {
     label: "TYPES.Advancement.itemGrant",
     defaultImage: "icons/svg/item-bag.svg",
@@ -2059,6 +2065,12 @@ export const Advancement = {
     defaultImage: "icons/svg/hanging-sign.svg",
     itemTypes: new Set(["career", "ancestryTrait", "class", "complication", "culture", "feature", "subclass", "title"]),
     documentClass: pseudoDocuments.advancements.SkillAdvancement,
+  },
+  summon: {
+    label: "TYPES.Advancement.summon",
+    defaultImage: "icons/svg/teleport.svg",
+    itemTypes: new Set(["subclass"]),
+    documentClass: pseudoDocuments.advancements.SummonChoiceAdvancement,
   },
   language: {
     label: "TYPES.Advancement.language",

--- a/src/module/data/pseudo-documents/advancements/_module.mjs
+++ b/src/module/data/pseudo-documents/advancements/_module.mjs
@@ -1,7 +1,10 @@
+export { default as ActorChoiceAdvancement } from "./actor-choice-advancement.mjs";
 export { default as BaseAdvancement } from "./base-advancement.mjs";
 export { default as CharacteristicAdvancement } from "./characteristic-advancement.mjs";
+export { default as CompanionChoiceAdvancement } from "./companion-choice-advancement.mjs";
 export { default as EffectGrantAdvancement } from "./effect-grant-advancement.mjs";
 export { default as ItemGrantAdvancement } from "./item-grant-advancement.mjs";
 export { default as LanguageAdvancement } from "./language-advancement.mjs";
 export { default as SkillAdvancement } from "./skill-advancement.mjs";
+export { default as SummonChoiceAdvancement } from "./summon-choice-advancement.mjs";
 export { default as TraitAdvancement } from "./trait-advancement.mjs";

--- a/src/module/data/pseudo-documents/advancements/_types.d.ts
+++ b/src/module/data/pseudo-documents/advancements/_types.d.ts
@@ -1,5 +1,36 @@
 export {};
 
+declare module "./actor-choice-advancement.mjs" {
+  export default interface ActorChoiceAdvancement {
+    dsid: string;
+  }
+}
+
+// declare module "./companion-choice-advancement.mjs" {
+//   export default interface SummonChoiceAdvancement {
+
+//   }
+// }
+
+interface SummonChoicePool {
+  uuid: string;
+  count: number;
+}
+
+export type ActorChoice = {
+  /** The UUID of the actor. */
+  uuid: string;
+};
+
+declare module "./summon-choice-advancement.mjs" {
+  export default interface SummonChoiceAdvancement {
+    cost: number;
+    /** If `null`, then this is explicitly a "choose all" - but also if the number is equal to or greater than the pool. */
+    chooseN: number | null;
+    pool: SummonChoicePool[]
+  }
+}
+
 declare module "./base-advancement.mjs" {
   export default interface BaseAdvancement {
     requirements: {

--- a/src/module/data/pseudo-documents/advancements/actor-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/actor-choice-advancement.mjs
@@ -1,0 +1,104 @@
+import ActorChoiceConfigurationDialog from "../../../applications/apps/advancement/actor-choice-configuration-dialog.mjs";
+import AdvancementLeaf from "../../../utils/advancement/leaf.mjs";
+import BaseAdvancement from "./base-advancement.mjs";
+
+/**
+ * @import { ActorChoice } from "./_types";
+ * @import DrawSteelActor from "../../../documents/actor.mjs";
+ */
+
+const { StringField } = foundry.data.fields;
+
+/**
+ * An advancement that selects other actors.
+ * @abstract
+ */
+export default class ActorChoiceAdvancement extends BaseAdvancement {
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      dsid: new StringField(),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.ADVANCEMENT.ACTOR_CHOICE");
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Getter to indicate that this is an actor choice advancement.
+   */
+  get isActorChoice() {
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Options available for this specific Actor Choice advancement, with values corresponding to actor UUIDs.
+   * @type {ActorChoice[]}
+   * @abstract
+   */
+  get actorOptions() {
+    throw new Error("An Actor Choice Advancement must implement `get actorOptions`.");
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get isChoice() {
+    if (this.chooseN === null) return false;
+    if (this.chooseN < this.actorOptions.length) return true;
+    return false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async createLeaves(node) {
+    const promises = [];
+    for (const { uuid } of this.actorOptions) {
+      // TODO: Optimize DB calls
+      /** @type {DrawSteelActor} */
+      const actor = await fromUuid(uuid);
+      if (!actor) continue;
+      node.choices[actor.uuid] = new AdvancementLeaf(node, actor.uuid, actor.toAnchor().outerHTML, { actor });
+    }
+    return Promise.allSettled(promises);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async configureAdvancement(node = null) {
+    const selection = await ActorChoiceConfigurationDialog.create({ node });
+
+    if (!selection) return null;
+
+    const promises = [];
+
+    if (node) {
+      node.selected = selection.choices.reduce((selected, uuid) => {
+        selected[uuid] = true;
+        return selected;
+      }, {});
+    }
+
+    await Promise.allSettled(promises);
+
+    return { [`flags.draw-steel.advancement.${this.id}.selected`]: selection.choices };
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async reconfigure() {
+    await super.reconfigure();
+
+    const configuration = await this.configureAdvancement();
+    if (configuration) await this.document.update(configuration);
+  }
+}

--- a/src/module/data/pseudo-documents/advancements/actor-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/actor-choice-advancement.mjs
@@ -30,6 +30,7 @@ export default class ActorChoiceAdvancement extends BaseAdvancement {
 
   /**
    * Getter to indicate that this is an actor choice advancement.
+   * @type {boolean}
    */
   get isActorChoice() {
     return true;

--- a/src/module/data/pseudo-documents/advancements/base-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/base-advancement.mjs
@@ -83,7 +83,7 @@ export default class BaseAdvancement extends TypedPseudoDocument {
   /* -------------------------------------------------- */
 
   /**
-   * Does this trait have a choice to make?
+   * Does this advancement have a choice to make?
    * @type {boolean}
    */
   get isChoice() {

--- a/src/module/data/pseudo-documents/advancements/companion-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/companion-choice-advancement.mjs
@@ -13,6 +13,7 @@ export default class CompanionChoiceAdvancement extends ActorChoiceAdvancement {
 
   /**
    * A companion advancement only offers a choice of a single companion.
+   * @type {number}
    */
   get chooseN() {
     return 1;

--- a/src/module/data/pseudo-documents/advancements/companion-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/companion-choice-advancement.mjs
@@ -1,0 +1,39 @@
+import ActorChoiceAdvancement from "./actor-choice-advancement.mjs";
+
+/**
+ * An advancement that selects the Beastheart's companion.
+ */
+export default class CompanionChoiceAdvancement extends ActorChoiceAdvancement {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "companion";
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * A companion advancement only offers a choice of a single companion.
+   */
+  get chooseN() {
+    return 1;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get isChoice() {
+    return true;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get actorOptions() {
+    return [];
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async getSheetContext() {}
+}

--- a/src/module/data/pseudo-documents/advancements/effect-grant-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/effect-grant-advancement.mjs
@@ -57,16 +57,6 @@ export default class EffectGrantAdvancement extends BaseAdvancement {
 
   /* -------------------------------------------------- */
 
-  /**
-   * Does this item grant advancement use point buy rather than a simple count.
-   * @type {boolean}
-   */
-  get pointBuy() {
-    return !!this.constructor.ADDITIONAL_TYPES[this.additional.type]?.points;
-  }
-
-  /* -------------------------------------------------- */
-
   /** @inheritdoc */
   prepareBaseData() {
     super.prepareBaseData();
@@ -123,7 +113,6 @@ export default class EffectGrantAdvancement extends BaseAdvancement {
 
     if (node) {
       node.selected = selection.choices.reduce((selected, uuid) => {
-        const leaf = node.choices[uuid];
         selected[uuid] = true;
         return selected;
       }, {});

--- a/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
@@ -1,0 +1,84 @@
+import ActorChoiceAdvancement from "./actor-choice-advancement.mjs";
+import { requiredInteger } from "../../helpers.mjs";
+
+/**
+ * @import DrawSteelActor from "../../../documents/actor.mjs";
+ */
+
+const { ArrayField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
+
+/**
+ * An advancement that selects other actors from a pool for the Summoner.
+ */
+export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      cost: new NumberField({ initial: null, min: 1, integer: true }),
+      chooseN: new NumberField({ required: true, integer: true, min: 1, initial: 2 }),
+      pool: new ArrayField(new SchemaField({
+        uuid: new DocumentUUIDField({ embedded: false, type: "Actor" }),
+        count: requiredInteger({ initial: 2, min: 1 }),
+      })),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static get TYPE() {
+    return "summon";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get actorOptions() {
+    return Object.values(this.pool).reduce((options, entry) => {
+      const idx = fromUuidSync(entry.uuid);
+      if (idx) options.push({ uuid: idx.uuid });
+      return options;
+    }, []);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async getSheetContext(options) {
+    const ctx = {};
+
+    ctx.actorPool = [];
+    for (const [i, pool] of this.pool.entries()) {
+      const actor = await fromUuid(pool.uuid);
+      ctx.actorPool.push({
+        ...pool,
+        index: i,
+        link: actor ? actor.toAnchor() : _loc("DRAW_STEEL.ADVANCEMENT.SHEET.unknownActor"),
+      });
+    }
+
+    return ctx;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+     * Process a dropped actor.
+     * @param {DrawSteelActor} document
+     * @returns {Promise<DrawSteelActor>}
+     */
+  handleDrop(document) {
+    if (document.documentName !== "Actor") return;
+
+    if (document.type !== "npc") return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.restrictedTypeSummon", {
+      format: { type: _loc(CONFIG.Actor.typeLabels[document.type]) },
+    });
+    if (!document.pack) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.requirePackSummon", { localize: true });
+    const exists = this.pool.some(k => k.uuid === document.uuid);
+    if (exists) return;
+
+    const pool = foundry.utils.deepClone(this._source.pool);
+    pool.push({ uuid: document.uuid });
+    return this.update({ pool });
+  }
+}

--- a/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
@@ -63,10 +63,10 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
   /* -------------------------------------------------- */
 
   /**
-     * Process a dropped actor.
-     * @param {DrawSteelActor} document
-     * @returns {Promise<DrawSteelActor>}
-     */
+   * Process a dropped actor.
+   * @param {DrawSteelActor} document
+   * @returns {Promise<DrawSteelActor>}
+   */
   handleDrop(document) {
     if (document.documentName !== "Actor") return;
 

--- a/src/module/utils/_module.mjs
+++ b/src/module/utils/_module.mjs
@@ -1,5 +1,6 @@
 export * as advancement from "./advancement/_module.mjs";
 export { default as constructHTMLButton } from "./construct-html-button.mjs";
+export { default as createDocumentLink } from "./create-document-link.mjs";
 export { default as enrichHTML } from "./enrich-html.mjs";
 export { default as evaluateFormula } from "./evaluate-formula.mjs";
 export { default as getDocumentTypes } from "./get-document-types.mjs";

--- a/src/module/utils/advancement/leaf.mjs
+++ b/src/module/utils/advancement/leaf.mjs
@@ -1,7 +1,7 @@
 import AdvancementNode from "./node.mjs";
 
 /**
- * @import { DrawSteelActiveEffect, DrawSteelItem } from "../../documents/_module.mjs";
+ * @import { DrawSteelActiveEffect, DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";
  */
 
 /**
@@ -14,6 +14,8 @@ export default class AdvancementLeaf {
    * @param {string} label
    * @param {object} [options={}]
    * @param {DrawSteelItem} [options.item]
+   * @param {DrawSteelActiveEffect} [options.effect]
+   * @param {DrawSteelActor} [options.actor]
    */
   constructor(node, key, label, options = {}) {
     Object.defineProperties(this, {
@@ -22,6 +24,7 @@ export default class AdvancementLeaf {
       label: { value: label, configurable: false, writable: false },
       item: { value: options.item ?? null, configurable: false, writable: false },
       effect: { value: options.effect ?? null, configurable: false, writable: false },
+      actor: { value: options.actor ?? null, configurable: false, writable: false },
     });
   }
 
@@ -83,4 +86,12 @@ export default class AdvancementLeaf {
    * @type {DrawSteelActiveEffect | null}
    */
   effect = null;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The actor associated with this leaf's key. Only used by actor choice advancements.
+   * @type {DrawSteelActor | null}
+   */
+  actor = null;
 }

--- a/src/module/utils/create-document-link.mjs
+++ b/src/module/utils/create-document-link.mjs
@@ -1,0 +1,46 @@
+/**
+ * @import { EnrichmentAnchorOptions } from "@client/applications/ux/text-editor.mjs"
+ */
+
+/**
+ * Create a content link for a document from its uuid.
+ * @param {string} uuid The documents UUID. Must be able to resolve synchronously.
+ * @param {Partial<EnrichmentAnchorOptions>} [options]  Additional options to configure how the link is constructed.
+ * @returns {HTMLAnchorElement} Returns null if no document was found.
+ */
+export default function createDocumentLink(uuid, { attrs = {}, dataset = {}, classes = [], name, icon } = {}) {
+  const entry = fromUuidSync(uuid, { strict: false });
+  if (!entry) return null;
+  if (entry instanceof foundry.abstract.Document) return entry.toAnchor({ attrs, dataset, classes, name, icon });
+
+  const parseInfo = foundry.utils.parseUuid(uuid);
+
+  // Build dataset
+  const documentConfig = CONFIG[parseInfo.documentType];
+  const documentName = _loc(`DOCUMENT.${parseInfo.documentType}`);
+  let anchorIcon = icon ?? documentConfig.sidebarIcon;
+  if (!classes.includes("content-link")) classes.unshift("content-link");
+  attrs = foundry.utils.mergeObject({ draggable: "true" }, attrs);
+  dataset = foundry.utils.mergeObject({
+    uuid,
+    link: "",
+    id: parseInfo.id,
+    type: parseInfo.documentType,
+    pack: parseInfo.collection?.collection,
+    tooltip: documentName,
+  }, dataset);
+
+  // If this is a typed document, add the type to the dataset
+  if (entry.type) {
+    const typeLabel = documentConfig.typeLabels[entry.type];
+    const typeName = game.i18n.has(typeLabel) ? `${_loc(typeLabel)}` : "";
+    attrs["aria-label"] ??= typeName
+      ? _loc("DOCUMENT.TypePageFormat", { type: typeName, page: documentName })
+      : documentName;
+    dataset.tooltip = "";
+    anchorIcon = icon ?? documentConfig.typeIcons?.[entry.type] ?? documentConfig.sidebarIcon;
+  }
+
+  name ??= entry.name;
+  return foundry.applications.ux.TextEditor.implementation.createAnchor({ attrs, dataset, name, classes, icon: anchorIcon });
+}

--- a/src/module/utils/create-document-link.mjs
+++ b/src/module/utils/create-document-link.mjs
@@ -33,7 +33,7 @@ export default function createDocumentLink(uuid, { attrs = {}, dataset = {}, cla
   // If this is a typed document, add the type to the dataset
   if (entry.type) {
     const typeLabel = documentConfig.typeLabels[entry.type];
-    const typeName = game.i18n.has(typeLabel) ? `${_loc(typeLabel)}` : "";
+    const typeName = game.i18n.has(typeLabel) ? _loc(typeLabel) : "";
     attrs["aria-label"] ??= typeName
       ? _loc("DOCUMENT.TypePageFormat", { type: typeName, page: documentName })
       : documentName;
@@ -42,5 +42,5 @@ export default function createDocumentLink(uuid, { attrs = {}, dataset = {}, cla
   }
 
   name ??= entry.name;
-  return foundry.applications.ux.TextEditor.implementation.createAnchor({ attrs, dataset, name, classes, icon: anchorIcon });
+  return CONFIG.ux.TextEditor.createAnchor({ attrs, dataset, name, classes, icon: anchorIcon });
 }

--- a/src/styles/system/applications/sheets/pseudo-documents.css
+++ b/src/styles/system/applications/sheets/pseudo-documents.css
@@ -2,6 +2,13 @@
   h4.section-header {
     margin: 0;
   }
+
+  .drop-target-area {
+    input[type="number"] {
+      flex: 0 0 50px;
+      text-align: center;
+    }
+  }
 }
 
 .draw-steel.configure-advancement {

--- a/templates/apps/advancement/actor-choice-configuration-dialog/body.hbs
+++ b/templates/apps/advancement/actor-choice-configuration-dialog/body.hbs
@@ -1,0 +1,16 @@
+<section>
+  {{#if enrichedDescription}}
+  {{{enrichedDescription}}}
+  {{/if}}
+  <fieldset class="actor-choices">
+    <legend>{{chooseLabel}}</legend>
+    {{#each actors}}
+    <div class="form-group">
+      <label>{{{link}}}</label>
+      <div class="form-fields">
+        <input type="checkbox" value="{{uuid}}" name="choices" {{checked chosen}} {{disabled disabled}}>
+      </div>
+    </div>
+    {{/each}}
+  </fieldset>
+</section>

--- a/templates/sheets/pseudo-documents/advancement/details.hbs
+++ b/templates/sheets/pseudo-documents/advancement/details.hbs
@@ -31,6 +31,26 @@
   </fieldset>
   {{/if}}
 
+  {{#if fields.dsid}}{{formGroup fields.dsid value=source.dsid name="dsid"}}{{/if}}
+
+  {{!-- SUMMON CHOICE POOL --}}
+  {{#if (eq document.type "summon")}}
+  {{formGroup fields.cost value=source.cost name="cost" classes="slim"}}
+
+  <section class="drop-target-area">
+    {{#each ctx.actorPool}}
+    <div class="form-group" data-pool-index="{{@index}}">
+      <input type="hidden" name="{{concat "pool." @index ".uuid"}}" value="{{uuid}}">
+      {{formInput @root.fields.pool.element.fields.count value=count name=(concat "pool." @index ".count")}}
+      <label>{{{link.outerHTML}}}</label>
+      <div class="form-fields">
+        <button type="button" data-action="deletePoolActor" class="icon fa-solid fa-trash"></button>
+      </div>
+    </div>
+    {{/each}}
+  </section>
+  {{/if}}
+
   {{!-- ITEM GRANT POOL --}}
   {{#if (eq document.type "itemGrant")}}
   <section class="drop-target-area">
@@ -45,7 +65,7 @@
   </section>
   {{/if}}
 
-  {{!-- ITEM GRANT POOL --}}
+  {{!-- EFFECT GRANT POOL --}}
   {{#if (eq document.type "effectGrant")}}
   <section class="drop-target-area">
     {{#each ctx.effectPool}}


### PR DESCRIPTION
Note: This should get pointed at a proper 1.2.x branch

1. Implements an ActorChoice advancement class
2. Implements two subclasses of that for Companions (Beastheart) & Summons (Summoner)
3. Does a bit of cleanup in the EffectGrant where I realized some stuff was unused
4. Implements an ActorChoiceConfigurationDialog to configure the actor choice

This PR does *not* handle resolving the choices once made; the choices are saved appropriately, I expect we will want to do actor creation + possible permission error handling, plus of course appropriate flag setting.

My current design intent for how this links to a possible summoning functionality on abilities is that a given advancement contributes to the pool of an ability based on DSID; this covers the assumed usage of `companion` and `call-forth`. It's possible that's an incorrect setup, it's a single field on the ActorChoiceAdvancement we can easily adjust. Possibly worth surveying the 3pp community for if any of them are interacting with this kind of functionality to make allowances.