### PR TITLE
[#2028] Removed winded handling from objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 - Added type hints for compendium-exclusive item types. (#2014)
 
+### Removed
+
+- Removed winded data and stamina bar markers from object actors. (#2028)
+
 ### Fixed
 
 - Updated Player-Facing Compendium Content:

--- a/src/module/canvas/placeables/token.mjs
+++ b/src/module/canvas/placeables/token.mjs
@@ -231,8 +231,10 @@ export default class DrawSteelToken extends foundry.canvas.placeables.Token {
       const zeroMark = (0 - data.min) / totalStamina * bw;
       bar.moveTo(zeroMark, 0).lineTo(zeroMark, bh);
     }
-    const windedMark = (data.winded - data.min) / totalStamina * bw;
-    bar.moveTo(windedMark, 0).lineTo(windedMark, bh);
+    if (data.winded) {
+      const windedMark = (data.winded - data.min) / totalStamina * bw;
+      bar.moveTo(windedMark, 0).lineTo(windedMark, bh);
+    }
 
     // Set position
     const posY = index === 0 ? height - bh : 0;

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -149,8 +149,6 @@ export default class BaseActorModel extends DrawSteelSystemModel {
     // If our current stamina has not been set, match it to max:
     this.stamina.value ??= this.stamina.max;
 
-    this.stamina.winded = Math.floor(this.stamina.max / 2);
-
     // Presents better if there's a 0 instead of blank
     this.combat.save.bonus ||= "0";
 

--- a/src/module/data/actor/creature.mjs
+++ b/src/module/data/actor/creature.mjs
@@ -58,6 +58,8 @@ export default class CreatureModel extends BaseActorModel {
   prepareDerivedData() {
     super.prepareDerivedData();
 
+    this.stamina.winded = Math.floor(this.stamina.max / 2);
+
     const highestCharacteristic = Math.max(0, ...Object.values(this.characteristics).map(c => c.value));
 
     this.potency.weak += highestCharacteristic - 2 + this.potency.bonuses;

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -111,7 +111,7 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
       barData.min = staminaData.min ?? 0;
       barData.value += staminaData.temporary || 0;
       barData.temporary = staminaData.temporary;
-      barData.winded = staminaData.winded;
+      if (staminaData.winded) barData.winded = staminaData.winded;
 
       return barData;
     }


### PR DESCRIPTION
Pretty sure this is fine to do in a hotfix. Bumped the winded assignment to CreatureModel and made sure our stamina bar drawing is sensitive to the possibility that winded might not be present.

Closes #2028 