### PR TITLE
Reconfigure Button

### DIFF
--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -757,7 +757,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    * 
    */
   static #canReconfigAdvancement() {
-    const advancementSource = this.item.parent?.items.get(this.item.getFlag("draw-steel.advancement", "parentId")
+    const advancementSource = this.item.parent?.items.get(this.item.getFlag("draw-steel.advancement", "parentId");
     if (!advancementSource) return false;
     return !!advancementSource.pseudoCollections.Advancement.get(this.item.getFlag("draw-steel.advancement", "advancementId");
   }

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -757,7 +757,9 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    * 
    */
   static #canReconfigAdvancement() {
-    return (this.item.parent && (this.item.flags["draw-steel"] != undefined));
+    const advancementSource = this.item.parent?.items.get(this.item.getFlag("draw-steel.advancement", "parentId")
+    if (!advancementSource) return false;
+    return !!advancementSource.pseudoCollections.Advancement.get(this.item.getFlag("draw-steel.advancement", "advancementId");
   }
 
   /**
@@ -766,8 +768,8 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
    * @private
    */
   static async #rewindAdvancement() {
-    const advancementSource = this.item.parent.items.get(this.item.flags["draw-steel"].advancement.parentId);
-    const advancement = advancementSource.pseudoCollections.Advancement.get(this.item.flags["draw-steel"].advancement["advancementId"]);
+    const advancementSource = this.item.parent.items.get(this.item.getFlag("draw-steel.advancement", "parentId");
+    const advancement = advancementSource.pseudoCollections.Advancement.get(this.item.getFlag("draw-steel.advancement", "advancementId");
     await advancement.reconfigure();
   }
 

--- a/src/module/applications/sheets/item-sheet.mjs
+++ b/src/module/applications/sheets/item-sheet.mjs
@@ -35,6 +35,7 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       createCultureAdvancement: this.#createCultureAdvancement,
       reconfigureAdvancement: this.#reconfigureAdvancement,
       shareDoc: this.#shareDoc,
+      rewindAdvancement: this.#rewindAdvancement,
     },
     window: {
       controls: [{
@@ -42,6 +43,11 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
         label: "DRAW_STEEL.SOURCE.CompendiumSource.UpdateFrom.Label",
         action: "updateFromCompendium",
         visible: DrawSteelItemSheet.#canUpdateFromCompendium,
+      }, {
+        icon: "fa-solid fa-arrow-rotate-right",
+        label: "DRAW_STEEL.ADVANCEMENT.SHEET.reconfigure",
+        action: "rewindAdvancement",
+        visible: DrawSteelItemSheet.#canReconfigAdvancement,
       }, {
         icon: "fa-solid fa-share-from-square",
         label: "DRAW_STEEL.SHEET.Share",
@@ -742,6 +748,27 @@ export default class DrawSteelItemSheet extends DSDocumentSheet {
       };
     } else createData = { type };
     ds.data.pseudoDocuments.advancements.SkillAdvancement.create(createData, { parent: this.item });
+  }
+
+  /**
+   * If an item has an advancement that can be reconfigured.
+   * @this DrawSteelItemSheet
+   * @returns {bool}
+   * 
+   */
+  static #canReconfigAdvancement() {
+    return (this.item.parent && (this.item.flags["draw-steel"] != undefined));
+  }
+
+  /**
+   * Finds which advanceemnt an item came from, calls the advancement's reconfigure.
+   * @this DrawSteelItemSheet
+   * @private
+   */
+  static async #rewindAdvancement() {
+    const advancementSource = this.item.parent.items.get(this.item.flags["draw-steel"].advancement.parentId);
+    const advancement = advancementSource.pseudoCollections.Advancement.get(this.item.flags["draw-steel"].advancement["advancementId"]);
+    await advancement.reconfigure();
   }
 
   /**

--- a/src/module/data/fields/_types.d.ts
+++ b/src/module/data/fields/_types.d.ts
@@ -19,9 +19,9 @@ export interface LocalDocumentFieldOptions extends StringFieldOptions {
    * Read the value as a string instead of a model?
    * @defaultValue `false`
    */
- idOnly?: boolean;
+  idOnly?: boolean;
 
- /**
+  /**
   * The document subtype referenced by this field.
   * @defaultValue `null`
   */

--- a/src/module/data/models/_types.d.ts
+++ b/src/module/data/models/_types.d.ts
@@ -1,4 +1,4 @@
-export {}
+export {};
 
 declare module "./object-size.mjs" {
   export default interface ObjectSizeModel {

--- a/templates/apps/document-input/object-sizes-input.hbs
+++ b/templates/apps/document-input/object-sizes-input.hbs
@@ -13,14 +13,14 @@
 
   {{!-- We expect fewer shapes than regions so we can afford to just have a long form if there's a few --}}
   <div class="standard-form scrollable">
-  {{#each shapeContexts as |shapeContext i|}}
-  <fieldset class="region-element region-shape flexrow" data-shape-index="{{i}}" aria-label="{{localize "SHAPE.label"}} 0">
-    <legend>
-      {{localize (concat "SHAPE.TYPES." shapeContext.shape.type ".name")}}
-      <button type="button" class="icon fa-solid fa-trash" data-action="deleteShape"></button>
-    </legend>
-    {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shapeContext.shape.type ".hbs") shapeContext }}
-  </fieldset>
-  {{/each}}
+    {{#each shapeContexts as |shapeContext i|}}
+    <fieldset class="region-element region-shape flexrow" data-shape-index="{{i}}" aria-label="{{localize "SHAPE.label"}} 0">
+      <legend>
+        {{localize (concat "SHAPE.TYPES." shapeContext.shape.type ".name")}}
+        <button type="button" class="icon fa-solid fa-trash" data-action="deleteShape"></button>
+      </legend>
+      {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shapeContext.shape.type ".hbs") shapeContext }}
+    </fieldset>
+    {{/each}}
   </div>
 </section>

--- a/templates/apps/object-sizes/cone.hbs
+++ b/templates/apps/object-sizes/cone.hbs
@@ -1,13 +1,13 @@
 <section class="standard-form">
-    {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{formField fields.angle name=(concat name ".angle") value=source.angle rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+  {{formField fields.angle name=(concat name ".angle") value=source.angle rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
 
-    {{formField fields.rotation name=(concat name ".rotation") value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
+  {{formField fields.rotation name=(concat name ".rotation") value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}
 
-    {{formField fields.curvature name=(concat name ".curvature") value=source.curvature rootId=rootId classes="slim" localize=true}}
+  {{formField fields.curvature name=(concat name ".curvature") value=source.curvature rootId=rootId classes="slim" localize=true}}
 
-    {{#if fields.hole}}
-    {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
-    {{/if}}
+  {{#if fields.hole}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
+  {{/if}}
 </section>

--- a/templates/apps/object-sizes/emanation.hbs
+++ b/templates/apps/object-sizes/emanation.hbs
@@ -1,12 +1,12 @@
 <section class="standard-form">
-    <fieldset>
-        <legend>{{localize "SHAPE.TYPES.emanation.FIELDS.base.label"}}: {{localize (concat "SHAPE.TYPES." shape.base.type ".name")}}</legend>
-        {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shape.base.type ".hbs") baseContext }}
-    </fieldset>
+  <fieldset>
+    <legend>{{localize "SHAPE.TYPES.emanation.FIELDS.base.label"}}: {{localize (concat "SHAPE.TYPES." shape.base.type ".name")}}</legend>
+    {{> (concat "systems/draw-steel/templates/apps/object-sizes/" shape.base.type ".hbs") baseContext }}
+  </fieldset>
 
-    {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
+  {{formField fields.radius name=(concat name ".radius") value=source.radius input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
-    {{#if fields.hole}}
-    {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
-    {{/if}}
+  {{#if fields.hole}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
+  {{/if}}
 </section>

--- a/templates/apps/object-sizes/rectangle.hbs
+++ b/templates/apps/object-sizes/rectangle.hbs
@@ -6,13 +6,13 @@
   {{formField fields.height name=(concat name ".height") value=source.height input=dimensionInput grid=shape.grid classes="slim" rootId=rootId}}
 
   <div class="form-group slim">
-      <label>{{localize "SHAPE.TYPES.rectangle.anchor.label"}}</label>
-      <div class="form-fields">
-          <label for="{{rootId}}-{{fields.anchorX.fieldPath}}">X</label>
-          {{formInput fields.anchorX name=(concat name ".anchorX") value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
-          <label for="{{rootId}}-{{fields.anchorY.fieldPath}}">Y</label>
-          {{formInput fields.anchorY name=(concat name ".anchorY") value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
-      </div>
+    <label>{{localize "SHAPE.TYPES.rectangle.anchor.label"}}</label>
+    <div class="form-fields">
+      <label for="{{rootId}}-{{fields.anchorX.fieldPath}}">X</label>
+      {{formInput fields.anchorX name=(concat name ".anchorX") value=source.anchorX id=(concat rootId "-" fields.anchorX.fieldPath)}}
+      <label for="{{rootId}}-{{fields.anchorY.fieldPath}}">Y</label>
+      {{formInput fields.anchorY name=(concat name ".anchorY") value=source.anchorY id=(concat rootId "-" fields.anchorY.fieldPath)}}
+    </div>
   </div>
 
   {{formField fields.rotation name=(concat name ".rotation") value=source.rotation rootId=rootId classes="slim" units="MEASUREMENT.Degrees" localize=true}}

--- a/templates/apps/object-sizes/token.hbs
+++ b/templates/apps/object-sizes/token.hbs
@@ -1,15 +1,17 @@
 <section class="standard-form scrollable">
-    <div class="form-group slim">
-        <label>{{localize "SHAPE.TYPES.token.size.label"}} <span class="units">({{localize "MEASUREMENT.GridSpaces"}})</span></label>
-        <div class="form-fields slim">
-            <label for="{{rootId}}-token.width">X</label>
-            {{formInput fields.width name=(concat name ".base.width") value=source.width id=(concat rootId "-token.width")}}
-            <label for="{{rootId}}-token.height">Y</label>
-            {{formInput fields.height name=(concat name ".base.height") value=source.height id=(concat rootId "-token.height")}}
-        </div>
+  <div class="form-group slim">
+    <label>
+      {{localize "SHAPE.TYPES.token.size.label"}} <span class="units">({{localize "MEASUREMENT.GridSpaces"}})</span>
+    </label>
+    <div class="form-fields slim">
+      <label for="{{rootId}}-token.width">X</label>
+      {{formInput fields.width name=(concat name ".base.width") value=source.width id=(concat rootId "-token.width")}}
+      <label for="{{rootId}}-token.height">Y</label>
+      {{formInput fields.height name=(concat name ".base.height") value=source.height id=(concat rootId "-token.height")}}
     </div>
+  </div>
 
-    {{#if fields.hole}}
-    {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
-    {{/if}}
+  {{#if fields.hole}}
+  {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}
+  {{/if}}
 </section>


### PR DESCRIPTION
As described in #1513, added header button that reconfigures an advancement an item belongs to. Is not present unless it belongs to an advancement.

<img width="602" height="535" alt="image" src="https://github.com/user-attachments/assets/4b073cbe-6bd6-4d4e-8007-9211ebadcf70" />

closes #1513