### PR TITLE
[#348] Automatically toggle with captain effects

### DIFF
--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -1,6 +1,9 @@
 import BaseCombatantGroupModel from "./base.mjs";
-import { DrawSteelActor } from "../../documents/_module.mjs";
 import DrawSteelCombatant from "../../documents/combatant.mjs";
+
+/**
+ * @import { DrawSteelActiveEffect, DrawSteelActor } from "../../documents/_module.mjs";
+ */
 
 const fields = foundry.data.fields;
 
@@ -96,6 +99,8 @@ export default class SquadModel extends BaseCombatantGroupModel {
       this.checkDefeatedMinions();
     }
     if (options.ds?.staminaDiff) this.displayMinionStaminaChange(options.ds.staminaDiff, options.ds.damageType);
+
+    if (game.user.isActiveGM && changed.system && ("captainId" in changed.system)) this.refreshCaptainEffect();
   }
 
   /* -------------------------------------------------- */
@@ -110,6 +115,30 @@ export default class SquadModel extends BaseCombatantGroupModel {
     this.minions.forEach((minion) => {
       minion.actor?.system.displayStaminaChange(diff, damageType);
     });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Refresh all captain effects on minions in this squad.
+   */
+  async refreshCaptainEffect() {
+    const active = this.captain && !this.captain.isDefeated;
+    const operation = this.minions.reduce((batch, minion) => {
+      /** @type {DrawSteelActiveEffect} */
+      const effect = minion.actor?.system.monster.withCaptainEffect;
+      if (effect) batch.push({
+        action: "update",
+        // prefer disable/enable to expiry because we delete expired AEs at the end of combat
+        updates: [{ _id: effect.id, disabled: !active }],
+        documentName: "ActiveEffect",
+        parent: effect.parent,
+        pack: effect.pack,
+      });
+      return batch;
+    }, []);
+
+    await foundry.documents.modifyBatch(operation);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/combatant-group/squad.mjs
+++ b/src/module/data/combatant-group/squad.mjs
@@ -124,21 +124,15 @@ export default class SquadModel extends BaseCombatantGroupModel {
    */
   async refreshCaptainEffect() {
     const active = this.captain && !this.captain.isDefeated;
-    const operation = this.minions.reduce((batch, minion) => {
-      /** @type {DrawSteelActiveEffect} */
-      const effect = minion.actor?.system.monster.withCaptainEffect;
-      if (effect) batch.push({
-        action: "update",
-        // prefer disable/enable to expiry because we delete expired AEs at the end of combat
-        updates: [{ _id: effect.id, disabled: !active }],
-        documentName: "ActiveEffect",
-        parent: effect.parent,
-        pack: effect.pack,
-      });
-      return batch;
-    }, []);
+    const actors = new Set(Array.from(this.minions).map(c => c.actor).filter(_ => _));
+    const operations = Array.from(actors).map(actor => {
+      const effect = actor.system.monster.withCaptainEffect;
+      if (!effect) return null;
 
-    await foundry.documents.modifyBatch(operation);
+      const { documentName, parent, pack, id } = effect;
+      return { documentName, parent, pack, action: "update", updates: [{ _id: id, disabled: !active }] };
+    }).filter(_ => _);
+    await foundry.documents.modifyBatch(operations);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/_types.d.ts
+++ b/src/module/documents/_types.d.ts
@@ -77,6 +77,7 @@ declare module "@client/documents/_module.mjs" {
   interface BaseCombatant extends CombatantData, InstanceType<ClientDocument> {
     type: "base";
     system: CombatantModels.BaseCombatantModel;
+    group: DrawSteelCombatantGroup;
   }
 
   interface BaseJournalEntry extends JournalEntryData, InstanceType<ClientDocument> {

--- a/src/module/documents/combatant.mjs
+++ b/src/module/documents/combatant.mjs
@@ -42,6 +42,7 @@ export default class DrawSteelCombatant extends foundry.documents.Combatant {
       }
       this.refreshCombatant();
     }
+    if (game.user.isActiveGM && ("defeated" in changed) && this.system.isCaptain) this.group.system.refreshCaptainEffect();
   }
 
   /* -------------------------------------------------- */
@@ -51,6 +52,7 @@ export default class DrawSteelCombatant extends foundry.documents.Combatant {
     super._onDelete(options, userId);
 
     this.group?.system.refreshSquad();
+    if (game.user.isActiveGM) this.group?.system.refreshCaptainEffect?.();
     this.refreshCombatant();
   }
 

--- a/src/module/documents/token.mjs
+++ b/src/module/documents/token.mjs
@@ -89,6 +89,14 @@ export default class DrawSteelTokenDocument extends foundry.documents.TokenDocum
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _onRelatedUpdate(update = {}, operation = {}) {
+    if (game.user.isActiveGM) this.combatant?.group?.system.refreshCaptainEffect?.();
+    return super._onRelatedUpdate(update, operation);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   async _onOverrideSize(changes) {
     return this.resize(changes, { pan: false, animation: {
       duration: 500,


### PR DESCRIPTION
Main design decision was to just use the `disabled` property because we auto-delete `expired` effects as part of combat cleanup.

Closes #348