### PR TITLE
[#1871] Track maximum HR within turn cycle

### DIFF
--- a/src/module/data/actor/_types.d.ts
+++ b/src/module/data/actor/_types.d.ts
@@ -122,11 +122,6 @@ declare module "./creature.mjs" {
 }
 
 declare module "./hero.mjs" {
-  type HeroicResource = {
-    value: number;
-    label?: string;
-  };
-
   export default interface HeroModel {
     combat: Combat & {
       initiativeThreshold: number;
@@ -137,8 +132,15 @@ declare module "./hero.mjs" {
       divisor: number;
     };
     hero: {
-      primary: HeroicResource;
-      epic: HeroicResource;
+      primary: {
+        value: number;
+        tracking: number;
+        label?: string;
+      };
+      epic: {
+        value: number;
+        label?: string;
+      };
       xp: number;
       renown: number;
       wealth: number;

--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -4,8 +4,8 @@ import FormulaField from "../fields/formula-field.mjs";
 import SizeModel from "../models/size.mjs";
 
 /**
- * @import { DataField } from "@common/data/fields.mjs";
- * @import { DrawSteelActor, DrawSteelCombatant, DrawSteelCombatantGroup } from "../../documents/_module.mjs";
+ * @import { DatabaseUpdateOperation } from "@common/abstract/_types.mjs";
+ * @import { DrawSteelActor, DrawSteelCombatant, DrawSteelCombatantGroup, DrawSteelUser } from "../../documents/_module.mjs";
  * @import AbilityModel from "../item/ability.mjs";
  * @import { CoreResource } from "./_types";
  * @import { AbilityBonus } from "../_types";
@@ -242,8 +242,8 @@ export default class BaseActorModel extends DrawSteelSystemModel {
   /**
    * @inheritdoc
    * @param {Record<string, unknown>} changes
-   * @param {import("@common/abstract/_types.mjs").DatabaseUpdateOperation} operation
-   * @param {User} user
+   * @param {DatabaseUpdateOperation} options
+   * @param {DrawSteelUser} user
    */
   async _preUpdate(changes, options, user) {
     const allowed = await super._preUpdate(changes, options, user);
@@ -361,6 +361,15 @@ export default class BaseActorModel extends DrawSteelSystemModel {
    * @abstract
    */
   async _onStartTurn(combatant) {}
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Updates performed at the end of this actor's turn.
+   * @param {DrawSteelCombatant} combatant The combatant representation.
+   * @abstract
+   */
+  async _onEndTurn(combatant) {}
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -313,7 +313,7 @@ export default class HeroModel extends CreatureModel {
   /** @inheritdoc */
   async _onEndTurn(combatant) {
     await super._onEndTurn(combatant);
-    await this.parent.update({ "system.hero.primary.tracking": this.hero.primary.value });
+    await this.parent.update({ "system.hero.primary.tracking": this.hero.primary.value }, { render: false });
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -62,6 +62,7 @@ export default class HeroModel extends CreatureModel {
     schema.hero = new fields.SchemaField({
       primary: new fields.SchemaField({
         value: new fields.NumberField({ initial: 0, integer: true, nullable: false }),
+        tracking: new fields.NumberField({ initial: 0, integer: true, nullable: false }),
       }),
       epic: new fields.SchemaField({
         value: new fields.NumberField({ initial: 0, integer: true, nullable: false }),
@@ -273,6 +274,17 @@ export default class HeroModel extends CreatureModel {
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  async _preUpdate(changes, options, user) {
+    const allowed = await super._preUpdate(changes, options, user);
+    if (allowed === false) return false;
+
+    const hr = foundry.utils.getProperty(changes, "system.hero.primary.value");
+    if (Number.isNumeric(hr)) foundry.utils.setProperty(changes, "system.hero.primary.tracking", Math.max(hr, this.hero.primary.tracking));
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   async startCombat(combatant) {
     await super.startCombat(combatant);
     await this.parent.update({ "system.hero.primary.value": this.hero.victories });
@@ -294,6 +306,14 @@ export default class HeroModel extends CreatureModel {
       });
       await this.updateResource(recoveryRoll.total);
     }
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _onEndTurn(combatant) {
+    await super._onEndTurn(combatant);
+    await this.parent.update({ "system.hero.primary.tracking": this.hero.primary.value });
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/combat.mjs
+++ b/src/module/documents/combat.mjs
@@ -317,6 +317,7 @@ export default class DrawSteelCombat extends foundry.documents.Combat {
         SavingThrowManager.delegateSavingThrow(effect);
       }
     }
+    combatant.actor?.system._onEndTurn(combatant);
   }
 
   /* -------------------------------------------------- */


### PR DESCRIPTION
Some classes, like the Fury and Null, care about piling up resources. However, the benefits of you stockpiling your heroic resource don't expire until the end of your turn, which means we need to track the highest those resources go and then only reset the value at the end of turn. To do this I've implemented a generalized _onEndTurn logic for actor data models.

By itself, this PR doesn't actually accomplish much, but it sets up for #702 where we'd actually have data on AEs that suppresses them based on the actor conditions.

A follow-up question is that since we fixed the general combat order logic, it might make more sense to have our _onStartTurn trigger care about the combat tracker defined start of turn, rather than the initiative value (# of turns remaining this round) decreasing.

Closes #1871