### PR TITLE
Reworked Power & Damage Roll Display

### DIFF
--- a/src/module/data/pseudo-documents/message-parts/ability-result.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-result.mjs
@@ -101,7 +101,7 @@ export default class AbilityResultPart extends RollPart {
   static async #applyEffect(event, target) {
     /** @type {AppliedPowerRollEffect} */
     const pre = await fromUuid(target.dataset.uuid);
-    if (!pre) return void ui.notifications.error("DRAW_STEEL.ChatMessage.PARTS.abilityResult.NoPRE", { localize: true });
+    if (!pre) return void ui.notifications.error("DRAW_STEEL.ChatMessage.NoPRE", { localize: true });
 
     await pre.applyEffect(this.tierKey, target.dataset.effectId);
   }
@@ -118,7 +118,7 @@ export default class AbilityResultPart extends RollPart {
   static async #gainResource(event, target) {
     /** @type {GainResourcePowerRollEffect} */
     const pre = await fromUuid(target.dataset.uuid);
-    if (!pre) return void ui.notifications.error("DRAW_STEEL.ChatMessage.PARTS.abilityResult.NoPRE", { localize: true });
+    if (!pre) return void ui.notifications.error("DRAW_STEEL.ChatMessage.NoPRE", { localize: true });
 
     await pre.applyGain(this.tierKey);
   }

--- a/src/module/data/pseudo-documents/message-parts/ability-use.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-use.mjs
@@ -81,8 +81,6 @@ export default class AbilityUsePart extends BaseMessagePart {
     };
     context.ctx.embed = await item.toEmbed(embedConfig);
 
-    context.ctx.buttons = [];
-
     if (item.isOwner && item.system.hasTemplate) {
       context.ctx.buttons.push(ds.utils.constructHTMLButton({
         label: _loc("DRAW_STEEL.Item.ability.placeTemplate"),

--- a/src/module/data/pseudo-documents/message-parts/base-message-part.mjs
+++ b/src/module/data/pseudo-documents/message-parts/base-message-part.mjs
@@ -110,11 +110,14 @@ export default class BaseMessagePart extends TypedPseudoDocument {
    * @returns {Promise<void>}
    */
   async _prepareContext(context) {
-    context.ctx = {};
+    context.ctx = {
+      buttons: [],
+    };
+
     const isPrivate = context.ctx.isPrivate = !this.isContentVisible;
     const name = this.message.author?.name ?? _loc("CHAT.UnknownUser");
     context.ctx.flavor = isPrivate ? _loc("CHAT.PrivateRollContent", { user: foundry.utils.escapeHTML(name) }) : this.flavor;
-    context.ctx.rolls = await Promise.all(this.rolls.map(roll => roll.render({ isPrivate })));
+    context.ctx.rolls = await Promise.all(this.rolls.map((roll, rollIndex) => roll.render({ isPrivate, rollIndex })));
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/message-parts/project.mjs
+++ b/src/module/data/pseudo-documents/message-parts/project.mjs
@@ -63,7 +63,6 @@ export default class ProjectPart extends BaseMessagePart {
   async _prepareContext(context) {
     await super._prepareContext(context);
 
-    context.ctx.buttons = [];
     const project = this.project;
     const eventSetting = game.settings.get(systemID, "projectEvents");
 

--- a/src/module/data/pseudo-documents/message-parts/roll.mjs
+++ b/src/module/data/pseudo-documents/message-parts/roll.mjs
@@ -23,16 +23,4 @@ export default class RollPart extends BaseMessagePart {
 
   /** @inheritdoc */
   static TEMPLATE = systemPath("templates/sidebar/chat/parts/roll.hbs");
-
-  /* -------------------------------------------------- */
-
-  /** @inheritdoc */
-  async _prepareContext(context) {
-    await super._prepareContext(context);
-
-    context.ctx.buttons = this.rolls.map((roll, i) => {
-      if (roll instanceof DamageRoll) return roll.toRollButton(i);
-      return null;
-    }).filter(_ => _);
-  }
 }

--- a/src/module/data/pseudo-documents/message-parts/saving-throw.mjs
+++ b/src/module/data/pseudo-documents/message-parts/saving-throw.mjs
@@ -54,7 +54,6 @@ export default class SavingThrowPart extends BaseMessagePart {
   async _prepareContext(context) {
     await super._prepareContext(context);
 
-    context.ctx.buttons = [];
     const effect = this.effect;
 
     // Strictly GM-owned actors shouldn't have this option, and should only show if you have effect perms

--- a/src/module/data/pseudo-documents/message-parts/test-request.mjs
+++ b/src/module/data/pseudo-documents/message-parts/test-request.mjs
@@ -49,7 +49,6 @@ export default class TestRequestPart extends BaseMessagePart {
   /** @inheritdoc */
   async _prepareContext(context) {
     await super._prepareContext(context);
-    context.ctx.buttons ??= [];
 
     // Result source is expected to be a Power Roll Tier Outcomes page.
     const resultSource = await fromUuid(this.resultSource);

--- a/src/module/rolls/damage.mjs
+++ b/src/module/rolls/damage.mjs
@@ -1,4 +1,5 @@
 import DSRoll from "./base.mjs";
+import { systemPath } from "../constants.mjs";
 
 /**
  * A roll subclass with damage-specific info like damage type.
@@ -23,6 +24,11 @@ export default class DamageRoll extends DSRoll {
 
     await roll.applyDamage(null, { halfDamage: event.shiftKey });
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static CHAT_TEMPLATE = systemPath("templates/rolls/damage.hbs");
 
   /* -------------------------------------------------- */
 
@@ -73,6 +79,26 @@ export default class DamageRoll extends DSRoll {
    */
   get aoe() {
     return this.options.aoe || false;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareChatRenderContext(options = {}) {
+    const context = await super._prepareChatRenderContext(options);
+
+    context.isGM = game.user.isGM;
+    if ("rollIndex" in options) {
+      Object.assign(context, {
+        rollIndex: options.rollIndex,
+        buttonIcon: this.isHeal ? "fa-solid fa-heart-pulse" : "fa-solid fa-burst",
+        tooltipPath: this.isHeal ?
+          "DRAW_STEEL.ChatMessage.base.Buttons.ApplyHeal.Tooltip" :
+          "DRAW_STEEL.ChatMessage.base.Buttons.ApplyDamage.Tooltip",
+      });
+    }
+
+    return context;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/rolls/power.mjs
+++ b/src/module/rolls/power.mjs
@@ -63,6 +63,7 @@ export default class PowerRoll extends DSRoll {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
   static CHAT_TEMPLATE = systemPath("templates/rolls/power.hbs");
 
   /* -------------------------------------------------- */

--- a/src/styles/system/applications/sidebar/tabs/chat.css
+++ b/src/styles/system/applications/sidebar/tabs/chat.css
@@ -53,10 +53,6 @@
     }
 
     .dice-roll {
-      border: 1px solid var(--color-border-light-2);
-      padding: 5px;
-      border-radius: 5px;
-
       .header {
         flex-basis: 100%;
         text-align: center;
@@ -66,17 +62,32 @@
 
       .inline-result {
         display: flex;
+        gap: 5px;
+        align-items: stretch;
         margin-bottom: 5px;
 
         .dice-formula {
-          flex: 1 0 calc(100% - 50px);
+          flex: 1;
           border-radius: 3px 0px 0px 3px;
           margin-bottom: 0px;
+          line-height: 30px;
         }
 
         .dice-total {
           flex: 0 0 50px;
-          border-radius: 0px 3px 3px 0px;
+          border-radius: 3px 0px 0px 3px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          &.apply-damage {
+            flex: 0 0 100px;
+            border-radius: 0px 3px 3px 0px;
+            border: 1px solid var(--button-border-color);
+            &:hover {
+              background-color: var(--button-hover-background-color);
+              border-color: var(--button-hover-border-color);
+            }
+          }
         }
       }
 

--- a/templates/rolls/damage.hbs
+++ b/templates/rolls/damage.hbs
@@ -1,0 +1,25 @@
+<div class="dice-roll" data-action="expandRoll">
+  {{#if flavor}}
+  <div class="dice-flavor">{{flavor}}</div>
+  {{/if}}
+  <div class="dice-result">
+    <div class="inline-result">
+      <div class="dice-formula">{{formula}}</div>
+      {{#if rollIndex includeZero=true}}
+      <button
+        type="button"
+        data-action="applyDamage"
+        class="dice-total apply-damage"
+        data-tooltip="{{tooltipPath}}"
+        data-index="{{rollIndex}}"
+      >
+        <i class="{{buttonIcon}}"></i>
+        {{total}}
+      </button>
+      {{else}}
+      <h4 class="dice-total">{{total}}</h4>
+      {{/if}}
+    </div>
+    {{{tooltip}}}
+  </div>
+</div>

--- a/templates/rolls/damage.hbs
+++ b/templates/rolls/damage.hbs
@@ -13,7 +13,7 @@
         data-tooltip="{{tooltipPath}}"
         data-index="{{rollIndex}}"
       >
-        <i class="{{buttonIcon}}"></i>
+        <i class="{{buttonIcon}}" inert></i>
         {{total}}
       </button>
       {{else}}

--- a/templates/rolls/power.hbs
+++ b/templates/rolls/power.hbs
@@ -9,19 +9,20 @@
   {{/if}}
   {{/if}}
 
-  <div class="tier {{tier.class}}">
-    {{tier.label}}
-    {{#if modifier.number}}
-    <em>({{localize "DRAW_STEEL.ROLL.Power.Modifier.Label" number=modifier.number mod=modifier.mod}})</em>
-    {{/if}}
-  </div>
-  {{#if flavor}}
-  <div class="dice-flavor">{{flavor}}</div>
-  {{/if}}
   <div class="dice-result" data-tooltip-text="{{formula}}">
     <div class="inline-result">
-      <div class="dice-formula">{{flavorlessFormula}}</div>
       <div class="dice-total {{critical}}">{{total}}</div>
+      <div class="power-result">
+        <div class="tier {{tier.class}}">
+          {{tier.label}}
+          {{#if modifier.number}}
+          <em>({{localize "DRAW_STEEL.ROLL.Power.Modifier.Label" number=modifier.number mod=modifier.mod}})</em>
+          {{/if}}
+        </div>
+        {{#if flavor}}
+        <div class="dice-flavor">{{flavor}}</div>
+      </div>
+      {{/if}}
     </div>
     {{{tooltip}}}
   </div>


### PR DESCRIPTION
Massively condensed the space used for the power roll and damage results ahead of work to implement per-target message parts for #1628

<img width="297" height="642" alt="image" src="https://github.com/user-attachments/assets/246b91bd-c508-47bc-89df-b22015acf054" />

<img width="291" height="874" alt="image" src="https://github.com/user-attachments/assets/f049eb0f-200e-4544-9bd7-1522a59147dc" />
