### PR TITLE
[#1628] Implemented ability target part

### DIFF
--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2108,6 +2108,9 @@ export const MessagePart = {
   savingThrow: {
     documentClass: pseudoDocuments.messageParts.SavingThrowPart,
   },
+  targetResult: {
+    documentClass: pseudoDocuments.messageParts.TargetResult,
+  },
   test: {
     documentClass: pseudoDocuments.messageParts.TestPart,
   },

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -607,7 +607,14 @@ export default class AbilityModel extends BaseItemModel {
 
       const evaluatedRolls = [];
 
+      const targets = [];
+
       for (const context of fd.rolls) {
+        // Strip from roll options
+        if (context.target) {
+          targets.push(context.target);
+          delete context.target;
+        }
         const roll = new PowerRoll(dialogConfig.context.formula, {}, { flavor: _loc(PowerRoll.TYPES.ability.label), ...context });
         roll.terms[0] = baseRoll.terms[0];
         await roll.evaluate({ allowInteractive: false });
@@ -615,17 +622,16 @@ export default class AbilityModel extends BaseItemModel {
         evaluatedRolls.push(roll);
       }
 
-      // Power Rolls grouped by tier of success
-      const groupedRolls = Object.groupBy(evaluatedRolls, roll => roll.product);
+      evaluatedRolls.sort((a, b) => a.product - b.product);
 
-      // Each tier group gets a message part. Rolls within a group are in the same message part
-      for (const tierNumber in groupedRolls) {
+      if (!targets.length) {
+        const tierNumber = evaluatedRolls[0].product;
         const partId = `tier${tierNumber}Result`.padEnd(16, "0");
 
         const rollPart = {
           _id: partId,
           type: "abilityResult",
-          rolls: groupedRolls[tierNumber],
+          rolls: evaluatedRolls,
           tier: tierNumber,
           abilityUuid: this.parent.uuid,
         };
@@ -643,6 +649,34 @@ export default class AbilityModel extends BaseItemModel {
         }
 
         messageData.system.parts[partId] = rollPart;
+      }
+      else {
+        for (const [index, roll] of evaluatedRolls.entries()) {
+          const partId = foundry.utils.randomID();
+
+          const rollPart = {
+            _id: partId,
+            type: "targetResult",
+            rolls: [roll],
+            tier: roll.product,
+            abilityUuid: this.parent.uuid,
+            targetUuid: targets[index],
+          };
+
+          for (const damageEffect of this.power.effects.documentsByType.damage) {
+            const damageRoll = damageEffect.toDamageRoll(roll.product, {
+              damageSelection: fd.damage,
+              spend: Object.values(fd.spend ?? {}),
+            });
+            if (!damageRoll) continue;
+            await damageRoll.evaluate();
+            rollPart.rolls.push(damageRoll);
+            // If there's a roll, add it to the base message data for DSN purposes
+            if (!damageRoll.isDeterministic) messageData.rolls.push(damageRoll);
+          }
+
+          messageData.system.parts[partId] = rollPart;
+        }
       }
     }
 

--- a/src/module/data/pseudo-documents/message-parts/_module.mjs
+++ b/src/module/data/pseudo-documents/message-parts/_module.mjs
@@ -5,6 +5,7 @@ export { default as ContentPart } from "./content.mjs";
 export { default as HeroTokenPart } from "./hero-token.mjs";
 export { default as RollPart } from "./roll.mjs";
 export { default as SavingThrowPart } from "./saving-throw.mjs";
+export { default as TargetResult } from "./target-result.mjs";
 export { default as TestRequestPart } from "./test-request.mjs";
 export { default as TestPart } from "./test.mjs";
 export { default as ProjectPart } from "./project.mjs";

--- a/src/module/data/pseudo-documents/message-parts/_types.d.ts
+++ b/src/module/data/pseudo-documents/message-parts/_types.d.ts
@@ -29,6 +29,14 @@ declare module "./hero-token.mjs" {
   }
 }
 
+declare module "./target-result.mjs" {
+  export default interface TargetResult {
+    abilityUuid: string;
+    tier: number;
+    targetUuid: string;
+  }
+}
+
 declare module "./test-request.mjs" {
   export default interface TestRequestPart {
     characteristics: Set<string>;

--- a/src/module/data/pseudo-documents/message-parts/target-result.mjs
+++ b/src/module/data/pseudo-documents/message-parts/target-result.mjs
@@ -1,0 +1,337 @@
+import DamageRoll from "../../../rolls/damage.mjs";
+import RollPart from "./roll.mjs";
+import { systemPath } from "../../../constants.mjs";
+
+/**
+ * @import { DrawSteelActor, DrawSteelItem, DrawSteelTokenDocument } from "../../../documents/_module.mjs";
+ * @import AbilityData from "../../item/ability.mjs";
+ * @import { AppliedPowerRollEffect, GainResourcePowerRollEffect } from "../power-roll-effects/_module.mjs";
+ * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs"
+ */
+
+const { DocumentUUIDField, NumberField } = foundry.data.fields;
+const { createFormGroup, createNumberInput, createSelectInput, createTextInput } = foundry.applications.fields;
+
+/**
+ * A part that displays the result of an ability power roll and its consequences for a single target.
+ */
+export default class TargetResultPart extends RollPart {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "targetResult";
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static ACTIONS = {
+    ...super.ACTIONS,
+    applyDamage: this.#applyDamage,
+    applyEffect: this.#applyEffect,
+    gainResource: this.#gainResource,
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static TEMPLATE = systemPath("templates/sidebar/chat/parts/target-result.hbs");
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return Object.assign(super.defineSchema(), {
+      abilityUuid: new DocumentUUIDField({ nullable: false, type: "Item" }),
+      tier: new NumberField({ integer: true, min: 1, max: 3, nullable: false }),
+      targetUuid: new DocumentUUIDField({ nullable: false, type: "Actor" }),
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Fetches the ability from the UUID. Can return null if the effect no longer exists.
+   * @type {Omit<DrawSteelItem, "system"> & { system: AbilityData } | null}
+   */
+  get ability() {
+    return fromUuidSync(this.abilityUuid);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The targeted token.
+   * @type {DrawSteelTokenDocument}
+   */
+  get token() {
+    return this.actorTarget.token ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The targeted actor, or null if one is not available.
+   * @type {DrawSteelActor | null}
+   */
+  get actorTarget() {
+    return fromUuidSync(this.targetUuid) ?? null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The key of the tier.
+   * @type {"tier1" | "tier2" | "tier3" | null}
+   */
+  get tierKey() {
+    const tier = this.tier;
+    if (tier) return `tier${tier}`;
+    else return null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(context) {
+    await super._prepareContext(context);
+
+    const token = this.token;
+    const actor = this.actorTarget;
+    context.ctx.target = {
+      owner: actor.isOwner,
+      uuid: this.targetUuid,
+      name: token?.name || actor?.name || _loc("COMMON.Unknown"),
+      img: token?.img || actor?.img || getDocumentClass("Token").DEFAULT_ICON,
+    };
+
+    const item = this.ability;
+
+    if (item) {
+      for (const pre of item.system.power.effects) {
+        const newButtons = pre.constructButtons(this.tier);
+        if (newButtons) context.ctx.buttons.push(...newButtons);
+      }
+
+      context.ctx.foundItem = true;
+      context.ctx.tierSymbol = ds.rolls.PowerRoll.RESULT_TIERS[`tier${this.tier}`].glyph;
+      context.ctx.resultHTML = await item.system.powerRollText(this.tier);
+    }
+
+    context.ctx.showContextMenu = !!this.rolls.find(roll => (roll instanceof DamageRoll) && !roll.isHeal);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Apply damage to the targeted actor.
+   *
+   * @this TargetResultPart
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #applyDamage(event, target) {
+    const idx = target.dataset.index;
+    const roll = this.rolls[idx];
+    await roll.applyDamage([this.actorTarget], { halfDamage: event.shiftKey });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Apply an effect to the targeted actor.
+   *
+   * @this TargetResultPart
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #applyEffect(event, target) {
+    /** @type {AppliedPowerRollEffect} */
+    const pre = await fromUuid(target.dataset.uuid);
+    if (!pre) return void ui.notifications.error("DRAW_STEEL.ChatMessage.NoPRE", { localize: true });
+
+    await pre.applyEffect(this.tierKey, target.dataset.effectId, { targets: [this.actorTarget] });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Apply an effect to the targeted actor.
+   *
+   * @this TargetResultPart
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #gainResource(event, target) {
+    /** @type {GainResourcePowerRollEffect} */
+    const pre = await fromUuid(target.dataset.uuid);
+    if (!pre) return void ui.notifications.error("DRAW_STEEL.ChatMessage.NoPRE", { localize: true });
+
+    await pre.applyGain(this.tierKey, { targets: [this.actorTarget] });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create a new DamageRoll based on applying modifications to a given DamageRoll.
+   * After creation, the new roll is added to the message rolls.
+   * @param {DamageRoll} roll The damage roll to modify.
+   * @param {object} modifications The modification options to apply.
+   * @param {string} [modifications.additionalTerms] Additional formula components to append to the roll.
+   * @param {string} [modifications.damageType] The damage type to use for the modified roll.
+   * @param {object} [evaluationOptions={}] Options passed to the DamageRoll#evaluate.
+   * @returns {Promise<DamageRoll>}
+   */
+  async createModifiedDamageRoll(roll, { additionalTerms = "", damageType }, evaluationOptions = {}) {
+    const rollData = this.ability?.getRollData() ?? this.message.getRollData();
+
+    const newRoll = DamageRoll.fromData(roll.toJSON());
+
+    if (additionalTerms) {
+      const terms = DamageRoll.parse(additionalTerms, rollData);
+      for (const term of terms) if (!term._evaluated) await term.evaluate(evaluationOptions);
+      newRoll.terms = newRoll.terms.concat(new foundry.dice.terms.OperatorTerm({ operator: "+" }), terms);
+      newRoll.resetFormula();
+      newRoll._total = newRoll._evaluateTotal();
+    }
+
+    if (damageType !== undefined) {
+      // Without this, changing the new roll damage type changes the original rolls damage type.
+      newRoll.options = { ...newRoll.options };
+      newRoll.options.type = damageType;
+      const damageLabel = ds.CONFIG.damageTypes[damageType]?.label ?? damageType ?? "";
+      const flavor = _loc("DRAW_STEEL.Item.ability.DamageFlavor", { type: damageLabel });
+      newRoll.options.flavor = flavor;
+    }
+
+    const rolls = this.rolls.concat(newRoll);
+
+    await this.update({ rolls }, { notify: true, ds: {
+      dsn: { [this.id]: [rolls.length - 1] },
+    } });
+
+    return newRoll;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _addListeners(element, context) {
+    super._addListeners(element, context);
+
+    const menuItems = this._getResultPartContextOptions();
+    new foundry.applications.ux.ContextMenu.implementation(element, "[data-action=resultPartContext", menuItems, { jQuery: false, fixed: true, eventName: "click" });
+
+    // Buttons in this part that require ownership of the targeted actor
+    if (!this.actorTarget?.isOwner) {
+      const ownerButtons = new Set("applyDamage", "applyEffect", "gainResource");
+      for (const button of element.querySelectorAll("[data-action]")) {
+        if (!ownerButtons.has(button.dataset.action)) continue;
+        button.disabled = true;
+        button.classList.add("disabled");
+      }
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Get context menu entries for this ability result part.
+   * @returns {ContextMenuEntry[]}
+   */
+  _getResultPartContextOptions() {
+    const damageRolls = this.rolls.filter(roll => (roll instanceof DamageRoll) && !roll.isHeal);
+    if (!damageRolls.length) return [];
+
+    const baseLocalizationPath = "DRAW_STEEL.ChatMessage.PARTS.abilityResult.ContextMenuOptions.DamageModification";
+    return damageRolls.map(roll => {
+      const damageType = ds.CONFIG.damageTypes[roll.options.type]?.label ?? roll.options.type;
+      const label = _loc(`${baseLocalizationPath}.${damageType ? "WithType" : "Typeless"}`, {
+        total: roll.total,
+        type: damageType,
+      });
+      return {
+        label,
+        icon: "fa-solid fa-gear",
+        visible: () => this.message.isOwner,
+        onClick: () => this.modifyDamageDialog(roll),
+      };
+    });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+  * Prompt the dialog to modify the damage roll and then create the modified roll.
+  * @param {DamageRoll} roll
+  */
+  async modifyDamageDialog(roll) {
+    const content = document.createElement("div");
+
+    let sourceActor = this.ability?.actor;
+
+    // Retainers use their mentor's surges and surge value
+    if (sourceActor.type === "retainer") sourceActor = sourceActor.system.retainer.mentor;
+
+    const surgeDamage = sourceActor.getRollData()?.chr;
+
+    if (sourceActor.type === "hero") {
+      const surgeMax = Math.min(3, sourceActor.system.hero.surges);
+
+      const surges = createFormGroup({
+        label: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Surges.label",
+        hint: _loc("DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Surges.hint", { damage: surgeDamage }),
+        input: createNumberInput({ name: "surges", step: 1, min: 0, max: surgeMax }),
+        localize: true,
+        classes: ["slim"],
+      });
+
+      content.append(surges);
+    }
+
+    const additionalTermGroup = createFormGroup({
+      label: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.AdditionalTerms.label",
+      hint: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.AdditionalTerms.hint",
+      input: createTextInput({ name: "additionalTerms" }),
+      localize: true,
+    });
+
+    const damageTypes = Object.entries(ds.CONFIG.damageTypes).map(([value, { label }]) => ({ value, label }));
+    const damageSelect = createSelectInput({
+      value: roll.options.type,
+      options: damageTypes,
+      name: "damageType",
+      blank: "",
+    });
+    const damageTypeGroup = createFormGroup({
+      label: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.DamageType.label",
+      hint: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.DamageType.hint",
+      input: damageSelect,
+      localize: true,
+    });
+
+    content.append(additionalTermGroup, damageTypeGroup);
+
+    const modifications = await ds.applications.api.DSDialog.input({
+      content,
+      classes: ["modify-damage-dialog"],
+      window: {
+        title: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Title",
+        icon: "fa-fw fa-solid fa-gear",
+      },
+    });
+
+    // If the dialog is closed or submitted without modifications, don't create a new roll.
+    if (!modifications) return;
+
+    if (modifications.surges) {
+      await sourceActor.modifyTokenAttribute("hero.surges", -1 * modifications.surges, true, false);
+      if (modifications.additionalTerms) modifications.additionalTerms += `+ ${modifications.surges} * ${surgeDamage}`;
+      else modifications.additionalTerms = `${modifications.surges} * ${surgeDamage}`;
+      delete modifications.surges;
+    }
+
+    if ((!modifications.additionalTerms) && (modifications.damageType === roll.options.type)) return;
+
+    return this.createModifiedDamageRoll(roll, modifications);
+  }
+}

--- a/src/styles/system/applications/sidebar/tabs/chat.css
+++ b/src/styles/system/applications/sidebar/tabs/chat.css
@@ -17,7 +17,18 @@
 
       .message-part-header {
         display: flex;
-        justify-content: end;
+        justify-content: space-between;
+        flex-direction: row-reverse;
+
+        img {
+          width: 40px;
+        }
+        .targetName {
+          text-align: center;
+          font-size: var(--font-size-16);
+          font-weight: bold;
+          line-height: 30px;
+        }
       }
 
       .message-part-flavor {

--- a/templates/sidebar/chat/parts/target-result.hbs
+++ b/templates/sidebar/chat/parts/target-result.hbs
@@ -1,0 +1,24 @@
+{{#if ctx.showContextMenu}}
+<div class="message-part-header">
+  <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="resultPartContext"></a>
+  {{#if ctx.target.owner}}
+  <a class="targetName" data-uuid="{{ctx.target.uuid}}" data-tooltip="DRAW_STEEL.ROLL.Power.SelectToken" data-action="selectToken">
+    {{ctx.target.name}}
+  </a>
+  {{else}}
+  <div class="targetName" data-uuid="{{ctx.target.uuid}}">{{ctx.target.name}}</div>
+  {{/if}}
+  <img src="{{ctx.target.img}}">
+</div>
+{{/if}}
+{{#if part.flavor}}
+<div class="message-part-flavor">{{ctx.flavor}}</div>
+{{/if}}
+<div class="message-part-rolls">
+  {{#each ctx.rolls}}{{{this}}}{{/each}}
+</div>
+{{#if ctx.buttons.length}}
+<footer class="message-part-buttons">
+  {{#each ctx.buttons as |button|}}{{{button.outerHTML}}}{{/each}}
+</footer>
+{{/if}}


### PR DESCRIPTION
Implements a new part that handles results by target rather than our current method of grouping by tier result. Currently just rewires the existing buttons to apply to only the target rather than fully implementing a "Confirm Effects" type logic. This unblocks significant other work such as #1320 as well as #1869.

<img width="291" height="314" alt="image" src="https://github.com/user-attachments/assets/6c7f95c5-51ed-469c-ad18-ea13ca6b28e7" />


Closes #1628