### PR TITLE
[#2024] Adjusted size update propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Increased foundry minimum to 14.366.
 - Retainers no longer show level-up when equal in level to their mentor. (#2015)
 - Dropping a class on a retainer will now prompt to delete the existing one. (#2030)
 - The "With Captain" select for minions can now be cleared.
+- Updating an actor's size will now also update their prototype token's depth, in addition to height and width. (#2024)
 
 ## 1.1.1
 

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -255,6 +255,7 @@ export default class BaseActorModel extends DrawSteelSystemModel {
         prototypeToken: {
           width: newSize,
           height: newSize,
+          depth: newSize,
         },
       });
     }


### PR DESCRIPTION
I'm unsure on which way to go; I think it's more useful to keep this prototype token update than not, but maybe we should *only* rely on the tokenActiveEffectChanges solution we have in CreatureModel#prepareDerivedData?

Closes #2024