### PR TITLE
[#1387] Improved unowned ability damage display

### DIFF
--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -153,7 +153,8 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
     }
 
     const simplifiedFormula = this.actor ? ds.utils.simplifyRollFormula(value, this.item.getRollData()) : value;
-    const formattedDamageString = Handlebars.escapeExpression(_loc(i18nString, { value: simplifiedFormula, damageTypes }));
+    let formattedDamageString = Handlebars.escapeExpression(_loc(i18nString, { value: simplifiedFormula, damageTypes }));
+    if (!this.actor) formattedDamageString = this.#replaceRollData(formattedDamageString);
 
     let result = `<span data-tooltip="${value}" data-tooltip-direction="UP">${formattedDamageString}</span>`;
 
@@ -179,6 +180,27 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
       damage: result,
       potency: potencyString,
     });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Replace roll data terms with DS glyphs.
+   * @param {string} formula
+   * @returns {string}
+   */
+  #replaceRollData(formula) {
+    const data = Object.entries(ds.CONFIG.characteristics).reduce((rollData, [key, chr]) => {
+      const html = rollData[chr.rollKey] = `<span style="font-family: var(--font-glyph)">${chr.rollKey}</span>`;
+      if (this.parent.power.roll.characteristics.has(key)) rollData.chr.push(html);
+      return rollData;
+    }, { chr: [] });
+
+    const formatter = game.i18n.getListFormatter({ type: "disjunction" });
+
+    data.chr = formatter.format(data.chr);
+
+    return DamageRoll.replaceFormulaData(formula, data);
   }
 
   /* -------------------------------------------------- */


### PR DESCRIPTION
Only real question is if we want to sub the inline styles for a class on the spans. This also improves our embed rendering (the original impetus for the ticket).

<img width="571" height="359" alt="image" src="https://github.com/user-attachments/assets/5563dc6d-d053-4062-a423-50ea37f9c144" />

<img width="573" height="363" alt="image" src="https://github.com/user-attachments/assets/f1860f4c-bb16-4043-bb1a-b6fd7f8f354c" />

<img width="514" height="212" alt="image" src="https://github.com/user-attachments/assets/e7d8c092-0855-4fd8-9e8a-aed1fd33a214" />

Closes #1387