### PR TITLE
[#2021] Add Portfolio Summoning

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1082,7 +1082,13 @@
           "count": {
             "label": "Count",
             "hint": "How many signature minions to summon?"
-          }
+          },
+          "cost": {
+            "label": "Cost",
+            "hint": "Total amount of heroic resource to spend on this summoning. Automatically adjusts after changing the other inputs."
+          },
+          "optionLabel": "{name} ({cost})",
+          "signature": "Signature"
         },
         "Errors": {
           "ACTOR_CREATE": "You do not have permission to import actors!",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1078,6 +1078,10 @@
           "uuid": {
             "label": "Actor",
             "hint": "Choose an actor to summon, importing from compendium if it hasn't yet already."
+          },
+          "count": {
+            "label": "Count",
+            "hint": "How many signature minions to summon?"
           }
         },
         "Errors": {
@@ -2673,6 +2677,7 @@
     "SpecialEffect": {
       "base": "Effect",
       "persistent": "Persistent",
+      "portfolioSummon": "Summon (Portfolio)",
       "spend": "Spend",
       "strained": "Strained",
       "summon": "Summon"

--- a/src/module/applications/apps/advancement/actor-choice-configuration-dialog.mjs
+++ b/src/module/applications/apps/advancement/actor-choice-configuration-dialog.mjs
@@ -11,7 +11,8 @@ import { systemPath } from "../../../constants.mjs";
 
 /**
  * @typedef ActorChoiceConfigurationOptions
- * @property {AdvancementNode} node   The node to configure.
+ * @property {ActorChoiceAdvancement} advancement   The advancement to configure.
+ * @property {string[]} chosen                      Chosen actors by UUID.
  */
 
 /**
@@ -21,12 +22,13 @@ export default class ActorChoiceConfigurationDialog extends DSApplication {
   /**
    * @param {ApplicationConfiguration & ActorChoiceConfigurationOptions} options
    */
-  constructor({ node, ...options }) {
-    if (!(node.advancement?.isActorChoice)) {
+  constructor({ advancement, chosen, ...options }) {
+    if (!(advancement?.isActorChoice)) {
       throw new Error("An actor choice configuration dialog must be passed an AdvancementNode with an Actor Choice.");
     }
     super(options);
-    this.#node = node;
+    this.#advancement = advancement;
+    this.chosen = new Set(chosen);
   }
 
   /* -------------------------------------------------- */
@@ -53,24 +55,13 @@ export default class ActorChoiceConfigurationDialog extends DSApplication {
 
   /* -------------------------------------------------- */
 
+  #advancement;
   /**
    * The advancement being configured.
    * @type {ActorChoiceAdvancement}
    */
   get advancement() {
-    return this.#node.advancement;
-  }
-
-  /* -------------------------------------------------- */
-
-  /**
-   * The node this is configuring. May be null.
-   * @type {AdvancementNode | null}
-   */
-  #node;
-  // eslint-disable-next-line @jsdoc/require-jsdoc
-  get node() {
-    return this.#node;
+    return this.#advancement;
   }
 
   /* -------------------------------------------------- */
@@ -79,7 +70,7 @@ export default class ActorChoiceConfigurationDialog extends DSApplication {
    * Cached reference to the actors this can be configuring. Constructed during the first run of _prepareContext.
    * @type {Set<DrawSteelActor>}
    */
-  #actors;
+  #actors = new Set();
   // eslint-disable-next-line @jsdoc/require-jsdoc
   get actors() {
     return this.#actors;
@@ -92,7 +83,7 @@ export default class ActorChoiceConfigurationDialog extends DSApplication {
    * A new set is constructed each time the form data is processed.
    * @type {Set<string>}
    */
-  chosen = new Set();
+  chosen;
 
   /* -------------------------------------------------- */
 
@@ -117,13 +108,8 @@ export default class ActorChoiceConfigurationDialog extends DSApplication {
 
   /** @inheritdoc */
   async _prepareContext(options) {
-    if (options.isFirstRender) {
-      this.#actors = new Set(Object.values(this.node.choices).map(choice => choice.actor));
-
-      this.actors.forEach(actor => {
-        if (this.node.selected[actor.uuid]) this.chosen.add(actor.uuid);
-      });
-    }
+    // fromUuid call respects caching
+    if (options.isFirstRender) for (const { uuid } of this.#advancement.actorOptions) this.#actors.add(await fromUuid(uuid));
 
     return super._prepareContext(options);
   }

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -2162,6 +2162,11 @@ export const SpecialEffect = {
     defaultImage: "icons/svg/teleport.svg",
     documentClass: pseudoDocuments.specialEffects.SummonSpecialEffect,
   },
+  portfolioSummon: {
+    label: "TYPES.SpecialEffect.portfolioSummon",
+    defaultImage: "icons/svg/teleport.svg",
+    documentClass: pseudoDocuments.specialEffects.PortfolioSummonSpecialEffect,
+  },
 };
 preLocalize("SpecialEffect", { key: "label" });
 

--- a/src/module/data/actor/_types.d.ts
+++ b/src/module/data/actor/_types.d.ts
@@ -61,6 +61,12 @@ interface Skills {
   list: string;
 }
 
+export interface SummonPortfolio {
+  uuid: string;
+  count: string;
+  cost: number | null
+}
+
 declare module "./base-actor.mjs" {
   export default interface BaseActorModel {
     parent: DrawSteelActor;

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -7,6 +7,7 @@ import DrawSteelChatMessage from "../../documents/chat-message.mjs";
 /**
  * @import { DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";
  * @import AdvancementChain from "../../utils/advancement-chain.mjs";
+ * @import { SummonPortfolio } from "./_types"
  */
 
 const fields = foundry.data.fields;
@@ -403,6 +404,17 @@ export default class HeroModel extends CreatureModel {
    * @internal
    */
   _respiteAdvancements = {};
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Internal record used to cache summon advancements to track the available summons in the portfolio.
+   * Outer keys are portfolio ID, inner object is source UUID, count, and HR cost.
+   * This record is populated during `prepareEmbeddedDocuments`.
+   * @type {Record<string, SummonPortfolio[]>}
+   * @internal
+   */
+  _summonPortfolios = {};
 
   /* -------------------------------------------------- */
 

--- a/src/module/data/item/advancement.mjs
+++ b/src/module/data/item/advancement.mjs
@@ -45,11 +45,11 @@ export default class AdvancementModel extends BaseItemModel {
 
     const respiteAdvancements = this.actor.system._respiteAdvancements;
 
-    const record = this.actor.system._traits;
-    const unfilled = this.actor.system._unfilledTraits;
+    const traitRecord = this.actor.system._traits;
+    const traitUnfilled = this.actor.system._unfilledTraits;
     const addTrait = (type, trait) => {
-      record[type] ??= new Set();
-      for (const k of trait) record[type].add(k);
+      traitRecord[type] ??= new Set();
+      for (const k of trait) traitRecord[type].add(k);
     };
 
     const level = this.actor.system.level;
@@ -69,14 +69,20 @@ export default class AdvancementModel extends BaseItemModel {
           : advancement.traitOptions.map(option => option.value);
         addTrait(advancement.type, selected);
         if (selected.length < advancement.chooseN) {
-          unfilled[advancement.type] ??= new Set();
-          unfilled[advancement.type].add(advancement.getRelativeUUID(this.actor));
+          traitUnfilled[advancement.type] ??= new Set();
+          traitUnfilled[advancement.type].add(advancement.getRelativeUUID(this.actor));
         }
       } else if (advancement.type === "characteristic") {
         for (const chr of flags[advancement.id]?.selected ?? []) {
           const chrInfo = this.actor.system.characteristics[chr];
           chrInfo.value = Math.min(chrInfo.value + 1, advancement.max);
         }
+      } else if (advancement.type === "summon") {
+        const options = advancement.pool
+          .filter(o => flags[advancement.id]?.selected.includes(o.uuid))
+          .map(o => ({ ...o, cost: advancement.cost }));
+        const portfolio = this.actor.system._summonPortfolios[advancement.dsid] ??= [];
+        portfolio.push(...options);
       }
     }
   }

--- a/src/module/data/pseudo-documents/advancements/_types.d.ts
+++ b/src/module/data/pseudo-documents/advancements/_types.d.ts
@@ -1,4 +1,4 @@
-export {};
+import DrawSteelItem from "../../../documents/item.mjs";
 
 declare module "./actor-choice-advancement.mjs" {
   export default interface ActorChoiceAdvancement {
@@ -40,6 +40,7 @@ declare module "./base-advancement.mjs" {
     repick: {
       respite: null | "activity" | "finish";
     }
+    document: DrawSteelItem;
   }
 }
 

--- a/src/module/data/pseudo-documents/advancements/actor-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/actor-choice-advancement.mjs
@@ -75,7 +75,15 @@ export default class ActorChoiceAdvancement extends BaseAdvancement {
 
   /** @inheritdoc */
   async configureAdvancement(node = null) {
-    const selection = await ActorChoiceConfigurationDialog.create({ node });
+
+    const path = `flags.draw-steel.advancement.${this.id}.selected`;
+    const chosen = node
+      ? Object.entries(node.selected).reduce((arr, [k, v]) => arr.concat(v ? k : []), [])
+      : this.document.isEmbedded
+        ? foundry.utils.getProperty(this.document, path) ?? []
+        : [];
+
+    const selection = await ActorChoiceConfigurationDialog.create({ advancement: this, chosen });
 
     if (!selection) return null;
 
@@ -90,7 +98,7 @@ export default class ActorChoiceAdvancement extends BaseAdvancement {
 
     await Promise.allSettled(promises);
 
-    return { [`flags.draw-steel.advancement.${this.id}.selected`]: selection.choices };
+    return { [path]: selection.choices };
   }
 
   /* -------------------------------------------------- */

--- a/src/module/data/pseudo-documents/message-parts/_types.d.ts
+++ b/src/module/data/pseudo-documents/message-parts/_types.d.ts
@@ -1,3 +1,4 @@
+import { DrawSteelChatMessage } from "../../../documents/_module.mjs";
 import DSRoll from "../../../rolls/base.mjs";
 import StandardModel from "../../message/standard.mjs";
 
@@ -17,6 +18,7 @@ declare module "./ability-use.mjs" {
 declare module "./base-message-part.mjs" {
   export default interface MessagePart {
     parent: StandardModel;
+    document: DrawSteelChatMessage;
     type: string;
     rolls: DSRoll[],
     flavor: string;

--- a/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
+++ b/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
@@ -1,3 +1,11 @@
+import DrawSteelItem from "../../../documents/item.mjs";
+
+declare module "./base-power-roll-effect.mjs" {
+  export default interface BasePowerRollEffect {
+    document: DrawSteelItem;
+  }
+}
+
 type PotencySchema = {
   value: string;
   characteristic: string;

--- a/src/module/data/pseudo-documents/special-effect/_module.mjs
+++ b/src/module/data/pseudo-documents/special-effect/_module.mjs
@@ -1,5 +1,6 @@
 export { default as BaseSpecialEffect } from "./base-special-effect.mjs";
 export { default as PersistentSpecialEffect } from "./persistent-effect.mjs";
+export { default as PortfolioSummonSpecialEffect } from "./portfolio-summon-effect.mjs";
 export { default as SpendSpecialEffect } from "./spend-effect.mjs";
 export { default as StrainedSpecialEffect } from "./strained-effect.mjs";
 export { default as SummonSpecialEffect } from "./summon-effect.mjs";

--- a/src/module/data/pseudo-documents/special-effect/_types.d.ts
+++ b/src/module/data/pseudo-documents/special-effect/_types.d.ts
@@ -1,8 +1,10 @@
 import AbilityModel from "../../item/ability.mjs";
+import DrawSteelItem from "../../../documents/item.mjs";
 
 declare module "./base-special-effect.mjs" {
   export default interface BaseSpecialEffect {
     parent: AbilityModel;
+    document: DrawSteelItem;
     description: string;
     before: boolean;
   }

--- a/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
@@ -27,21 +27,19 @@ export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
    */
   async performSummon() {
     const hero = this.document.actor;
-    if (hero.type !== "hero") {
-      return void ui.notifications.error();
-    }
 
     /** @type {SummonPortfolio[]} */
-    const portfolio = hero.system._summonPortfolios[this.document.dsid];
-
-    if (!portfolio) return void ui.notifications.error();
-
-    // TODO: Sacrifice and other adjustments
-    const currentHR = hero.system.hero.primary.value;
+    const portfolio = hero.system._summonPortfolios[this.document.dsid] ?? [];
 
     const summonOptions = portfolio.reduce((options, o) => {
       const idx = fromUuidSync(o.uuid);
-      if (idx && (o.cost <= currentHR)) options.push({ label: idx.name, value: idx.uuid });
+      if (idx) options.push({
+        label: _loc("DRAW_STEEL.Actor.Summoning.ActorSelectDialog.optionLabel", {
+          name: idx.name,
+          cost: o.cost ?? _loc("DRAW_STEEL.Actor.Summoning.ActorSelectDialog.signature"),
+        }),
+        value: idx.uuid,
+      });
       return options;
     }, []);
 
@@ -66,12 +64,24 @@ export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
       input: createNumberInput({
         name: "count",
         min: 1,
-        max: hero.system.hero.primary.value,
+        value: 1,
       }),
       localize: true,
     });
 
-    content.append(uuidSelect, signatureCount);
+    const resourceCost = createFormGroup({
+      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.cost.label",
+      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.cost.hint",
+      input: createNumberInput({
+        name: "cost",
+        min: 1,
+        max: hero.system.hero.primary.value,
+        value: portfolio[0].cost ?? 1,
+      }),
+      localize: true,
+    });
+
+    content.append(uuidSelect, signatureCount, resourceCost);
 
     const fd = await DSDialog.input({
       content,
@@ -81,19 +91,30 @@ export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
       },
       render: (ev, dialog) => {
         /** @type {HTMLInputElement} */
-        const signature = dialog.element.querySelector("[name=\"count\"]").closest(".form-group");
+        const costInput = dialog.element.querySelector("[name=\"cost\"]");
+        /** @type {HTMLInputElement} */
+        const signatureInput = dialog.element.querySelector("[name=\"count\"]");
+        signatureInput.addEventListener("change", (e) => {
+          costInput.value = e.target.value;
+        });
+        /** @type {HTMLDivElement} */
+        const signatureGroup = signatureInput.closest(".form-group");
         dialog.element.querySelector("[name=\"uuid\"]").addEventListener("change", (e) => {
-          signature.hidden = portfolio.find(o => o.uuid === e.target.value).cost !== null;
+          const { cost } = portfolio.find(o => o.uuid === e.target.value);
+          signatureGroup.hidden = cost !== null;
+          costInput.value = cost ?? signatureInput.value;
         });
       },
     });
 
     if (!fd) return null;
 
-    let { cost, count } = portfolio.find(o => o.uuid === fd.uuid);
+    const summonInfo = portfolio.find(o => o.uuid === fd.uuid);
+
+    const cost = fd.cost;
 
     // Signature minions have a null count & cost and instead just directly scale with the # summoned
-    if (!cost) count = cost = fd.count;
+    const count = summonInfo.count ?? fd.count;
 
     const tokens = await this.parent.performSummon(fd.uuid, { count });
 

--- a/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
@@ -1,0 +1,106 @@
+import BaseSpecialEffect from "./base-special-effect.mjs";
+import DSDialog from "../../../applications/api/dialog.mjs";
+import { systemID } from "../../../constants.mjs";
+
+/**
+ * @import { DrawSteelActor, DrawSteelTokenDocument } from "../../../documents/_module.mjs"
+ * @import ActorChoiceAdvancement from "../advancements/actor-choice-advancement.mjs";
+ * @import { SummonPortfolio } from "../../actor/_types";
+ */
+
+const { createFormGroup, createSelectInput, createNumberInput } = foundry.applications.fields;
+
+/**
+ * A type of effect that summons from a fixed list of options.
+ */
+export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
+  /** @inheritdoc */
+  static get TYPE() {
+    return "portfolioSummon";
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Places summons.
+   * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
+   */
+  async performSummon() {
+    const hero = this.document.actor;
+    if (hero.type !== "hero") {
+      return void ui.notifications.error();
+    }
+
+    /** @type {SummonPortfolio[]} */
+    const portfolio = hero.system._summonPortfolios[this.document.dsid];
+
+    if (!portfolio) return void ui.notifications.error();
+
+    // TODO: Sacrifice and other adjustments
+    const currentHR = hero.system.hero.primary.value;
+
+    const summonOptions = portfolio.reduce((options, o) => {
+      const idx = fromUuidSync(o.uuid);
+      if (idx && (o.cost <= currentHR)) options.push({ label: idx.name, value: idx.uuid });
+      return options;
+    }, []);
+
+    if (!summonOptions.length) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.NO_OPTIONS", { localize: true });
+    // Token permissions handled by placeActor
+
+    const content = document.createElement("div");
+
+    const uuidSelect = createFormGroup({
+      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.label",
+      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.hint",
+      input: createSelectInput({
+        name: "uuid",
+        options: summonOptions,
+      }),
+      localize: true,
+    });
+
+    const signatureCount = createFormGroup({
+      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.count.label",
+      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.count.hint",
+      input: createNumberInput({
+        name: "count",
+        min: 1,
+        max: hero.system.hero.primary.value,
+      }),
+      localize: true,
+    });
+
+    content.append(uuidSelect, signatureCount);
+
+    const fd = await DSDialog.input({
+      content,
+      window: {
+        title: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.title",
+        icon: "fa-solid fa-transporter-2",
+      },
+      render: (ev, dialog) => {
+        /** @type {HTMLInputElement} */
+        const signature = dialog.element.querySelector("[name=\"count\"]").closest(".form-group");
+        dialog.element.querySelector("[name=\"uuid\"]").addEventListener("change", (e) => {
+          signature.hidden = portfolio.find(o => o.uuid === e.target.value).cost !== null;
+        });
+      },
+    });
+
+    if (!fd) return null;
+
+    let { cost, count } = portfolio.find(o => o.uuid === fd.uuid);
+
+    // Signature minions have a null count & cost and instead just directly scale with the # summoned
+    if (!cost) count = cost = fd.count;
+
+    const tokens = await this.parent.performSummon(fd.uuid, { count });
+
+    if (tokens?.length) {
+      await hero.modifyTokenAttribute("hero.primary.value", -cost, true);
+    }
+
+    return tokens;
+  }
+}

--- a/src/module/utils/advancement/chain.mjs
+++ b/src/module/utils/advancement/chain.mjs
@@ -382,6 +382,20 @@ export default class AdvancementChain {
           _idMap.set(effect.id, effectData._id);
         }
       }
+      else if (node.advancement.isActorChoice) {
+        const { document: item, id } = node.advancement;
+        /** @type {ItemData} */
+        let itemData;
+
+        if (item.parent === this.actor) {
+          toUpdate[item.id] ??= { _id: item.id };
+          itemData = toUpdate[item.id];
+        } else {
+          itemData = toCreate[item.uuid];
+        }
+
+        foundry.utils.setProperty(itemData, `flags.${systemID}.advancement.${id}.selected`, node.chosenSelection);
+      }
     }
 
     operations[0].data = Object.values(toCreate);


### PR DESCRIPTION
Portfolios now fully integrate into the summoning API by adding another special effect for them + doing more work in data prep. If we want we can loosen up from strict `item.dsid` matching to registering portfolios in a follow-up PR; might make sense for handling the start-of-turn summons which aren't technically part of Call Forth.

<img width="402" height="363" alt="image" src="https://github.com/user-attachments/assets/84af472e-827a-4471-8408-d7182f7c557c" />
