### PR TITLE
[#583] Summoning Data Model & Sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -385,6 +385,14 @@
           "multiple": {
             "label": "Multiple"
           }
+        },
+        "summoning": {
+          "pool": {
+            "label": "Actors"
+          },
+          "count": {
+            "label": "Count"
+          }
         }
       },
       "persistent": "Persistent {value}",
@@ -1056,6 +1064,13 @@
         "ImmunityReducedToZero": "{name}'s immunities have reduced the damage to zero."
       },
       "Summoning": {
+        "ActorSelectDialog": {
+          "title": "Summon Actor",
+          "uuid": {
+            "label": "Actor",
+            "hint": "Choose an actor to summon, importing from compendium if it hasn't yet already."
+          }
+        },
         "Errors": {
           "ACTOR_CREATE": "You do not have permission to import actors!",
           "TOKEN_CREATE": "You do not have permission to create new Tokens!",
@@ -2648,7 +2663,8 @@
       "base": "Effect",
       "persistent": "Persistent",
       "spend": "Spend",
-      "strained": "Strained"
+      "strained": "Strained",
+      "summon": "Summon"
     }
   },
   "TOKEN.MOVEMENT": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1073,6 +1073,8 @@
         },
         "Errors": {
           "ACTOR_CREATE": "You do not have permission to import actors!",
+          "NO_ACTOR": "No actor found to summon!",
+          "NO_OPTIONS": "No valid summoning options!",
           "TOKEN_CREATE": "You do not have permission to create new Tokens!",
           "WILDCARD": "You must have 'Use File Browser' permissions to summon creatures with wildcard artwork."
         }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1057,6 +1057,7 @@
       },
       "Summoning": {
         "Errors": {
+          "ACTOR_CREATE": "You do not have permission to import actors!",
           "TOKEN_CREATE": "You do not have permission to create new Tokens!",
           "WILDCARD": "You must have 'Use File Browser' permissions to summon creatures with wildcard artwork."
         }

--- a/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/special-effect-sheet.mjs
@@ -14,7 +14,7 @@ export default class SpecialEffectSheet extends PseudoDocumentSheet {
     details: {
       template: systemPath("templates/sheets/pseudo-documents/special-effect/content.hbs"),
       // Modules can push to this or otherwise load their details partial templates
-      templates: ["persistent.hbs", "spend.hbs"].map(t => systemPath(`templates/sheets/pseudo-documents/special-effect/${t}`)),
+      templates: ["persistent.hbs", "spend.hbs", "summon.hbs"].map(t => systemPath(`templates/sheets/pseudo-documents/special-effect/${t}`)),
     },
   };
 

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2154,6 +2154,11 @@ export const SpecialEffect = {
     defaultImage: "icons/svg/anchor.svg",
     documentClass: pseudoDocuments.specialEffects.StrainedSpecialEffect,
   },
+  summon: {
+    label: "TYPES.SpecialEffect.summon",
+    defaultImage: "icons/svg/teleport.svg",
+    documentClass: pseudoDocuments.specialEffects.SummonSpecialEffect,
+  },
 };
 preLocalize("SpecialEffect", { key: "label" });
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -891,4 +891,36 @@ export default class AbilityModel extends BaseItemModel {
     }
     return false;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+     * Places summons.
+     * @param {string} uuid               The UUID of the actor to summon. If this points to a compendium actor a copy will be imported.
+     * @param {Object} options
+     * @param {number} [options.count=1]  How many tokens to summon.
+     * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
+     */
+  async performSummon(uuid, { count = 1 }) {
+    /** @type {DrawSteelActor} */
+    const sourceActor = await fromUuid(uuid);
+
+    if (!sourceActor) return void ui.notifications.error("");
+
+    let worldActor = game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(systemID, "summonSource") === this.document.uuid));
+
+    if (!worldActor) {
+      // Ensure the user has permission to drop the actor and create a Token.
+      if (!game.user.can("ACTOR_CREATE")) {
+        ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
+        return null;
+      }
+
+      worldActor = game.actors.importFromCompendium(sourceActor.pack, sourceActor.id, {
+        "flags.draw-steel.summonSource": this.document.uuid,
+      }, { keepId: true });
+    }
+
+    return canvas.tokens.placeActor(worldActor, { count });
+  }
 }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -17,7 +17,7 @@ import enrichHTML from "../../utils/enrich-html.mjs";
  * @import { PowerRollModifiers } from "../../_types";
  * @import { PlaceAbilityOptions } from "./_types";
  * @import DrawSteelToken from "../../canvas/placeables/token.mjs";
- * @import DrawSteelTokenDocument from "../../documents/token.mjs";
+ * @import { DrawSteelActor, DrawSteelTokenDocument } from "../../documents/_module.mjs";
  */
 
 const fields = foundry.data.fields;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -901,13 +901,14 @@ export default class AbilityModel extends BaseItemModel {
    * @param {number} [options.count=1]  How many tokens to summon.
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
    */
-  async performSummon(uuid, { count = 1 }) {
+  async performSummon(uuid, { count = 1 } = {}) {
     /** @type {DrawSteelActor} */
     const sourceActor = await fromUuid(uuid);
 
-    if (!sourceActor) return void ui.notifications.error("");
+    if (!sourceActor) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
 
-    let worldActor = game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(systemID, "summonSource") === this.document.uuid));
+    // TODO: Rework into registry or other service to improve performance with large actor collections
+    let worldActor = game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(systemID, "summonSource") === this.parent.uuid));
 
     if (!worldActor) {
       // Ensure the user has permission to drop the actor and create a Token.
@@ -916,8 +917,8 @@ export default class AbilityModel extends BaseItemModel {
         return null;
       }
 
-      worldActor = game.actors.importFromCompendium(sourceActor.pack, sourceActor.id, {
-        "flags.draw-steel.summonSource": this.document.uuid,
+      worldActor = await game.actors.importFromCompendium(game.packs.get(sourceActor.pack), sourceActor.id, {
+        "flags.draw-steel.summonSource": this.parent.uuid,
       }, { keepId: true });
     }
 

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -895,12 +895,12 @@ export default class AbilityModel extends BaseItemModel {
   /* -------------------------------------------------- */
 
   /**
-     * Places summons.
-     * @param {string} uuid               The UUID of the actor to summon. If this points to a compendium actor a copy will be imported.
-     * @param {Object} options
-     * @param {number} [options.count=1]  How many tokens to summon.
-     * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
-     */
+   * Places summons.
+   * @param {string} uuid               The UUID of the actor to summon. If this points to a compendium actor a copy will be imported.
+   * @param {Object} options
+   * @param {number} [options.count=1]  How many tokens to summon.
+   * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
+   */
   async performSummon(uuid, { count = 1 }) {
     /** @type {DrawSteelActor} */
     const sourceActor = await fromUuid(uuid);

--- a/src/module/data/pseudo-documents/special-effect/_module.mjs
+++ b/src/module/data/pseudo-documents/special-effect/_module.mjs
@@ -2,3 +2,4 @@ export { default as BaseSpecialEffect } from "./base-special-effect.mjs";
 export { default as PersistentSpecialEffect } from "./persistent-effect.mjs";
 export { default as SpendSpecialEffect } from "./spend-effect.mjs";
 export { default as StrainedSpecialEffect } from "./strained-effect.mjs";
+export { default as SummonSpecialEffect } from "./summon-effect.mjs";

--- a/src/module/data/pseudo-documents/special-effect/_types.d.ts
+++ b/src/module/data/pseudo-documents/special-effect/_types.d.ts
@@ -25,6 +25,9 @@ declare module "./spend-effect.mjs" {
 
 declare module "./summon-effect.mjs" {
   export default interface SummonSpecialEffect {
-    pool: Set<string>;
+    summoning: {
+      pool: Set<string>;
+      count: number;
+    }
   }
 }

--- a/src/module/data/pseudo-documents/special-effect/_types.d.ts
+++ b/src/module/data/pseudo-documents/special-effect/_types.d.ts
@@ -22,3 +22,9 @@ declare module "./spend-effect.mjs" {
     }
   }
 }
+
+declare module "./summon-effect.mjs" {
+  export default interface SummonSpecialEffect {
+    pool: Set<string>;
+  }
+}

--- a/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
@@ -4,13 +4,14 @@ import { requiredInteger } from "../../helpers.mjs";
 import { systemPath } from "../../../constants.mjs";
 
 /**
- * @import { DrawSteelActor, DrawSteelTokenDocument} from "../../../documents/_module.mjs"
+ * @import { DrawSteelTokenDocument } from "../../../documents/_module.mjs"
  */
 
-const { DocumentUUIDField, SetField } = foundry.data.fields;
+const { DocumentUUIDField, SchemaField, SetField } = foundry.data.fields;
+const { createSelectInput, createFormGroup } = foundry.applications.fields;
 
 /**
- * A type of effect that performs a summon.
+ * A type of effect that summons from a fixed list of options.
  */
 export default class SummonSpecialEffect extends BaseSpecialEffect {
   /** @inheritdoc */
@@ -23,8 +24,10 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
   /** @inheritdoc */
   static defineSchema() {
     return Object.assign(super.defineSchema(), {
-      pool: new SetField(new DocumentUUIDField({ type: "Actor", embedded: false })),
-      count: new requiredInteger({ initial: 1, min: 1 }),
+      summoning: new SchemaField({
+        pool: new SetField(new DocumentUUIDField({ type: "Actor", embedded: false })),
+        count: requiredInteger({ initial: 1, min: 1 }),
+      }),
     });
   }
 
@@ -46,7 +49,8 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
     // Token permissions handled by placeActor
     let summonUuid;
 
-    if (this.pool.size > 1) {
+    if (this.pool.size === 1) summonUuid = this.pool.first();
+    else {
       const actorOptions = this.pool.reduce((options, uuid) => {
         const idx = fromUuidSync(uuid);
         if (idx) options.push({
@@ -56,12 +60,31 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
         return options;
       }, []);
 
-      const fd = DSDialog.input({});
+      const content = document.createElement("div");
+
+      const uuidSelect = createFormGroup({
+        label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.label",
+        hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.hint",
+        input: createSelectInput({
+          name: "uuid",
+          options: actorOptions,
+        }),
+        localize: true,
+      });
+
+      content.append(uuidSelect);
+
+      const fd = DSDialog.input({
+        content,
+        window: {
+          title: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.title",
+          icon: "fa-solid fa-transporter-2",
+        },
+      });
 
       if (!fd) return null;
       summonUuid = fd.uuid;
     }
-    else summonUuid = this.pool.first();
 
     return this.parent.performSummon(summonUuid);
   }

--- a/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
@@ -1,6 +1,7 @@
-import { systemID, systemPath } from "../../../constants.mjs";
 import BaseSpecialEffect from "./base-special-effect.mjs";
+import DSDialog from "../../../applications/api/dialog.mjs";
 import { requiredInteger } from "../../helpers.mjs";
+import { systemPath } from "../../../constants.mjs";
 
 /**
  * @import { DrawSteelActor, DrawSteelTokenDocument} from "../../../documents/_module.mjs"
@@ -43,35 +44,25 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
   async performSummon() {
     if (!this.pool.size) return void ui.notifications.error("");
     // Token permissions handled by placeActor
-    let uuid;
+    let summonUuid;
 
     if (this.pool.size > 1) {
+      const actorOptions = this.pool.reduce((options, uuid) => {
+        const idx = fromUuidSync(uuid);
+        if (idx) options.push({
+          label: idx.name,
+          value: uuid,
+        });
+        return options;
+      }, []);
 
-      // TODO: Pick actor from pool
+      const fd = DSDialog.input({});
 
-      if (!uuid) return null;
+      if (!fd) return null;
+      summonUuid = fd.uuid;
     }
-    else uuid = this.pool.first();
+    else summonUuid = this.pool.first();
 
-    /** @type {DrawSteelActor} */
-    const sourceActor = await fromUuid(uuid);
-
-    if (!sourceActor) return void ui.notifications.error("");
-
-    let worldActor = game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(systemID, "summonSource") === this.document.uuid));
-
-    if (!worldActor) {
-      // Ensure the user has permission to drop the actor and create a Token.
-      if (!game.user.can("ACTOR_CREATE")) {
-        ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
-        return null;
-      }
-
-      worldActor = game.actors.importFromCompendium(sourceActor.pack, sourceActor.id, {
-        "flags.draw-steel.summonSource": this.document.uuid,
-      }, { keepId: true });
-    }
-
-    return canvas.tokens.placeActor(worldActor);
+    return this.parent.performSummon(summonUuid);
   }
 }

--- a/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
@@ -45,21 +45,14 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
    */
   async performSummon() {
-    if (!this.pool.size) return void ui.notifications.error("");
+    const summonOptions = this.summoning.pool.map(uuid => fromUuidSync(uuid)).filter(_ => _);
+
+    if (!summonOptions.size) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.NO_OPTIONS", { localize: true });
     // Token permissions handled by placeActor
     let summonUuid;
 
-    if (this.pool.size === 1) summonUuid = this.pool.first();
+    if (summonOptions.size === 1) summonUuid = summonOptions.first().uuid;
     else {
-      const actorOptions = this.pool.reduce((options, uuid) => {
-        const idx = fromUuidSync(uuid);
-        if (idx) options.push({
-          label: idx.name,
-          value: uuid,
-        });
-        return options;
-      }, []);
-
       const content = document.createElement("div");
 
       const uuidSelect = createFormGroup({
@@ -67,14 +60,14 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
         hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.hint",
         input: createSelectInput({
           name: "uuid",
-          options: actorOptions,
+          options: summonOptions.map(idx => ({ label: idx.name, value: idx.uuid })),
         }),
         localize: true,
       });
 
       content.append(uuidSelect);
 
-      const fd = DSDialog.input({
+      const fd = await DSDialog.input({
         content,
         window: {
           title: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.title",
@@ -86,6 +79,6 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
       summonUuid = fd.uuid;
     }
 
-    return this.parent.performSummon(summonUuid);
+    return this.parent.performSummon(summonUuid, { count: this.summoning.count });
   }
 }

--- a/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
@@ -1,0 +1,77 @@
+import { systemID, systemPath } from "../../../constants.mjs";
+import BaseSpecialEffect from "./base-special-effect.mjs";
+import { requiredInteger } from "../../helpers.mjs";
+
+/**
+ * @import { DrawSteelActor, DrawSteelTokenDocument} from "../../../documents/_module.mjs"
+ */
+
+const { DocumentUUIDField, SetField } = foundry.data.fields;
+
+/**
+ * A type of effect that performs a summon.
+ */
+export default class SummonSpecialEffect extends BaseSpecialEffect {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "summon";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      pool: new SetField(new DocumentUUIDField({ type: "Actor", embedded: false })),
+      count: new requiredInteger({ initial: 1, min: 1 }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  get detailsPartial() {
+    return systemPath("templates/sheets/pseudo-documents/special-effect/summon.hbs");
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Places summons.
+   * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
+   */
+  async performSummon() {
+    if (!this.pool.size) return void ui.notifications.error("");
+    // Token permissions handled by placeActor
+    let uuid;
+
+    if (this.pool.size > 1) {
+
+      // TODO: Pick actor from pool
+
+      if (!uuid) return null;
+    }
+    else uuid = this.pool.first();
+
+    /** @type {DrawSteelActor} */
+    const sourceActor = await fromUuid(uuid);
+
+    if (!sourceActor) return void ui.notifications.error("");
+
+    let worldActor = game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(systemID, "summonSource") === this.document.uuid));
+
+    if (!worldActor) {
+      // Ensure the user has permission to drop the actor and create a Token.
+      if (!game.user.can("ACTOR_CREATE")) {
+        ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
+        return null;
+      }
+
+      worldActor = game.actors.importFromCompendium(sourceActor.pack, sourceActor.id, {
+        "flags.draw-steel.summonSource": this.document.uuid,
+      }, { keepId: true });
+    }
+
+    return canvas.tokens.placeActor(worldActor);
+  }
+}

--- a/templates/sheets/pseudo-documents/special-effect/summon.hbs
+++ b/templates/sheets/pseudo-documents/special-effect/summon.hbs
@@ -1,0 +1,3 @@
+
+{{formGroup fields.summoning.fields.pool value=source.summoning.pool name="summoning.pool"}}
+{{formGroup fields.summoning.fields.count value=source.summoning.count name="summoning.count" classes="slim"}}


### PR DESCRIPTION
Implements fixed-actor summoning logic as a new Special Effect.

<img width="493" height="667" alt="image" src="https://github.com/user-attachments/assets/b10dcd88-eb80-4680-a554-ce924c6a8e51" />

Implementation questions:
- How about abilities with Spend logic that replace what's summoned
- Call Forth as a "Portfolio" summon could be another subtype, as could the companion. The common thread is that effect sudokus figure out *which* actor to summon, and then the ability model method does the actual handling of reusing/importing the actor.