### PR TITLE
Summoner compendium

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1315,12 +1315,14 @@
           "Elementalist": "Elementalist",
           "Fury": "Fury",
           "Talent": "Talent",
-          "Troubador": "Troubador"
+          "Troubador": "Troubador",
+          "Summoner":"Summoner"
         },
         "Keywords": {
           "Animal": "Animal",
           "Animapathy": "Animapathy",
           "Area": "Area",
+          "Champion":"Champion",
           "Charge": "Charge",
           "Chronopathy": "Chronopathy",
           "Cryokinesis": "Cryokinesis",
@@ -1342,6 +1344,7 @@
           "Telepathy": "Telepathy",
           "Void": "Void",
           "Weapon": "Weapon"
+          
         },
         "Type": {
           "Main": "Main Action",

--- a/src/module/config.mjs
+++ b/src/module/config.mjs
@@ -1476,6 +1476,10 @@ const abilityKeywords = {
   area: {
     label: "DRAW_STEEL.Item.ability.Keywords.Area",
   },
+  champion:{
+    label:"DRAW_STEEL.Item.ability.Keywords.Champion",
+    group:"DRAW_STEEL.Item.ability.KeywordGroups.Summoner"
+  },
   charge: {
     label: "DRAW_STEEL.Item.ability.Keywords.Charge",
   },

--- a/src/packs/abilities/Folder_Summoner_JLje7RdyY8ONDzVK.json
+++ b/src/packs/abilities/Folder_Summoner_JLje7RdyY8ONDzVK.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Summoner",
+  "color": null,
+  "sorting": "a",
+  "_id": "JLje7RdyY8ONDzVK",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587740784,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!JLje7RdyY8ONDzVK"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Call_Forth_czHTOVQ7Xi9WReqK.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Call_Forth_czHTOVQ7Xi9WReqK.json
@@ -1,0 +1,93 @@
+{
+  "folder": "k4yDU9wUbuXSgOOT",
+  "name": "Call Forth",
+  "type": "ability",
+  "_id": "czHTOVQ7Xi9WReqK",
+  "img": "icons/magic/life/heart-area-circle-red-green.webp",
+  "system": {
+    "source": {
+      "book": "Summoner",
+      "page": "9",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "call-forth",
+    "prerequisites": {
+      "value": "",
+      "dsid": [
+        "summoner"
+      ],
+      "level": null
+    },
+    "story": "My power is yours, and yours, mine. I summon thee.",
+    "keywords": [
+      "magic",
+      "ranged"
+    ],
+    "type": "main",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": "@R + 5",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "self",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "before0000000000": {
+        "_id": "before0000000000",
+        "type": "base",
+        "description": "<p>You summon one or more minions from your portfolio into unoccupied spaces within distance. Choose one of the following options:</p><ul><li><p><strong>Signature Minions</strong>: You summon one signature minion for each essence you spend on this ability.</p></li><li><p><strong>All Other Minions</strong>: You summon the set number of minions listed on the stat block for their essence cost.</p></li></ul>",
+        "before": true,
+        "name": "",
+        "img": null,
+        "sort": 0
+      },
+      "9zm50NvZiWmnuPZ5": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "summon",
+        "_id": "9zm50NvZiWmnuPZ5",
+        "description": "",
+        "before": false,
+        "summoning": {
+          "pool": [],
+          "count": 1
+        }
+      }
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787588730204,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 100000,
+  "_key": "!items!czHTOVQ7Xi9WReqK"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Minion_Bridge_vKzCZPA68o2CA2VB.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Minion_Bridge_vKzCZPA68o2CA2VB.json
@@ -1,0 +1,90 @@
+{
+  "folder": "k4yDU9wUbuXSgOOT",
+  "name": "Minion Bridge",
+  "type": "ability",
+  "_id": "vKzCZPA68o2CA2VB",
+  "img": "icons/skills/movement/arrows-up-trio-red.webp",
+  "system": {
+    "source": {
+      "book": "Summoner",
+      "page": "10",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-bridge",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your minions do everything in their power to form a safe path for you to cross.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "maneuver",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": "1",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "One of your minions",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "spend00000000000": {
+        "_id": "spend00000000000",
+        "type": "spend",
+        "sort": 100000,
+        "resource": {
+          "value": 1,
+          "multiple": false
+        },
+        "description": "<p>An adjacent ally can shift alongside you during this movement. They must end their movement in an unoccupied square adjacent to the last minion you moved through.</p>",
+        "name": "",
+        "img": null,
+        "before": false
+      },
+      "before0000000000": {
+        "_id": "before0000000000",
+        "type": "base",
+        "description": "<p>You shift into a square adjacent to the target, including vertically.</p><p>You can shift into squares that contain one of your minions, even if they occupy difficult terrain. Each time you shift into a square that contains one of your minions while using this maneuver, you can shift an additional square.</p>",
+        "before": true,
+        "name": "",
+        "img": null,
+        "sort": 0
+      }
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590057493,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 0,
+  "_key": "!items!vKzCZPA68o2CA2VB"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Strike_For_Me_WAzv6xku3g4d4WBj.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Strike_For_Me_WAzv6xku3g4d4WBj.json
@@ -1,0 +1,120 @@
+{
+  "folder": "k4yDU9wUbuXSgOOT",
+  "name": "Strike For Me",
+  "type": "ability",
+  "_id": "WAzv6xku3g4d4WBj",
+  "img": "icons/skills/targeting/target-strike-triple-blue.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "strike-for-me",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your minions fight in your stead.",
+    "keywords": [
+      "magic",
+      "ranged"
+    ],
+    "type": "triggered",
+    "category": "",
+    "resource": null,
+    "trigger": "You use a triggered action to make a free strike or use a signature ability.",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "Each of Your Minions",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "nuih6g0rkk0f1ncy": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "other",
+          "_id": "nuih6g0rkk0f1ncy",
+          "other": {
+            "tier1": {
+              "display": "Up to three targets each make a free strike",
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "display": "Up to five targets each make a free strike",
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "Up to seven targets each make a free strike",
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "7nX1jqBNufB56aLs": {
+        "sort": 100000,
+        "name": "Special",
+        "img": null,
+        "type": "base",
+        "_id": "7nX1jqBNufB56aLs",
+        "description": "<p>On a natural 19 or 20, each target makes a free strike.</p>",
+        "before": false
+      },
+      "gLoRYrTsKMzhO67S": {
+        "sort": 200000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "gLoRYrTsKMzhO67S",
+        "description": "<p>Your minions act in place of you making a free strike or using a signature ability. If you were granted the triggered action against a specific target, your minions must strike the same target. If the triggered action granted you a signature ability, you have an edge on the power roll.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787588406029,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!WAzv6xku3g4d4WBj"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Summoner_Strike_9wYvFs6YIWgsFepg.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Core_k4yDU9wUbuXSgOOT/ability_Summoner_Strike_9wYvFs6YIWgsFepg.json
@@ -1,0 +1,89 @@
+{
+  "folder": "k4yDU9wUbuXSgOOT",
+  "name": "Summoner Strike",
+  "type": "ability",
+  "_id": "9wYvFs6YIWgsFepg",
+  "img": "icons/magic/lightning/bolt-forked-blue-yellow.webp",
+  "system": {
+    "source": {
+      "book": "Summoner",
+      "page": "9",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "summoner-strike",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "A sudden burst of energy erupts from your implement and shocks your foes' nerves.",
+    "keywords": [
+      "magic",
+      "melee",
+      "ranged",
+      "strike"
+    ],
+    "type": "main",
+    "category": "freeStrike",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": "1",
+      "secondary": "5",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "custom": "",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "asmcjdLrGTlmKQGu": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "asmcjdLrGTlmKQGu",
+        "description": "<p>[[/damage @R]] Damage. If the target has [[potency R weak]] they are [[/apply slowed save]]</p>",
+        "before": false
+      },
+      "B2eW4rhDGRnrJahk": {
+        "sort": 200000,
+        "name": "Special",
+        "img": null,
+        "type": "base",
+        "_id": "B2eW4rhDGRnrJahk",
+        "description": "<p>This ability has the Charge keyword when it's used as a melee strike.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787588059457,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!9wYvFs6YIWgsFepg"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Core_k4yDU9wUbuXSgOOT.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Core_k4yDU9wUbuXSgOOT.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JLje7RdyY8ONDzVK",
+  "name": "Core",
+  "color": null,
+  "sorting": "a",
+  "_id": "k4yDU9wUbuXSgOOT",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587749166,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!k4yDU9wUbuXSgOOT"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_1_4s1wz38jXyJjINh1.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_1_4s1wz38jXyJjINh1.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JLje7RdyY8ONDzVK",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "4s1wz38jXyJjINh1",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587753702,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!4s1wz38jXyJjINh1"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_2_FsImes7cB6dJ00O5.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_2_FsImes7cB6dJ00O5.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JLje7RdyY8ONDzVK",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "FsImes7cB6dJ00O5",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787602381629,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!FsImes7cB6dJ00O5"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_3_AFieXJzTQ1j5n27m.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_3_AFieXJzTQ1j5n27m.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JLje7RdyY8ONDzVK",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "AFieXJzTQ1j5n27m",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604579544,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!AFieXJzTQ1j5n27m"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_6_t51W0QApaNbMvbKx.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_6_t51W0QApaNbMvbKx.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JLje7RdyY8ONDzVK",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "t51W0QApaNbMvbKx",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787698947305,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!t51W0QApaNbMvbKx"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_9_NkcIfWgp2FYlJHL3.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Folder_Level_9_NkcIfWgp2FYlJHL3.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JLje7RdyY8ONDzVK",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "NkcIfWgp2FYlJHL3",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702117958,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!NkcIfWgp2FYlJHL3"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Distraction_Tactics_iC4Fu7TxWbMZK3Zx.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Distraction_Tactics_iC4Fu7TxWbMZK3Zx.json
@@ -1,0 +1,77 @@
+{
+  "folder": "BVzXsj2Z6eRfba09",
+  "name": "Distraction Tactics",
+  "type": "ability",
+  "_id": "iC4Fu7TxWbMZK3Zx",
+  "img": "icons/magic/symbols/question-stone-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "distraction-tactics",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your minions do the work to draw the heat away from your allies.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "maneuver",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "self",
+      "primary": "1",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "sEoB2TVuIskJREwf": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "sEoB2TVuIskJREwf",
+        "description": "<p>Until the end of the encounter or until you are dying, each minion under your control during the encounter is the target of the following effect:</p><p>The target's strikes can inflict [[potency I WEAK]] [[/apply taunted turn]]{taunted (EoT)} to enemies. The potency increases by 1 for each minion that joined the strike.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787601155305,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!iC4Fu7TxWbMZK3Zx"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Essence_Transfer_JRQwfgHgfYZzPtgv.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Essence_Transfer_JRQwfgHgfYZzPtgv.json
@@ -1,0 +1,154 @@
+{
+  "folder": "BVzXsj2Z6eRfba09",
+  "name": "Essence Transfer",
+  "type": "ability",
+  "_id": "JRQwfgHgfYZzPtgv",
+  "img": "icons/magic/unholy/energy-smoke-pink.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "essence-transfer",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You pierce your foe and repurpose some of that 'fiber of their being' they weren't using.",
+    "keywords": [
+      "magic",
+      "melee",
+      "strike"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": "1",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "custom": "",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "rfyo94Mya9gJH1Q5": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "rfyo94Mya9gJH1Q5",
+          "damage": {
+            "tier1": {
+              "value": "5 + @chr",
+              "types": [
+                "corruption"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "8 + @chr",
+              "types": [
+                "corruption"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "11 + @chr",
+              "types": [
+                "corruption"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        },
+        "HTqgVBtBXiUhyZYu": {
+          "sort": 200000,
+          "name": "",
+          "img": null,
+          "type": "other",
+          "_id": "HTqgVBtBXiUhyZYu",
+          "other": {
+            "tier1": {
+              "display": "2 Charges",
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "display": "3 Charges",
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "4 Charges",
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "etJGiy5LHcmV5AeG": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "etJGiy5LHcmV5AeG",
+        "description": "<p>You can spend charges to activate one of the following effects. You can activate an effect multiple times. All charges disappear after using this ability.</p><ul><li><p>1 charge: You or an ally within your Summoner's Range can spend a Recovery.</p></li><li><p>1 charge: You or an ally within your Summoner's Range gain a surge.</p></li><li><p>2 charges: You call forth a signature minion into an unoccupied space within your Summoner's Range.</p></li></ul>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787600787834,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!JRQwfgHgfYZzPtgv"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Explosive_Parade_09Tz5XBzvI2uNUKb.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Explosive_Parade_09Tz5XBzvI2uNUKb.json
@@ -1,0 +1,120 @@
+{
+  "folder": "BVzXsj2Z6eRfba09",
+  "name": "Explosive Parade",
+  "type": "ability",
+  "_id": "09Tz5XBzvI2uNUKb",
+  "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "explosive-parade",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your minions swell with energy until they can no longer exist in this realm.",
+    "keywords": [
+      "magic",
+      "ranged"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "M4HLQxqR0j5LAmGp": {
+          "sort": 100000,
+          "name": "Summoning",
+          "img": null,
+          "type": "other",
+          "_id": "M4HLQxqR0j5LAmGp",
+          "other": {
+            "tier1": {
+              "display": "You summon four signature minions.",
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "display": "You summon five signature minions.",
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "You summon six signature minions.",
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "n5CHbyiJ9HUX0NSj": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "n5CHbyiJ9HUX0NSj",
+        "description": "<p>The minions are summoned within distance regardless of your minion maximum and without organizing them into squads. Each newly summoned minion immediately moves up to their speed toward a creature or object.</p><p>If they move adjacent to their target, become targeted by an opportunity attack, or stop moving, they explode, dealing 2 damage to one adjacent creature or object and pushing them 1 square. If a target is affected by two or more minions' explosions, the effects stack. These minions activate no effects upon death, and you gain no essence from their deaths.</p>",
+        "before": false
+      },
+      "QOr8rdgnpvi7bIU9": {
+        "sort": 200000,
+        "name": "Special",
+        "img": null,
+        "type": "base",
+        "_id": "QOr8rdgnpvi7bIU9",
+        "description": "<p>In addition to the minions summoned as a part of this ability, you can choose to command any number of your minions within distance, provided they haven't used a main action or maneuver during the turn.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787601017878,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!09Tz5XBzvI2uNUKb"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Rallying_Cry_vDb2t7duOcIl1w9R.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Rallying_Cry_vDb2t7duOcIl1w9R.json
@@ -1,0 +1,78 @@
+{
+  "folder": "BVzXsj2Z6eRfba09",
+  "name": "Rallying Cry",
+  "type": "ability",
+  "_id": "vDb2t7duOcIl1w9R",
+  "img": "icons/skills/social/intimidation-impressing.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "rallying-cry",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "\"Show them what you're made of!\"",
+    "keywords": [
+      "magic",
+      "ranged"
+    ],
+    "type": "maneuver",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "3",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "ally",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "YoIrinZozlLU9gIM": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "YoIrinZozlLU9gIM",
+        "description": "<p>Each target chooses between gaining [[/gain 2 surge]]{gaining 2 surges} or dealing additional damage equal to your [[lookup @R]]{reason} on their next strike.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787601580660,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!vDb2t7duOcIl1w9R"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Shields_of_Essence_17F57a0z1uONFLbj.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Shields_of_Essence_17F57a0z1uONFLbj.json
@@ -1,0 +1,109 @@
+{
+  "folder": "BVzXsj2Z6eRfba09",
+  "name": "Shields of Essence",
+  "type": "ability",
+  "_id": "17F57a0z1uONFLbj",
+  "img": "icons/magic/defensive/armor-stone-skin.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "shields-of-essence",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You call forth protective forces to keep you all from harm.",
+    "keywords": [
+      "magic",
+      "ranged"
+    ],
+    "type": "maneuver",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {
+        "ugEko0AOAErgYRl2": {
+          "sort": 100000,
+          "name": "Targets",
+          "img": null,
+          "type": "other",
+          "_id": "ugEko0AOAErgYRl2",
+          "other": {
+            "tier1": {
+              "display": "Three creatures",
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "display": "Four creatures",
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "Five creatures",
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "KuCBX6qOfnkV15AG": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "KuCBX6qOfnkV15AG",
+        "description": "<p>Until the end of the encounter, each target can use a free triggered action whenever they take damage to reduce the incoming damage by half and then lose this effect.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787601290453,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!17F57a0z1uONFLbj"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Summoner_s_Sword_yzp3J1MPcRLogYjI.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/5_Essence_BVzXsj2Z6eRfba09/ability_Summoner_s_Sword_yzp3J1MPcRLogYjI.json
@@ -1,0 +1,118 @@
+{
+  "folder": "BVzXsj2Z6eRfba09",
+  "name": "Summoner's Sword",
+  "type": "ability",
+  "_id": "yzp3J1MPcRLogYjI",
+  "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-teal-purple.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "summoners-sword",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You draw your strength from the army you surround yourself with and summon a hot blade of energy and fervor.",
+    "keywords": [
+      "magic",
+      "melee",
+      "strike"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 5,
+    "trigger": "",
+    "distance": {
+      "type": "melee",
+      "primary": "3",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creatureObject",
+      "custom": "",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "rhLpNwJtwbeRoQDI": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "rhLpNwJtwbeRoQDI",
+          "damage": {
+            "tier1": {
+              "value": "@chr",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "2 + @chr",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "4 + @chr",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "KWLjDu4SB4KKiGnE": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "KWLjDu4SB4KKiGnE",
+        "description": "<p>This strike deals an additional 2 damage for each ally adjacent to you.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787601436920,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!yzp3J1MPcRLogYjI"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Folder_5_Essence_BVzXsj2Z6eRfba09.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Folder_5_Essence_BVzXsj2Z6eRfba09.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "4s1wz38jXyJjINh1",
+  "name": "5 Essence",
+  "color": null,
+  "sorting": "a",
+  "_id": "BVzXsj2Z6eRfba09",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787600759452,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!BVzXsj2Z6eRfba09"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Folder_Quick_Command_c7Npa7d8ilwSrJHD.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Folder_Quick_Command_c7Npa7d8ilwSrJHD.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "4s1wz38jXyJjINh1",
+  "name": "Quick Command",
+  "color": null,
+  "sorting": "a",
+  "_id": "c7Npa7d8ilwSrJHD",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787592076448,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!c7Npa7d8ilwSrJHD"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Focus_Fire__K6TaJ3C98yjmeA3d.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Focus_Fire__K6TaJ3C98yjmeA3d.json
@@ -1,0 +1,88 @@
+{
+  "folder": "c7Npa7d8ilwSrJHD",
+  "name": "Focus Fire!",
+  "type": "ability",
+  "_id": "K6TaJ3C98yjmeA3d",
+  "img": "icons/skills/ranged/target-bullseye-arrow-white.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "focus-fire",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You ensure the enemy can't escape the incoming attack.",
+    "keywords": [],
+    "type": "triggered",
+    "category": "",
+    "resource": null,
+    "trigger": "The target deals damage to another creature.",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "selfOrAlly",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "RgSJWRIrcAml3XxR": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "RgSJWRIrcAml3XxR",
+        "description": "<p>The target gains a surge for each of your minions adjacent to them (up to a maximum of 3 surges), which they can use on the triggering damage.</p>",
+        "before": false
+      },
+      "CCunPXl4J6kEyYK6": {
+        "sort": 200000,
+        "name": "",
+        "img": null,
+        "type": "spend",
+        "_id": "CCunPXl4J6kEyYK6",
+        "description": "<p>If the triggering damage is from an ability that uses a power roll, the power roll gains an edge.</p>",
+        "before": false,
+        "resource": {
+          "value": 1,
+          "multiple": false
+        }
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787592085310,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!K6TaJ3C98yjmeA3d"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Halt__0LjJ5YWxuC1qJTII.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Halt__0LjJ5YWxuC1qJTII.json
@@ -1,0 +1,84 @@
+{
+  "folder": "c7Npa7d8ilwSrJHD",
+  "name": "Halt!",
+  "type": "ability",
+  "_id": "0LjJ5YWxuC1qJTII",
+  "img": "icons/skills/movement/portal-silhouette-pink.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "halt",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You order a minion to get in the way.",
+    "keywords": [],
+    "type": "triggered",
+    "category": "",
+    "resource": null,
+    "trigger": "The target starts their turn, moves, or is force moved.",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "creature",
+      "custom": "",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "aAVJHRXyxzH9uS2f": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "aAVJHRXyxzH9uS2f",
+        "description": "<p>You summon a signature minion in an unoccupied space adjacent to the target. If the target is force moved into the minion, you can choose to make the target take no damage from the collision.</p>",
+        "before": false
+      },
+      "ghBAMM5GG6M054MP": {
+        "sort": 200000,
+        "name": "Special",
+        "img": null,
+        "type": "base",
+        "_id": "ghBAMM5GG6M054MP",
+        "description": "<p>Instead of summoning a new minion, you can command one of your minions within distance to shift up to their speed toward a square adjacent to the target before any additional effects occur.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787592195770,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!0LjJ5YWxuC1qJTII"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Not_Yet__fzcUwf43Mq6ezXmp.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Not_Yet__fzcUwf43Mq6ezXmp.json
@@ -1,0 +1,84 @@
+{
+  "folder": "c7Npa7d8ilwSrJHD",
+  "name": "Not Yet!",
+  "type": "ability",
+  "_id": "fzcUwf43Mq6ezXmp",
+  "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "not-yet",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "I command you to not die.",
+    "keywords": [],
+    "type": "triggered",
+    "category": "",
+    "resource": null,
+    "trigger": "The target receives enough damage to die or be destroyed.",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "ally",
+      "custom": "",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "8aIH2WLJjAalHQ8d": {
+        "sort": 100000,
+        "name": "Special",
+        "img": null,
+        "type": "base",
+        "_id": "8aIH2WLJjAalHQ8d",
+        "description": "<p>If the target is a minion, they must be the only minion remaining in their squad.</p>",
+        "before": false
+      },
+      "OueycRavXADdGvzA": {
+        "sort": 200000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "OueycRavXADdGvzA",
+        "description": "<p>The damage the target receives is reduced by an amount that leaves the target alive with 1 point of Stamina.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787592301531,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!fzcUwf43Mq6ezXmp"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Shield__XbbJ3rqIJt4Rt9d2.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_1_4s1wz38jXyJjINh1/Quick_Command_c7Npa7d8ilwSrJHD/ability_Shield__XbbJ3rqIJt4Rt9d2.json
@@ -1,0 +1,88 @@
+{
+  "folder": "c7Npa7d8ilwSrJHD",
+  "name": "Shield!",
+  "type": "ability",
+  "_id": "XbbJ3rqIJt4Rt9d2",
+  "img": "icons/magic/defensive/barrier-shield-dome-blue-purple.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "shield",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You call upon a minion to use their body to dampen the blow.",
+    "keywords": [],
+    "type": "triggered",
+    "category": "",
+    "resource": null,
+    "trigger": "The target is targeted by a strike.",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "selfOrAlly",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "ktEqrT3yea2mqxsh": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "ktEqrT3yea2mqxsh",
+        "description": "<p>If one of your minions is adjacent to the target and is within distance of the strike, they become the new target of the strike.</p>",
+        "before": false
+      },
+      "HyiAFYrGzjztHaxT": {
+        "sort": 200000,
+        "name": "",
+        "img": null,
+        "type": "spend",
+        "_id": "HyiAFYrGzjztHaxT",
+        "description": "<p>Instead of commanding an existing minion, you summon a signature minion into an unoccupied space adjacent to the target to take the strike.</p>",
+        "before": false,
+        "resource": {
+          "value": 1,
+          "multiple": false
+        }
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787592443334,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!XbbJ3rqIJt4Rt9d2"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_2_FsImes7cB6dJ00O5/Demon_3tBoSCOFnCtYR0TR/ability_Fixture__The_Boil_V8cAcPRg1XoFejcO.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_2_FsImes7cB6dJ00O5/Demon_3tBoSCOFnCtYR0TR/ability_Fixture__The_Boil_V8cAcPRg1XoFejcO.json
@@ -1,0 +1,79 @@
+{
+  "folder": "3tBoSCOFnCtYR0TR",
+  "name": "Fixture: The Boil",
+  "type": "ability",
+  "_id": "V8cAcPRg1XoFejcO",
+  "img": "icons/magic/unholy/projectiles-blood-salvo-red.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "fixture-the-boil",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "The boil arises from the chaotic depths of the Abyssal Waste, concentrated into a heaving mass by the pressure of a coherent reality. As it slushes and threatens to burst, the noises drive nearby demons into a frenzy.",
+    "keywords": [],
+    "type": "maneuver",
+    "category": "",
+    "resource": null,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": "5 + @R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "jWQIfE0jEob9uAKY": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "summon",
+        "_id": "jWQIfE0jEob9uAKY",
+        "description": "",
+        "before": false,
+        "summoning": {
+          "pool": [],
+          "count": 1
+        }
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787602406810,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!V8cAcPRg1XoFejcO"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_2_FsImes7cB6dJ00O5/Folder_Demon_3tBoSCOFnCtYR0TR.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_2_FsImes7cB6dJ00O5/Folder_Demon_3tBoSCOFnCtYR0TR.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "FsImes7cB6dJ00O5",
+  "name": "Demon",
+  "color": null,
+  "sorting": "a",
+  "_id": "3tBoSCOFnCtYR0TR",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787602394088,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!3tBoSCOFnCtYR0TR"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Blitz_Tactics_EyAlK3DH58yu8oGM.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Blitz_Tactics_EyAlK3DH58yu8oGM.json
@@ -1,0 +1,77 @@
+{
+  "folder": "9342oC64JO7QiJd1",
+  "name": "Blitz Tactics",
+  "type": "ability",
+  "_id": "EyAlK3DH58yu8oGM",
+  "img": "icons/skills/movement/arrow-upward-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "blitz-tactics",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Rush 'em! CRUSH 'EM!",
+    "keywords": [
+      "magic"
+    ],
+    "type": "maneuver",
+    "category": "heroic",
+    "resource": 7,
+    "trigger": "",
+    "distance": {
+      "type": "self",
+      "primary": "1",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "2s8xOu8towceJG9w": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "2s8xOu8towceJG9w",
+        "description": "<p>Until the end of the encounter or you are dying, each minion under your control during the encounter is the target of the following effect. The first time on a turn that the target moves through an enemy's space, the enemy can choose to shift 1 square or be [[potency M WEAK]] (or [[potency M AVERAGE]] if the target is larger than the enemy) knocked prone. The potency increases by 1 for each subsequent target that moves through the enemy's space during the same move action.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604604418,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!EyAlK3DH58yu8oGM"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Cavalry_Call_WDmcLwlvdCYQ0PeJ.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Cavalry_Call_WDmcLwlvdCYQ0PeJ.json
@@ -1,0 +1,77 @@
+{
+  "folder": "9342oC64JO7QiJd1",
+  "name": "Cavalry Call",
+  "type": "ability",
+  "_id": "WDmcLwlvdCYQ0PeJ",
+  "img": "icons/magic/movement/trail-streak-zigzag-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "cavalry-call",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "A lone squad appears to disrupt the enemy's plans and peels off their forces, one by one.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 7,
+    "trigger": "",
+    "distance": {
+      "type": "ranged",
+      "primary": "5+@R",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "CwS75gY7hlwpfp40": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "CwS75gY7hlwpfp40",
+        "description": "<p>You summon a temporary squad containing 6 of your signature minions regardless of your minion maximum within distance. Whenever one of these minions deals damage to an enemy, the enemy is [[potency R AVERAGE]] compelled to move 5 squares toward the source of the damage (provoking opportunity attacks). The potency increases by 1 for enemies targeted by two or more of these minions.</p><p>These minions die at the end of your turn, activate no effects upon death, and you gain no essence from their deaths.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604700493,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!WDmcLwlvdCYQ0PeJ"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Essence_Funnel_Jhx5LrSQSgqT4SV5.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Essence_Funnel_Jhx5LrSQSgqT4SV5.json
@@ -1,0 +1,162 @@
+{
+  "folder": "9342oC64JO7QiJd1",
+  "name": "Essence Funnel",
+  "type": "ability",
+  "_id": "Jhx5LrSQSgqT4SV5",
+  "img": "icons/magic/fire/barrier-wall-flame-ring-blue.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "essence-funnel",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You rapidly summon and sacrifice minions in order to power a devastating blast of magic.",
+    "keywords": [
+      "area",
+      "magic"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 7,
+    "trigger": "",
+    "distance": {
+      "type": "line",
+      "primary": "10",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemyObject",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "blzBN3bjHdFnfBfz": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "blzBN3bjHdFnfBfz",
+          "damage": {
+            "tier1": {
+              "value": "5",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "9",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "12",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        },
+        "WtcsRbjG0fXDOwsk": {
+          "sort": 200000,
+          "name": "",
+          "img": null,
+          "type": "forced",
+          "_id": "WtcsRbjG0fXDOwsk",
+          "forced": {
+            "tier1": {
+              "display": "{{forced}}",
+              "movement": [
+                "push"
+              ],
+              "distance": "2",
+              "properties": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "display": "{{forced}}",
+              "movement": [
+                "push"
+              ],
+              "distance": "4",
+              "properties": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "{{forced}}",
+              "movement": [
+                "push"
+              ],
+              "distance": "8",
+              "properties": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "Mbkv3VucYONWvmxx": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "Mbkv3VucYONWvmxx",
+        "description": "<p>You can choose to kill any number of your minions within your [[lookup 5+@R]]{Summoner's Range} as a part of this ability, provided they haven't used a main action or maneuver during the turn. Each target takes an additional 1 damage, plus 1 damage for each minion killed this way. These minions activate no effects upon death, and you gain no essence from their deaths.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604798263,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!Jhx5LrSQSgqT4SV5"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Lead_By_Example_mmE5hWF4wBr7hZOK.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/7_Essence_9342oC64JO7QiJd1/ability_Lead_By_Example_mmE5hWF4wBr7hZOK.json
@@ -1,0 +1,160 @@
+{
+  "folder": "9342oC64JO7QiJd1",
+  "name": "Lead By Example",
+  "type": "ability",
+  "_id": "mmE5hWF4wBr7hZOK",
+  "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "lead-by-example",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your minions watch as your implement crackles with power, ready to slam unbelievable force into your foe.",
+    "keywords": [
+      "magic",
+      "melee",
+      "ranged",
+      "strike"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 7,
+    "trigger": "",
+    "distance": {
+      "type": "meleeRanged",
+      "primary": "1",
+      "secondary": "5+@R",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemyObject",
+      "custom": "",
+      "value": 1
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "qO9oxKYNZHDJTiG9": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "qO9oxKYNZHDJTiG9",
+          "damage": {
+            "tier1": {
+              "value": "8 + @chr",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "12+@chr",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "16+@chr",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        },
+        "0T02Bg0bULAIdibj": {
+          "sort": 200000,
+          "name": "",
+          "img": null,
+          "type": "applied",
+          "_id": "0T02Bg0bULAIdibj",
+          "applied": {
+            "tier1": {
+              "display": "{{potency}} dazed (save ends)",
+              "effects": {
+                "dazed": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "reason"
+              }
+            },
+            "tier2": {
+              "display": "",
+              "effects": {
+                "dazed": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "",
+              "effects": {
+                "dazed": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {}
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604948859,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!mmE5hWF4wBr7hZOK"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/Folder_7_Essence_9342oC64JO7QiJd1.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_3_AFieXJzTQ1j5n27m/Folder_7_Essence_9342oC64JO7QiJd1.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "AFieXJzTQ1j5n27m",
+  "name": "7 Essence",
+  "color": null,
+  "sorting": "a",
+  "_id": "9342oC64JO7QiJd1",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604591626,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!9342oC64JO7QiJd1"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_A_Champion_s_Cry_qhNa8pGpVyxdObOH.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_A_Champion_s_Cry_qhNa8pGpVyxdObOH.json
@@ -1,0 +1,178 @@
+{
+  "folder": "XLTepKKknqngECeR",
+  "name": "A Champion's Cry",
+  "type": "ability",
+  "_id": "qhNa8pGpVyxdObOH",
+  "img": "icons/magic/sonic/explosion-shock-wave-teal.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "a-champions-cry",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your champion unleashes a bellow that shakes you to your core.",
+    "keywords": [
+      "area",
+      "magic",
+      "champion"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 9,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "3",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemy",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "NticS4ZNV7u91odi": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "NticS4ZNV7u91odi",
+          "damage": {
+            "tier1": {
+              "value": "2",
+              "types": [
+                "psychic",
+                "sonic"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "5",
+              "types": [
+                "psychic",
+                "sonic"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "7",
+              "types": [
+                "psychic",
+                "sonic"
+              ],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        },
+        "TjLPFsBNLTrpA3QC": {
+          "sort": 200000,
+          "name": "",
+          "img": null,
+          "type": "applied",
+          "_id": "TjLPFsBNLTrpA3QC",
+          "applied": {
+            "tier1": {
+              "display": "{{potency}} frightened of you (save ends)",
+              "effects": {
+                "frightened": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "intuition"
+              }
+            },
+            "tier2": {
+              "display": "{{potency}} frightened of you and all allies (EoT)",
+              "effects": {
+                "frightened": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "turn"
+                }
+              },
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "{{potency}} frightened of you and all allies (save ends)",
+              "effects": {
+                "frightened": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "pXMCkpRKsQvaNKVT": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "pXMCkpRKsQvaNKVT",
+        "description": "<p>You can use this ability as if in the space of one of your minions within your Summoner's Range.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787699020096,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!qhNa8pGpVyxdObOH"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_Army_s_Idol_1gAOmN6RR3mpPCmA.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_Army_s_Idol_1gAOmN6RR3mpPCmA.json
@@ -1,0 +1,79 @@
+{
+  "folder": "XLTepKKknqngECeR",
+  "name": "Army's Idol",
+  "type": "ability",
+  "_id": "1gAOmN6RR3mpPCmA",
+  "img": "icons/magic/sonic/bell-alarm-red-purple.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "armys-idol",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your champion's appearance has an enchanting impact on you and your allies.",
+    "keywords": [
+      "area",
+      "magic",
+      "champion"
+    ],
+    "type": "maneuver",
+    "category": "heroic",
+    "resource": 9,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "4",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "selfAlly",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "yIVMjFqphSifrZcB": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "yIVMjFqphSifrZcB",
+        "description": "<p>You can use this ability as if in the space of one of your minions within your Summoner's Range.</p><p>Until the end of the encounter or you become dying, each target has a +2 bonus to saving throws.</p><p>Each target can immediately make each of their saving throws and stand up from prone.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787700193191,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!1gAOmN6RR3mpPCmA"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_The_Champion_Slams_the_Earth_Jp3p68JwTNAiLsUB.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_The_Champion_Slams_the_Earth_Jp3p68JwTNAiLsUB.json
@@ -1,0 +1,246 @@
+{
+  "folder": "XLTepKKknqngECeR",
+  "name": "The Champion Slams the Earth",
+  "type": "ability",
+  "_id": "Jp3p68JwTNAiLsUB",
+  "img": "icons/magic/earth/strike-stone-stalactite-blood-red.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "the-champion-slams-the-earth",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your champion lays their fury upon those unfortunate enough to be in their wake.",
+    "keywords": [
+      "area",
+      "magic",
+      "weapon",
+      "champion"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 9,
+    "trigger": "",
+    "distance": {
+      "type": "cube",
+      "primary": "4",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemyObject",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "rayjr29xGa7N5rqZ": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "rayjr29xGa7N5rqZ",
+          "damage": {
+            "tier1": {
+              "value": "5",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "8",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "11",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        },
+        "BOESoOmLLm8A10qL": {
+          "sort": 200000,
+          "name": "",
+          "img": null,
+          "type": "applied",
+          "_id": "BOESoOmLLm8A10qL",
+          "applied": {
+            "tier1": {
+              "display": "{{potency}} prone and can't stand (save ends)",
+              "effects": {
+                "prone": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": ""
+                },
+                "88HrzeohpddIxNVH": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "might"
+              }
+            },
+            "tier2": {
+              "display": "",
+              "effects": {
+                "prone": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": ""
+                },
+                "88HrzeohpddIxNVH": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "save"
+                }
+              },
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "",
+              "effects": {
+                "prone": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": ""
+                },
+                "88HrzeohpddIxNVH": {
+                  "condition": "failure",
+                  "properties": [],
+                  "end": "turn"
+                }
+              },
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "mL9elGWZ358fGszP": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "mL9elGWZ358fGszP",
+        "description": "<p>You can use this ability as if in the space of one of your minions within your Summoner's Range.</p>",
+        "before": false
+      },
+      "sumBDisMI1fQABbm": {
+        "sort": 200000,
+        "name": "Special",
+        "img": null,
+        "type": "base",
+        "_id": "sumBDisMI1fQABbm",
+        "description": "<p>You can change the damage type to be a type that your champion deals on their stat block (see Portfolio Champion).</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [
+    {
+      "folder": "N0lpDp0tt06nvpAM",
+      "name": "Can't Stand",
+      "type": "base",
+      "img": "icons/skills/movement/arrow-down-pink.webp",
+      "system": {
+        "changes": [],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": false,
+      "statuses": [],
+      "showIcon": 1,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787700495017,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": "Compendium.draw-steel.effects.ActiveEffect.gQX380Z2Rk63tssT",
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_id": "88HrzeohpddIxNVH",
+      "sort": 0,
+      "_key": "!items.effects!Jp3p68JwTNAiLsUB.88HrzeohpddIxNVH"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787700332634,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!Jp3p68JwTNAiLsUB"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_Their_Pall_Shrouds_All_IaVte8boP37MRubS.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/9_Essence_XLTepKKknqngECeR/ability_Their_Pall_Shrouds_All_IaVte8boP37MRubS.json
@@ -1,0 +1,79 @@
+{
+  "folder": "XLTepKKknqngECeR",
+  "name": "Their Pall Shrouds All",
+  "type": "ability",
+  "_id": "IaVte8boP37MRubS",
+  "img": "icons/magic/water/wave-water-teal.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "their-pall-shrouds-all",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your champion fills the area with a thick haze hiding friend from foe.",
+    "keywords": [
+      "area",
+      "magic",
+      "champion"
+    ],
+    "type": "maneuver",
+    "category": "heroic",
+    "resource": 9,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "4",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemy",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "Z8qt7zG0ZBpIeLO4": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "Z8qt7zG0ZBpIeLO4",
+        "description": "<p>You can use this ability as if in the space of one of your minions within your Summoner's Range.</p><p>Each target is R &lt; AVERAGE weakened (save ends).</p><p>Until the end of the encounter, whenever a target gets a tier 1 result on a strike, they deal half damage. If a target was striking a creature adjacent to one of their allies, they target their ally instead.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787700608746,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!IaVte8boP37MRubS"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/Folder_9_Essence_XLTepKKknqngECeR.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_6_t51W0QApaNbMvbKx/Folder_9_Essence_XLTepKKknqngECeR.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "t51W0QApaNbMvbKx",
+  "name": "9 Essence",
+  "color": null,
+  "sorting": "a",
+  "_id": "XLTepKKknqngECeR",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787698980744,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!XLTepKKknqngECeR"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_10_000_Minions_0FPo2KsO0J1rhApj.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_10_000_Minions_0FPo2KsO0J1rhApj.json
@@ -1,0 +1,77 @@
+{
+  "folder": "FokXN8a65T1c7b44",
+  "name": "10,000 Minions",
+  "type": "ability",
+  "_id": "0FPo2KsO0J1rhApj",
+  "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "10000-minions",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "The battle is now a war. Your entire army storms the field.",
+    "keywords": [
+      "magic"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 11,
+    "trigger": "",
+    "distance": {
+      "type": "special",
+      "primary": "1",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "It3PFDL9bYBXtQDa": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "It3PFDL9bYBXtQDa",
+        "description": "<p>Until the end of the encounter or you are dying, each square on the ground is considered teeming with minions. An enemy that ends their turn in an affected square takes [[/damage 5]]{5 damage}. This damage can't be reduced.</p><p>Additionally, you can use Minion Bridge treating each affected square as an eligible minion (up to a maximum of 10 additional squares).</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702144456,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!0FPo2KsO0J1rhApj"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_Bodyguard_Tactics_NzzLb4acXXv2N7vt.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_Bodyguard_Tactics_NzzLb4acXXv2N7vt.json
@@ -1,0 +1,78 @@
+{
+  "folder": "FokXN8a65T1c7b44",
+  "name": "Bodyguard Tactics",
+  "type": "ability",
+  "_id": "NzzLb4acXXv2N7vt",
+  "img": "icons/skills/melee/shield-block-gray-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "bodyguard-tactics",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "You surround your allies with a nigh-endless supply of summons that stand in the way of all impacts.",
+    "keywords": [
+      "area",
+      "magic"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 11,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "5",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "selfAlly",
+      "custom": "Self and each non-minion ally in the area",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "yJDxIsw1Vz4gP7DY": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "yJDxIsw1Vz4gP7DY",
+        "description": "<p>Until the end of the encounter or you are dying, each target has damage immunity 5 and can use a free triggered action once per turn whenever they are force moved to reduce the distance by half.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702231594,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!NzzLb4acXXv2N7vt"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_I_Abjure_Thee_knNxGM7E5zeQB6UU.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_I_Abjure_Thee_knNxGM7E5zeQB6UU.json
@@ -1,0 +1,78 @@
+{
+  "folder": "FokXN8a65T1c7b44",
+  "name": "I Abjure Thee",
+  "type": "ability",
+  "_id": "knNxGM7E5zeQB6UU",
+  "img": "icons/magic/holy/projectiles-blades-salvo-yellow.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "i-abjure-thee",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Cast those not affixed to this manifold into the void of a minion's existence.",
+    "keywords": [
+      "area",
+      "magic"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 11,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "3",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "special",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": []
+      },
+      "effects": {}
+    },
+    "effects": {
+      "I7PznXex2BrGmXtq": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "I7PznXex2BrGmXtq",
+        "description": "<p>Each enemy minion in the area is permanently removed from the encounter map. Up to three non-leader or non-solo enemies in the area are removed from the encounter for 1 round.</p><p>A leader or a solo enemy in the area that has R, I, or [[potency P AVERAGE]] is [[/apply weakened save]] and [[/apply slowed save]] as they are partially removed from the manifold. You can increase the potency by 1 for each of your minions adjacent to the target you choose to sacrifice as a part of using this ability.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702314221,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!knNxGM7E5zeQB6UU"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_The_Champion_s_Wrath_kmBykCfbj4cFxJFO.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/11_Essence_FokXN8a65T1c7b44/ability_The_Champion_s_Wrath_kmBykCfbj4cFxJFO.json
@@ -1,0 +1,164 @@
+{
+  "folder": "FokXN8a65T1c7b44",
+  "name": "The Champion's Wrath",
+  "type": "ability",
+  "_id": "kmBykCfbj4cFxJFO",
+  "img": "icons/magic/unholy/silhouette-evil-horned-giant.webp",
+  "system": {
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "the-champions-wrath",
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    },
+    "story": "Your champion appears and goes into a rampage, clearing the way for your minions to march forth.",
+    "keywords": [
+      "area",
+      "magic",
+      "weapon",
+      "champion"
+    ],
+    "type": "main",
+    "category": "heroic",
+    "resource": 11,
+    "trigger": "",
+    "distance": {
+      "type": "burst",
+      "primary": "4",
+      "secondary": "1",
+      "tertiary": "1"
+    },
+    "damageDisplay": "melee",
+    "target": {
+      "type": "enemy",
+      "custom": "",
+      "value": null
+    },
+    "power": {
+      "roll": {
+        "reactive": false,
+        "formula": "@chr",
+        "characteristics": [
+          "reason"
+        ]
+      },
+      "effects": {
+        "joo4L68ASOpgumax": {
+          "sort": 100000,
+          "name": "",
+          "img": null,
+          "type": "damage",
+          "_id": "joo4L68ASOpgumax",
+          "damage": {
+            "tier1": {
+              "value": "6",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "none"
+              }
+            },
+            "tier2": {
+              "value": "10",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "value": "14",
+              "types": [],
+              "ignoredImmunities": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        },
+        "fT3MbUMwpRpB0NRc": {
+          "sort": 200000,
+          "name": "",
+          "img": null,
+          "type": "forced",
+          "_id": "fT3MbUMwpRpB0NRc",
+          "forced": {
+            "tier1": {
+              "display": "{{forced}} {{potency}} push is vertical",
+              "movement": [
+                "push"
+              ],
+              "distance": "4",
+              "properties": [],
+              "potency": {
+                "value": "@potency.weak",
+                "characteristic": "might"
+              }
+            },
+            "tier2": {
+              "display": "",
+              "movement": [
+                "push"
+              ],
+              "distance": "5",
+              "properties": [],
+              "potency": {
+                "value": "@potency.average",
+                "characteristic": ""
+              }
+            },
+            "tier3": {
+              "display": "",
+              "movement": [
+                "push"
+              ],
+              "distance": "6",
+              "properties": [],
+              "potency": {
+                "value": "@potency.strong",
+                "characteristic": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "effects": {
+      "AfocUEzhDY0lr0O2": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "base",
+        "_id": "AfocUEzhDY0lr0O2",
+        "description": "<p>You can use this ability as if in the space of one of your minions within your Summoner's Range.</p><p>You can change the damage type to be a type that your champion deals on their stat block (see Portfolio Champion). For each enemy reduced to 0 Stamina by this ability, an ally within distance can move up to their speed.</p>",
+        "before": false
+      }
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702477496,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!kmBykCfbj4cFxJFO"
+}

--- a/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/Folder_11_Essence_FokXN8a65T1c7b44.json
+++ b/src/packs/abilities/Summoner_JLje7RdyY8ONDzVK/Level_9_NkcIfWgp2FYlJHL3/Folder_11_Essence_FokXN8a65T1c7b44.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "NkcIfWgp2FYlJHL3",
+  "name": "11 Essence",
+  "color": null,
+  "sorting": "a",
+  "_id": "FokXN8a65T1c7b44",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702131262,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!FokXN8a65T1c7b44"
+}

--- a/src/packs/classes/Folder_Summoner_looxdjOWIKafFCDq.json
+++ b/src/packs/classes/Folder_Summoner_looxdjOWIKafFCDq.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Summoner",
+  "color": "#745507",
+  "sorting": "a",
+  "_id": "looxdjOWIKafFCDq",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787584395509,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!looxdjOWIKafFCDq"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Graves_RDyyNBVTQQYweePg/feature_Dead_Men_Tell_All_Tales_25kP5GUvC2Upo8qT.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Graves_RDyyNBVTQQYweePg/feature_Dead_Men_Tell_All_Tales_25kP5GUvC2Upo8qT.json
@@ -1,0 +1,43 @@
+{
+  "folder": "RDyyNBVTQQYweePg",
+  "name": "Dead Men Tell All Tales",
+  "type": "feature",
+  "_id": "25kP5GUvC2Upo8qT",
+  "img": "icons/magic/death/skull-energy-light-white.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can touch the corpse of a creature who died within the past week and ask them a question. The corpse can choose to answer the question to the best of their ability. Each additional question you ask the corpse requires a medium Reason test, where failure or consequence breaks your connection with the corpse permanently.</p><p>The corpse can also choose to refuse to answer or lie, especially if you were the one to kill them in the first place.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "dead-men-tell-all-tales",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590527370,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!25kP5GUvC2Upo8qT"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Graves_RDyyNBVTQQYweePg/feature_Rise__XgMEJWhms54dEqKO.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Graves_RDyyNBVTQQYweePg/feature_Rise__XgMEJWhms54dEqKO.json
@@ -1,0 +1,43 @@
+{
+  "folder": "RDyyNBVTQQYweePg",
+  "name": "Rise!",
+  "type": "feature",
+  "_id": "XgMEJWhms54dEqKO",
+  "img": "icons/magic/death/hand-dirt-undead-zombie.webp",
+  "system": {
+    "description": {
+      "value": "<p>Once per round, when a creature dies unwillingly within your Summoner's Range, you can use a triggered action to summon a signature undead minion in their space at no cost, even if you're at your minion maximum, but only if they can be organized into one of your squads. The new minion can't act until the start of your next turn.</p><p>This ability becomes a free triggered action if the target was a minion (either yours or an enemy).</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "rise",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590603327,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!XgMEJWhms54dEqKO"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Spring_N6nN9ydn5FHaB0ix/feature_Fairy_Whispers_qXQDlQErzIY7izNQ.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Spring_N6nN9ydn5FHaB0ix/feature_Fairy_Whispers_qXQDlQErzIY7izNQ.json
@@ -1,0 +1,43 @@
+{
+  "folder": "N6nN9ydn5FHaB0ix",
+  "name": "Fairy Whispers",
+  "type": "feature",
+  "_id": "qXQDlQErzIY7izNQ",
+  "img": "icons/creatures/magical/humanoid-silhouette-dashing-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever you send a minion to perform a task for you outside of combat, they can bring back a rumor from the destination to which you sent them. When the minion returns, make a Reason test:</p><dl class=\"power-roll-display\"><dt class=\"tier1\"><p>!</p></dt><dd><p><span class=\"res\">You learn an undoubtedly false common rumor.</span></p></dd><dt class=\"tier2\"><p>@</p></dt><dd><p><span class=\"res\">You learn a common rumor that is most likely true.</span></p></dd><dt class=\"tier3\"><p>#</p></dt><dd><p><span class=\"res\">You learn an obscure rumor that could either be true or false.</span></p></dd></dl><p>You gain a bane on the test for each subsequent rumor you collect either on the same day or in the same location.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "fairy-whispers",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590749935,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!qXQDlQErzIY7izNQ"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Spring_N6nN9ydn5FHaB0ix/feature_Pixie_Dust_yV1cQbm41Y6kkVnL.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Spring_N6nN9ydn5FHaB0ix/feature_Pixie_Dust_yV1cQbm41Y6kkVnL.json
@@ -1,0 +1,102 @@
+{
+  "folder": "N6nN9ydn5FHaB0ix",
+  "name": "Pixie Dust",
+  "type": "feature",
+  "_id": "yV1cQbm41Y6kkVnL",
+  "img": "icons/magic/light/orbs-firefly-hand-yellow.webp",
+  "system": {
+    "description": {
+      "value": "<p>Increase your number of Recoveries by 2. Whenever one of your fey minions dies within your Summoner's Range, you can spend a Recovery to give temporary Stamina equal to [[/heal @R*2 type=temporary]]{twice your Reason score} to each non-minion ally adjacent to the minion when they died.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "pixie-dust",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Pixie Dust",
+      "img": "icons/svg/item-bag.svg",
+      "type": "base",
+      "origin": "Compendium.draw-steel.classes.Item.yV1cQbm41Y6kkVnL",
+      "_id": "fPOfQQBzQJLf1HK6",
+      "system": {
+        "changes": [
+          {
+            "key": "",
+            "type": "add",
+            "value": "",
+            "phase": "initial"
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787591168048,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!yV1cQbm41Y6kkVnL.fPOfQQBzQJLf1HK6"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590876481,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!yV1cQbm41Y6kkVnL"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Storms_NXKfNSMrWUz2uygm/feature_Elemental_Affinity_isQ1maSZjrX3r50h.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Storms_NXKfNSMrWUz2uygm/feature_Elemental_Affinity_isQ1maSZjrX3r50h.json
@@ -1,0 +1,43 @@
+{
+  "folder": "NXKfNSMrWUz2uygm",
+  "name": "Elemental Affinity",
+  "type": "feature",
+  "_id": "isQ1maSZjrX3r50h",
+  "img": "icons/magic/symbols/elements-air-earth-fire-water.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever you use Call Forth to summon one or more non-signature elemental minions, you can summon one bonus signature minion at no cost. You can choose between a signature minion that shares an Element keyword with the minions you summoned (such as Fire, Earth, or Air) or an elemental mote.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "elemental-affinity",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591418614,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!isQ1maSZjrX3r50h"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Storms_NXKfNSMrWUz2uygm/feature_Heart_of_Nature_QhlmpOp9XKcgNvCV.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of_Storms_NXKfNSMrWUz2uygm/feature_Heart_of_Nature_QhlmpOp9XKcgNvCV.json
@@ -1,0 +1,43 @@
+{
+  "folder": "NXKfNSMrWUz2uygm",
+  "name": "Heart of Nature",
+  "type": "feature",
+  "_id": "QhlmpOp9XKcgNvCV",
+  "img": "icons/magic/symbols/runes-carved-stone-yellow.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can sense the presence of creatures with the Elemental or Dragon keywords within 1 mile of you. You can innately feel their emotions or pain, and you can't obtain lower than a tier 2 outcome on any Intuition test made to socially interact with them.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "heart-of-nature",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591504720,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!QhlmpOp9XKcgNvCV"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of__Blight_IP44Jb3jB3T3DJok/feature_Death_Snap_9tFUdZyXM1rYC5zN.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of__Blight_IP44Jb3jB3T3DJok/feature_Death_Snap_9tFUdZyXM1rYC5zN.json
@@ -1,0 +1,43 @@
+{
+  "folder": "IP44Jb3jB3T3DJok",
+  "name": "Death Snap",
+  "type": "feature",
+  "_id": "9tFUdZyXM1rYC5zN",
+  "img": "icons/magic/unholy/strike-body-life-soul-purple.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever one of your demon minions would die unwillingly, they can deal damage to an adjacent creature equal to their free strike value before dying.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "death-snap",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590161738,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!9tFUdZyXM1rYC5zN"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of__Blight_IP44Jb3jB3T3DJok/feature_Soulsense_5XLwLZFvdFV8HNha.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Circle_of__Blight_IP44Jb3jB3T3DJok/feature_Soulsense_5XLwLZFvdFV8HNha.json
@@ -1,0 +1,43 @@
+{
+  "folder": "IP44Jb3jB3T3DJok",
+  "name": "Soulsense",
+  "type": "feature",
+  "_id": "5XLwLZFvdFV8HNha",
+  "img": "icons/magic/perception/eye-ringed-glow-angry-teal.webp",
+  "system": {
+    "description": {
+      "value": "<p>While you have line of effect to a creature with a soul, you can perceive a trail of where the creature has been in the last number of minutes equal to [[lookup 5*@level]]{5 × your level}.</p><p>When you finish a respite, you can always perceive the soul trails of each creature that took the respite with you until your next respite.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "soulsense",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787590346989,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!5XLwLZFvdFV8HNha"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of_Graves_RDyyNBVTQQYweePg.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of_Graves_RDyyNBVTQQYweePg.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Circle of Graves",
+  "color": null,
+  "sorting": "a",
+  "_id": "RDyyNBVTQQYweePg",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586525781,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!RDyyNBVTQQYweePg"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of_Spring_N6nN9ydn5FHaB0ix.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of_Spring_N6nN9ydn5FHaB0ix.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Circle of Spring",
+  "color": null,
+  "sorting": "a",
+  "_id": "N6nN9ydn5FHaB0ix",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586533934,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!N6nN9ydn5FHaB0ix"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of_Storms_NXKfNSMrWUz2uygm.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of_Storms_NXKfNSMrWUz2uygm.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Circle of Storms",
+  "color": null,
+  "sorting": "a",
+  "_id": "NXKfNSMrWUz2uygm",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586539952,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!NXKfNSMrWUz2uygm"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of__Blight_IP44Jb3jB3T3DJok.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Circle_of__Blight_IP44Jb3jB3T3DJok.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Circle of  Blight",
+  "color": null,
+  "sorting": "a",
+  "_id": "IP44Jb3jB3T3DJok",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586519159,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!IP44Jb3jB3T3DJok"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Formations_4ibJmGSRT5UnlcDh.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Formations_4ibJmGSRT5UnlcDh.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Formations",
+  "color": null,
+  "sorting": "a",
+  "_id": "4ibJmGSRT5UnlcDh",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591712550,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!4ibJmGSRT5UnlcDh"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Minion_Improvements_YMWLEMy391DMF0MT.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Folder_Minion_Improvements_YMWLEMy391DMF0MT.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Minion Improvements",
+  "color": null,
+  "sorting": "a",
+  "_id": "YMWLEMy391DMF0MT",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787698127050,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!YMWLEMy391DMF0MT"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Elite_Formation_MJzpVrjJyRII6T9o.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Elite_Formation_MJzpVrjJyRII6T9o.json
@@ -1,0 +1,43 @@
+{
+  "folder": "4ibJmGSRT5UnlcDh",
+  "name": "Elite Formation",
+  "type": "feature",
+  "_id": "MJzpVrjJyRII6T9o",
+  "img": "icons/magic/symbols/rune-sigil-horned-white-purple.webp",
+  "system": {
+    "description": {
+      "value": "<p>Each of your minions have their Stamina increased by 3 and their stability increased by 1.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "elite-formation",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591846841,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!MJzpVrjJyRII6T9o"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Horde_Formation_y08lJF0egFWBGvLr.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Horde_Formation_y08lJF0egFWBGvLr.json
@@ -1,0 +1,43 @@
+{
+  "folder": "4ibJmGSRT5UnlcDh",
+  "name": "Horde Formation",
+  "type": "feature",
+  "_id": "y08lJF0egFWBGvLr",
+  "img": "icons/skills/melee/strike-weapons-orange.webp",
+  "system": {
+    "description": {
+      "value": "<p>Your maximum number of minions increases by 4 and you summon up to four of your signature minions at the start of each of your turns instead of three.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "horde-formation",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591790895,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!y08lJF0egFWBGvLr"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Leader_Formation_RRCS6CjABw12BEDA.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Leader_Formation_RRCS6CjABw12BEDA.json
@@ -1,0 +1,43 @@
+{
+  "folder": "4ibJmGSRT5UnlcDh",
+  "name": "Leader Formation",
+  "type": "feature",
+  "_id": "RRCS6CjABw12BEDA",
+  "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
+  "system": {
+    "description": {
+      "value": "<p>You aren't affected by excess damage after all minions in a squad are dead. If your minion is within your Summoner's Range when they take damage, you can choose to take damage in place of the minion.</p><p>Additionally, you can use light armor treasures and light weapon treasures while you don't have a kit.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "leader-formation",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591875153,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!RRCS6CjABw12BEDA"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Platoon_Formation_avYIowv4d5i2h3Uy.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Formations_4ibJmGSRT5UnlcDh/feature_Platoon_Formation_avYIowv4d5i2h3Uy.json
@@ -1,0 +1,43 @@
+{
+  "folder": "4ibJmGSRT5UnlcDh",
+  "name": "Platoon Formation",
+  "type": "feature",
+  "_id": "avYIowv4d5i2h3Uy",
+  "img": "icons/skills/melee/spear-tips-quintuple-orange.webp",
+  "system": {
+    "description": {
+      "value": "<p>henever one of your squads uses a damaging ability, choose one target of that ability to take additional damage equal to your [[/damage @R]]{Reason score}.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "platoon-formation",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787591812319,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!avYIowv4d5i2h3Uy"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Improvement_III_cIlXEK8zpRuf6PMM.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Improvement_III_cIlXEK8zpRuf6PMM.json
@@ -1,0 +1,43 @@
+{
+  "folder": "YMWLEMy391DMF0MT",
+  "name": "Minion Improvement III",
+  "type": "feature",
+  "_id": "cIlXEK8zpRuf6PMM",
+  "img": "icons/magic/control/energy-stream-link-spiral-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You now start encounters and round-tracked situations by summoning up to two additional minions for every two Victories you have (in addition to the two you normally summon).</p><p>Each of your minions' Stamina improves as shown on the 10th-Level Minion Stamina Increase table. Additionally, each minion that receives a Stamina boost can treat their characteristics as one higher for the purposes of resisting potencies (to a maximum value of 5).</p><header class=\"sc-head\"><div class=\"sc-head__stack\"><div class=\"sc-head__col sc-head__col--left\"><h4>10th-Level Minion Stamina Increase</h4></div></div><div class=\"sc-head__rail sc-head__col--right\"></div></header><div class=\"sc-trait__body\"><div class=\"md-typeset__scrollwrap\"><div class=\"md-typeset__table\"><div class=\"table-scroll-wrapper\"><table><thead><tr><th role=\"columnheader\" data-colwidth=\"160\"><p>Minion</p></th><th role=\"columnheader\" data-colwidth=\"207\"><p>Stamina Increase</p></th></tr></thead><tbody><tr><td data-colwidth=\"160\"><p>Signature Minion</p></td><td data-colwidth=\"207\"><p>Stamina +1 (to a total of +3)</p></td></tr><tr><td data-colwidth=\"160\"><p>3-Essence Minion</p></td><td data-colwidth=\"207\"><p>Stamina +3 (to a total of +9)</p></td></tr><tr><td data-colwidth=\"160\"><p>5-Essence Minion</p></td><td data-colwidth=\"207\"><p>Stamina +2 (to a total of +6)</p></td></tr><tr><td data-colwidth=\"160\"><p>7-Essence Minion</p></td><td data-colwidth=\"207\"><p>Stamina +5 (to a total of +10)</p></td></tr></tbody></table></div></div></div></div>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-improvement-iii",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702732158,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!cIlXEK8zpRuf6PMM"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Improvement_II_fuMT5jy0UM8lUMfM.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Improvement_II_fuMT5jy0UM8lUMfM.json
@@ -1,0 +1,43 @@
+{
+  "folder": "YMWLEMy391DMF0MT",
+  "name": "Minion Improvement II",
+  "type": "feature",
+  "_id": "fuMT5jy0UM8lUMfM",
+  "img": "icons/magic/control/energy-stream-link-large-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>t the start of each of your turns during combat, you can summon one additional signature minion at no cost into an unoccupied space within your Summoner's Range (no action required).</p><p>Additionally, you can increase each of your minions' Stamina as shown on the 7th-Level Minion Stamina Increase table. Additionally, each minion that receives a Stamina boost can treat their characteristics as one higher for the purposes of resisting potencies (to a maximum value of 4).</p><p>These benefits are not reflected in the stat blocks of new minions you acquire.</p><header class=\"sc-head\"><div class=\"sc-head__stack\"><div class=\"sc-head__col sc-head__col--left\"><h4>7th-Level Minion Stamina Increase</h4></div></div><div class=\"sc-head__rail sc-head__col--right\"></div></header><div class=\"sc-trait__body\"><div class=\"md-typeset__scrollwrap\"><div class=\"md-typeset__table\"><div class=\"table-scroll-wrapper\"><table><thead><tr><th role=\"columnheader\" data-colwidth=\"150\"><p>Minion</p></th><th role=\"columnheader\" data-colwidth=\"215\"><p>Stamina Increase</p></th></tr></thead><tbody><tr><td data-colwidth=\"150\"><p>Signature Minion</p></td><td data-colwidth=\"215\"><p>Stamina +1 (to a total of +2)</p></td></tr><tr><td data-colwidth=\"150\"><p>3-Essence Minion</p></td><td data-colwidth=\"215\"><p>Stamina +3 (to a total of +6)</p></td></tr><tr><td data-colwidth=\"150\"><p>5-Essence Minion</p></td><td data-colwidth=\"215\"><p>Stamina +2 (to a total of +4)</p></td></tr><tr><td data-colwidth=\"150\"><p>7-Essence Minion</p></td><td data-colwidth=\"215\"><p>Stamina +5</p></td></tr></tbody></table></div></div></div></div>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-improvement-ii",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 50000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787701059870,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!fuMT5jy0UM8lUMfM"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Improvement_g4rRmUDlo68usfif.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Improvement_g4rRmUDlo68usfif.json
@@ -1,5 +1,5 @@
 {
-  "folder": "JSp1h7zHZJxUNPG9",
+  "folder": "YMWLEMy391DMF0MT",
   "name": "Minion Improvement",
   "type": "feature",
   "_id": "g4rRmUDlo68usfif",
@@ -218,6 +218,6 @@
     "duplicateSource": null,
     "exportSource": null
   },
-  "sort": 0,
+  "sort": 100000,
   "_key": "!items!g4rRmUDlo68usfif"
 }

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Machinations_Y8DMj8KKnZ3E5jgY.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/Minion_Improvements_YMWLEMy391DMF0MT/feature_Minion_Machinations_Y8DMj8KKnZ3E5jgY.json
@@ -1,0 +1,43 @@
+{
+  "folder": "YMWLEMy391DMF0MT",
+  "name": "Minion Machinations",
+  "type": "feature",
+  "_id": "Y8DMj8KKnZ3E5jgY",
+  "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
+  "system": {
+    "description": {
+      "value": "<p>Your maximum number of followers increases by 2.</p><p>You can summon and recruit an artisan follower and a sage follower that share a keyword with a minion you can summon. These followers can be creatures from your portfolio or preexisting denizens of your circle's source manifold. See Follower Types under Attract Followers in Draw Steel: Heroes for information on constructing your followers' stats.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-machinations",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787698148554,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!Y8DMj8KKnZ3E5jgY"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Among_Our_Ranks_QzC2N2P8GY42uXFi.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Among_Our_Ranks_QzC2N2P8GY42uXFi.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Among Our Ranks",
+  "type": "feature",
+  "_id": "QzC2N2P8GY42uXFi",
+  "img": "icons/magic/control/buff-flight-wings-runes-red.webp",
+  "system": {
+    "description": {
+      "value": "<p>As a respite activity, you summon a willing and not-restrained NPC or player ally to join your party, regardless of distance or manifold. The target stays until the start of your next respite or until they are killed, in which they are immediately dismissed to the place from which they were summoned. You can't have more than one character summoned in this way.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "among-our-ranks",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702990252,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!QzC2N2P8GY42uXFi"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Eidos_Ol3Ucb5Uh9mXXUOo.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Eidos_Ol3Ucb5Uh9mXXUOo.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Eidos",
+  "type": "feature",
+  "_id": "Ol3Ucb5Uh9mXXUOo",
+  "img": "icons/magic/symbols/chevron-elipse-circle-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You gain an epic resource called eidos. When you take a respite, you gain eidos equal to the XP you gain. You can spend eidos as if it were essence on minions and abilities you have. When you do, you summon up to two bonus signature minions into unoccupied spaces within your Summoner's Range.</p><p>You and your champion also have access to abilities that can be used by spending eidos (see Their Life for Mine and Portfolio Champion).</p><p>Eidos remains until you spend it.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "eidos",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702854617,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!Ol3Ucb5Uh9mXXUOo"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Essence_Salvage_d3ulV2Amw6cT3UiX.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Essence_Salvage_d3ulV2Amw6cT3UiX.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Essence Salvage",
+  "type": "feature",
+  "_id": "d3ulV2Amw6cT3UiX",
+  "img": "icons/magic/symbols/runes-star-magenta.webp",
+  "system": {
+    "description": {
+      "value": "<p>The first time each combat round that any minion unwillingly dies within your Summoner's Range, you [[/gain 2 hr]]{gain 2 essence} instead of 1.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "33",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "essence-salvage",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787605460480,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 0,
+  "_key": "!items!d3ulV2Amw6cT3UiX"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Essence_bpmpevbhJM9m3dS6.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Essence_bpmpevbhJM9m3dS6.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Essence",
+  "type": "feature",
+  "_id": "bpmpevbhJM9m3dS6",
+  "img": "icons/magic/symbols/runes-star-magenta.webp",
+  "system": {
+    "description": {
+      "value": "<p>You and your minions have a unique reserve of essence as your Heroic Resource. You use this magic to sculpt your forces and maintain control over the battlefield.</p><h4>Essence in Combat</h4><p>At the start of a combat encounter or some other stressful situation tracked in combat rounds (as determined by the Director), you gain essence equal to [[lookup @hero.victories]]{your Victories}. At the start of each of your turns during combat, you [[/gain 2 hr]]{gain 2 essence}.</p><p>The first time each round that any minion (either yours or an enemy) dies unwillingly within your Summoner's Range, you [[/gain 1 hr]]{gain 1 essence}.</p><p>Whenever you use a heroic ability or call forth a minion that costs essence, you can willingly sacrifice one or more of your minions within your Summoner's Range to reduce the cost by 1. You can't kill minions this way if they used a main action or maneuver during the turn. You can sacrifice more minions than you would reduce the cost by.</p><p>You lose any remaining essence at the end of the encounter.</p><h4>Essence Outside of Combat</h4><p>Though you can’t gain essence outside of combat, you can use your heroic abilities and effects that cost essence without spending it. Whenever you use an ability or effect outside of combat that costs essence, you can’t use that same ability or effect outside of combat again until you earn 1 or more Victories or finish a respite.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "essence",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 300000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587304082,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!bpmpevbhJM9m3dS6"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Font_of_Creation_5phy7YJFwhNNy0I3.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Font_of_Creation_5phy7YJFwhNNy0I3.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Font of Creation",
+  "type": "feature",
+  "_id": "5phy7YJFwhNNy0I3",
+  "img": "icons/magic/symbols/runes-star-pentagon-magenta.webp",
+  "system": {
+    "description": {
+      "value": "<p>When you gain essence at the start of each of your turns during combat, you gain 3 essence instead of 2.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "font-of-creation",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787701196706,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!5phy7YJFwhNNy0I3"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Kit_Improvement___Level_9_DpFcT8Qz2ekoSBFP.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Kit_Improvement___Level_9_DpFcT8Qz2ekoSBFP.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Kit Improvement - Level 9",
+  "type": "feature",
+  "_id": "DpFcT8Qz2ekoSBFP",
+  "img": "icons/weapons/wands/wand-gem-blue.webp",
+  "system": {
+    "description": {
+      "value": "<ul><li><p>The potency of your Summoner Strike ability increases to R &lt; STRONG.</p></li><li><p>You can choose one additional ward from your Summoner's Kit.</p></li><li><p>You have a double edge on tests made to dissuade or scare enemy minions or lackeys.</p></li><li><p>Your clothing and equipment become adorned with distinct and elaborate regalia to make you stand out from your army, like massive rib cage pauldrons, a tooth crested helmet, or a billowing mantle of fire.</p></li></ul>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "kit-improvement-level-9",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787701690671,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!DpFcT8Qz2ekoSBFP"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Minion_Chain_XhbUQ3YuC5166bS6.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Minion_Chain_XhbUQ3YuC5166bS6.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Minion Chain",
+  "type": "feature",
+  "_id": "XhbUQ3YuC5166bS6",
+  "img": "icons/magic/control/debuff-chains-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever you use Minion Bridge as a maneuver, each of your minions within your Summoner's Range can shift up to their speed before the maneuver takes effect, as long as each minion that shifts ends their movement adjacent to another one of your minions.</p><p>Additionally, your minions can chain themselves together to function as a ladder or a swinging rope. When your minions move as a part of using Minion Bridge, each minion can use this movement to shift into a position directly beneath another one of your minions, hoisting them and each other minion they have hoisted, until they form a chain. The chain can then choose to fall across an unoccupied space and/or the topmost minion grabs an object to keep the chain steady.</p><p>The chain lasts until the start of your next turn or until the chain is no longer steady. The chain can also end when a minion in the chain is destroyed or when you command your minions to let go as a free maneuver. All size 1 minions count as one square when determining the chain's length.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "33",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-chain",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787605479768,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 50000,
+  "_key": "!items!XhbUQ3YuC5166bS6"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Minion_Improvement_g4rRmUDlo68usfif.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Minion_Improvement_g4rRmUDlo68usfif.json
@@ -1,0 +1,223 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Minion Improvement",
+  "type": "feature",
+  "_id": "g4rRmUDlo68usfif",
+  "img": "icons/magic/control/energy-stream-link-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Your maximum number of minions increases by 4.</p><p>You can increase each of your minions' Stamina as shown on the 4th-Level Minion Stamina Increase table. Additionally, each minion that receives a Stamina boost can treat their characteristics as one higher for the purposes of resisting potencies (to a maximum value of 3).</p><p>These benefits are not reflected in the stat blocks of new minions you acquire.</p><header class=\"sc-head\"><div class=\"sc-head__stack\"><div class=\"sc-head__col sc-head__col--left\"><h4>4th-Level Minion Stamina Increase</h4></div></div><div class=\"sc-head__rail sc-head__col--right\"></div></header><div class=\"sc-trait__body\"><div class=\"md-typeset__scrollwrap\"><div class=\"md-typeset__table\"><div class=\"table-scroll-wrapper\"><table><thead><tr><th role=\"columnheader\" data-colwidth=\"156\"><p>Minion</p></th><th role=\"columnheader\" data-colwidth=\"147\"><p>Stamina Increase</p></th></tr></thead><tbody><tr><td data-colwidth=\"156\"><p>Signature Minion</p></td><td data-colwidth=\"147\"><p>Stamina +1</p></td></tr><tr><td data-colwidth=\"156\"><p>3-Essence Minion</p></td><td data-colwidth=\"147\"><p>Stamina +3</p></td></tr><tr><td data-colwidth=\"156\"><p>5-Essence Minion</p></td><td data-colwidth=\"147\"><p>Stamina +2</p></td></tr></tbody></table></div></div></div></div>",
+      "director": ""
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "33",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-improvement",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [
+        "summoner"
+      ],
+      "level": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Signature Minion Stamina Increase",
+      "img": "icons/svg/item-bag.svg",
+      "type": "base",
+      "origin": "Compendium.world.classes.Item.g4rRmUDlo68usfif",
+      "_id": "BQ859wY0P5fZL2Wf",
+      "system": {
+        "changes": [
+          {
+            "key": "system.stamina.max",
+            "type": "add",
+            "value": 1,
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": false,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787605436337,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!g4rRmUDlo68usfif.BQ859wY0P5fZL2Wf"
+    },
+    {
+      "name": "3-Essence Minions Stamina Increase",
+      "img": "icons/svg/item-bag.svg",
+      "type": "base",
+      "origin": "Compendium.world.classes.Item.g4rRmUDlo68usfif",
+      "_id": "DkEMaJ5X1vBByQqQ",
+      "system": {
+        "changes": [
+          {
+            "key": "system.stamina.max",
+            "type": "add",
+            "value": 3,
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": false,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787605436337,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!g4rRmUDlo68usfif.DkEMaJ5X1vBByQqQ"
+    },
+    {
+      "name": "5-Essence Minion Stamina Increase",
+      "img": "icons/svg/item-bag.svg",
+      "type": "base",
+      "origin": "Compendium.world.classes.Item.g4rRmUDlo68usfif",
+      "transfer": false,
+      "_id": "nZAzk18YM6klAfel",
+      "system": {
+        "changes": [
+          {
+            "key": "system.stamina.max",
+            "type": "add",
+            "value": 2,
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787605436337,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!g4rRmUDlo68usfif.nZAzk18YM6klAfel"
+    }
+  ],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787605436337,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 0,
+  "_key": "!items!g4rRmUDlo68usfif"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Minions_M1nvpPDxewehEK0b.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Minions_M1nvpPDxewehEK0b.json
@@ -1,0 +1,63 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Minions",
+  "type": "feature",
+  "_id": "M1nvpPDxewehEK0b",
+  "img": "icons/creatures/eyes/icy-cluster-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>The creatures you control are called minions. You can summon and maintain up to a maximum of 8 minions. Your minions are considered allies at your level.</p><p>You can manage up to two squads of minions. Newly summoned minions can either be organized into a new squad or be distributed into other squads under your control. A squad can't contain more than eight minions, and all minions in the squad must have the same name.</p><p>The maximum distance that you can summon minions and use specific conjuring abilities is called your Summoner's Range. Your Summoner's Range is equal to 5 + your Reason score. You must have line of effect to summon and give commands to minions within your Summoner's Range. Commanding a minion to take a main action or a maneuver while hidden reveals you.</p><p>You also have special minions at your disposal called signature minions, low-cost creatures that you've become accustomed to summoning often. See your Portfolio for more details about the types of minions you can summon.</p><h4>Minions in Combat</h4><p><strong>Start of Combat:</strong> At the start of a combat encounter or some other stressful situation tracked in combat rounds (as determined by the Director), you can summon up to two of your signature minions at no cost into unoccupied spaces within your Summoner's Range (no action required).</p><p><strong>Start of Turn:</strong> At the start of each of your turns during combat, you can summon up to three of your signature minions at no cost into unoccupied spaces within your Summoner's Range (no action required).</p><p><strong>Summoning:</strong> Each minion is summoned on the ground unless they can fly or hover. Unless an ability specifies, you can't summon any new minions beyond your minion maximum until the same number of existing minions are dismissed or destroyed.</p><p><strong>Stamina:</strong> Minions in a squad pool their Stamina together. Whenever a minion in a squad takes damage, the squad's Stamina pool is reduced by a number equal to the damage taken. Each time the pool is reduced by an amount equal to a single squad member's Stamina, one minion dies (starting with the minion that took damage, followed by the next nearest minion). If there is any excess damage after all minions in the squad are dead, you take damage equal to 2 + your level. Minions can't be winded, can't regain Stamina, and can't gain temporary Stamina.</p><p><strong>Area Effects:</strong> The damage from an area effect dealt to a squad's Stamina pool can only kill up to the minions in its area. Any excess damage is ignored.</p><p><strong>Strikes with Multiple Targets:</strong> A squad's Stamina pool only takes the largest single instance of damage from a strike that targets two or more minions in that squad. Any additional effects still affect the minions targeted by the strike.</p><p><strong>Conditions:</strong> You resolve any saving throws on conditions affecting one or more of your minions. Treat saving throws as if you had one instance of each condition.</p><p><strong>Damage Immunity and Weakness:</strong> If any minion in a squad has damage immunity or weakness to a particular damage type, apply that effect to the entire squad only once, regardless of how many minions share the same trait.</p><p><strong>Actions:</strong> Minions in a squad act together on your turn in any order, before, in-between, and/or after any of your actions. They can either take a move action and a main action (excluding Heal and Defend), a move action and a maneuver, or two move actions. Individual minions can also make opportunity attacks.</p><p><strong>Free Strikes:</strong> Unless otherwise specified, a minion's free strike has a distance of Melee 1 or Ranged 5 and deals the damage value listed on the stat block. The minion can choose to deal untyped damage or the damage type next to the damage value.</p><p><strong>Damage:</strong> Whenever multiple minions strike the same target simultaneously, the damage is added together and treated as a single strike. Minions in a squad targeting the same target with a signature ability only apply one instance of the signature ability while each additional minion increases the damage by a number equal to their free strike value.</p><p><strong>Surges:</strong> Your minions share your pool of surges and can apply them to their strikes. Whenever one or more of your minions would gain a surge during a turn, you gain that surge instead.</p><p><strong>Maneuvers:</strong> Unless otherwise specified on the minions' stat block, a squad uses their maneuver together as a unit. If a maneuver targets a single creature, all minions in the squad target the same creature. If a maneuver requires a power roll, the result is equal to 8 + the minions' characteristic + the number of squad members within distance of the maneuver.</p><p><strong>Individual Maneuvers:</strong> An individual minion can use a maneuver to alleviate their own circumstances, such as getting up from prone or escaping a grab. If they do, they can't take part in their squad's main action or maneuver.</p><p><strong>Characteristics:</strong> Your minions have their own characteristics for the purposes of resisting potencies, maneuvers, and making tests. You use your own characteristics where a minion's stat block refers to an R or uses a potency (such as M &lt; WEAK).</p><p><strong>Unconscious:</strong> If you are unconscious or unable to act on your turn, you can't summon new minions. Additionally, your remaining minions can't deal damage; they can only act to bring you to safety.</p><p><strong>End of Combat:</strong> At the end of combat, your minions finish their tasks (such as carrying someone to safety) and are then dismissed.</p><h4>Minions Outside of Combat</h4><p>While outside of combat, you can have up to 4 minions summoned without spending essence. You can freely summon your signature minions this way. For other minions, while you have a number of Victories equal to the minion's essence cost or more, you can summon up to the set number of minions listed on their stat block.</p><p>Each of your minions can be given a simple task and a destination you've previously visited and they'll fulfill it to the best of their ability. Example tasks include sending messages, scouting, and carrying supplies. Your minions aren't followers and can't make project rolls until you can summon specialists (see Minion Machinations).</p><p>When combat begins, any of your minions who were summoned outside of combat finish their tasks and are then dismissed.</p><aside class=\"boxed\"><h4>Soul-y Moley!</h4><p>Your minions are manifestations of the magic you weave and don't harbor any souls of their own. They are expressions of your own soul and are more akin to dreams than sapient creatures. </p><p>Treat your minions as if they had your soul whenever they are targeted by abilities that affect souls. Ignore any effects that trigger when a creature with a soul dies unless you're the one being targeted.</p></aside>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minions",
+    "advancements": {
+      "y5XJx1A571ii1mAP": {
+        "sort": 100000,
+        "name": "",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "y5XJx1A571ii1mAP",
+        "description": "",
+        "repick": {},
+        "pool": [],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      }
+    },
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 100000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586554515,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!M1nvpPDxewehEK0b"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_No_Matter_the_Cost_5ekZqcLufu9qjlIB.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_No_Matter_the_Cost_5ekZqcLufu9qjlIB.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "No Matter the Cost",
+  "type": "feature",
+  "_id": "5ekZqcLufu9qjlIB",
+  "img": "icons/magic/death/skull-pile-glowing-pink.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever you sacrifice minions, you now reduce the cost of a heroic ability or minion by the same amount (to a minimum of 1) instead of only reducing the cost by 1.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "no-matter-the-cost",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787702942643,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!5ekZqcLufu9qjlIB"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Return_to_the_Source_k4wWB8OMKPt6ImgP.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Return_to_the_Source_k4wWB8OMKPt6ImgP.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Return to the Source",
+  "type": "feature",
+  "_id": "k4wWB8OMKPt6ImgP",
+  "img": "icons/magic/time/arrows-circling-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can translate yourself and your allies into the space that your minions come from, as if summoning in reverse.</p><p>When you take a respite, you teleport to your circle's source manifold or point of origin, as shown on the Circle's Source Manifold table. You can bring along any allies to gather resources or research details about that location's denizens. You are seen as a native resident of the location, but your allies might be seen as intruders.</p><p>At the end of the respite, you and everyone you brought with you immediately teleports back into the same location from which you made the portal.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "return-to-the-source",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 75000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787698015983,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!k4wWB8OMKPt6ImgP"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Steward_of_Two_Worlds_j32fFgN0QCWcw8wH.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Steward_of_Two_Worlds_j32fFgN0QCWcw8wH.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Steward of Two Worlds",
+  "type": "feature",
+  "_id": "j32fFgN0QCWcw8wH",
+  "img": "icons/environment/cosmos/planet-moon-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You and your allies are now welcome in your circle's source manifold. Negotiations with native denizens of your circle's source manifold have their patience increased by 2.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "steward-of-two-worlds",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787701835185,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!j32fFgN0QCWcw8wH"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Summoner_s_Dominion_b18SPv6xoCkQ8B69.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Summoner_s_Dominion_b18SPv6xoCkQ8B69.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Summoner's Dominion",
+  "type": "feature",
+  "_id": "b18SPv6xoCkQ8B69",
+  "img": "icons/environment/settlement/fence-stone-brick.webp",
+  "system": {
+    "description": {
+      "value": "<p>Your circle allows you to call forth a piece of your portfolio's dominion like any minion.</p><p>Once per encounter, you can use a maneuver to summon a fixture from your minions' native manifold or origin into an unoccupied space on the ground within your Summoner's Range. You can spend 1 essence to relocate the fixture as a free maneuver on your turn. The fixture stays until the end of the encounter, until its Stamina is reduced to 0, or until you become dying.</p><p>Your fixture gains additional features at 5th and 9th level.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "summoners-dominion",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787602233003,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!b18SPv6xoCkQ8B69"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Summoner_s_Kit_9FF5MeuFsNEsTBMt.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Summoner_s_Kit_9FF5MeuFsNEsTBMt.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Summoner's Kit",
+  "type": "feature",
+  "_id": "9FF5MeuFsNEsTBMt",
+  "img": "icons/weapons/wands/wand-gem-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You conjure a kit for yourself. This kit includes an implement, such as a rod or a baton, which grants you the following benefits:</p><ul><li><p>The damage of your Summoner Strike ability increases to twice your Reason score.</p></li><li><p>The potency of your Summoner Strike ability increases to [[potency R AVERAGE]].</p></li><li><p>The distance of your Summoner Strike ability is now equal to your Summoner's Range ([[lookup 5+@R]]).</p></li></ul>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "summoners-kit",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604012292,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!9FF5MeuFsNEsTBMt"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Their_Life_for_Mine_SzorRJDyUw7Wp6gY.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Features_JSp1h7zHZJxUNPG9/feature_Their_Life_for_Mine_SzorRJDyUw7Wp6gY.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JSp1h7zHZJxUNPG9",
+  "name": "Their Life for Mine",
+  "type": "feature",
+  "_id": "SzorRJDyUw7Wp6gY",
+  "img": "icons/magic/life/heart-pink.webp",
+  "system": {
+    "description": {
+      "value": "<p>If you or an ally within your Summoner's Range would die from an effect that isn't age related, you sacrifice all your active minions (minimum 1) and spend all your essence (minimum 1) as a free triggered action to bring the target back to life, reconstructing the damaged parts of their body with summoned material related to your portfolio. The target comes back with 0 Stamina plus 1 Stamina for each minion and essence used in the effect. You must have at least one fragment of the creature's remains, and the creature's soul must be willing to return to life for the effect to work.</p><p>You can't use this feature again until you gain a new level, or until you spend 3 eidos to use it (see Eidos).</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "their-life-for-mine",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787701296883,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!SzorRJDyUw7Wp6gY"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Folder_Features_JSp1h7zHZJxUNPG9.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Folder_Features_JSp1h7zHZJxUNPG9.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "looxdjOWIKafFCDq",
+  "name": "Features",
+  "color": null,
+  "sorting": "a",
+  "_id": "JSp1h7zHZJxUNPG9",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586306962,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!JSp1h7zHZJxUNPG9"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Folder_Kits_rKKq8FzgF5mZWfnE.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Folder_Kits_rKKq8FzgF5mZWfnE.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "looxdjOWIKafFCDq",
+  "name": "Kits",
+  "color": null,
+  "sorting": "a",
+  "_id": "rKKq8FzgF5mZWfnE",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586323576,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!rKKq8FzgF5mZWfnE"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Folder_Subclasses_6Y13aMFGfU2d6Akf.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Folder_Subclasses_6Y13aMFGfU2d6Akf.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "looxdjOWIKafFCDq",
+  "name": "Subclasses",
+  "color": null,
+  "sorting": "a",
+  "_id": "6Y13aMFGfU2d6Akf",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787586317672,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!6Y13aMFGfU2d6Akf"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Conjured_Ward_Zd9UX2zuL2fpRh44.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Conjured_Ward_Zd9UX2zuL2fpRh44.json
@@ -1,0 +1,106 @@
+{
+  "folder": "rKKq8FzgF5mZWfnE",
+  "name": "Conjured Ward",
+  "type": "feature",
+  "_id": "Zd9UX2zuL2fpRh44",
+  "img": "icons/magic/defensive/shield-barrier-flaming-diamond-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You are clad in the natural defenses of your portfolio (bones, fairy wood, stone, writhing flesh). You gain a +3 bonus to Stamina and that bonus increases by 3 at 4th, 7th, and 10th levels.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "conjured-ward",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Stamina Bonus",
+      "img": "icons/magic/defensive/shield-barrier-flaming-diamond-blue.webp",
+      "type": "abilityModifier",
+      "origin": "Compendium.draw-steel.classes.Item.Zd9UX2zuL2fpRh44",
+      "_id": "O6DoKhSpUgE88ppC",
+      "system": {
+        "changes": [
+          {
+            "key": "system.stamina.bonuses.echelon",
+            "type": "add",
+            "value": 3,
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        },
+        "filters": {
+          "keywords": []
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787604295498,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!Zd9UX2zuL2fpRh44.O6DoKhSpUgE88ppC"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604275786,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!Zd9UX2zuL2fpRh44"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Emergency_Ward_WReW0HmGtiFCwN1j.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Emergency_Ward_WReW0HmGtiFCwN1j.json
@@ -1,0 +1,43 @@
+{
+  "folder": "rKKq8FzgF5mZWfnE",
+  "name": "Emergency Ward",
+  "type": "feature",
+  "_id": "WReW0HmGtiFCwN1j",
+  "img": "icons/magic/defensive/shield-barrier-flaming-diamond-red.webp",
+  "system": {
+    "description": {
+      "value": "<p>The first time each round you take damage, you can use a free triggered action to shift 1 after the triggering effect resolves and summon a signature minion into the square you left (as long as there is enough space).</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "emergency-ward",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604341187,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!WReW0HmGtiFCwN1j"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Howling_Ward_ZTr4xl77Wsm5ZoEe.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Howling_Ward_ZTr4xl77Wsm5ZoEe.json
@@ -1,0 +1,43 @@
+{
+  "folder": "rKKq8FzgF5mZWfnE",
+  "name": "Howling Ward",
+  "type": "feature",
+  "_id": "ZTr4xl77Wsm5ZoEe",
+  "img": "icons/magic/defensive/shield-barrier-flaming-pentagon-teal-purple.webp",
+  "system": {
+    "description": {
+      "value": "<p>You create a 1-aura vortex of slicing magic around you when you enter combat. An enemy that starts their turn adjacent to you takes [[/damage @R]]{damage equal to your Reason}.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "howling-ward",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604363685,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!ZTr4xl77Wsm5ZoEe"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Snare_Ward_1AcgDv7W1MAViZlF.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Kits_rKKq8FzgF5mZWfnE/feature_Snare_Ward_1AcgDv7W1MAViZlF.json
@@ -1,0 +1,43 @@
+{
+  "folder": "rKKq8FzgF5mZWfnE",
+  "name": "Snare Ward",
+  "type": "feature",
+  "_id": "1AcgDv7W1MAViZlF",
+  "img": "icons/magic/defensive/shield-barrier-flaming-pentagon-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever an adjacent creature deals damage to you, you can use a free triggered action to pull that creature toward one of your minions within your [[lookup 5+@R]]{Summoner's Range} a number of squares equal to your [[lookup @R]]{Reason score}.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "snare-ward",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787604413621,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!1AcgDv7W1MAViZlF"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Blight_6eXjS07IMWYzngpX.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Blight_6eXjS07IMWYzngpX.json
@@ -1,0 +1,177 @@
+{
+  "folder": "6Y13aMFGfU2d6Akf",
+  "name": "Circle of Blight",
+  "type": "subclass",
+  "_id": "6eXjS07IMWYzngpX",
+  "img": "icons/magic/unholy/hand-claw-glow-orange.webp",
+  "system": {
+    "description": {
+      "value": "<p>You are a demonologist who calls forth demons from the Abyssal Waste. Your portfolio includes shapechanging demons that grow in hunger and power over time. You can communicate with creatures that have the Abyssal keyword even if you don't share a language.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "circle-of-blight",
+    "advancements": {
+      "OwrVxEub9Tj6x1wS": {
+        "sort": 100000,
+        "name": "Death Snap",
+        "img": "icons/magic/unholy/strike-body-life-soul-purple.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "OwrVxEub9Tj6x1wS",
+        "description": "<p>Your Circle grants you the following feature:</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.9tFUdZyXM1rYC5zN"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "fHkRC6qziyDKfDe9": {
+        "sort": 200000,
+        "name": "Soulsense",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "fHkRC6qziyDKfDe9",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.5XLwLZFvdFV8HNha"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "HumrRhqlz9mwer1V": {
+        "sort": 300000,
+        "name": "Signature Minions",
+        "img": "systems/draw-steel/assets/roles/minion.webp",
+        "type": "summon",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "HumrRhqlz9mwer1V",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "cost": null,
+        "chooseN": 2,
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.summons.Actor.4gzlvFuzEdD0ErSd",
+            "count": 1
+          },
+          {
+            "uuid": "Compendium.draw-steel.summons.Actor.WiHk1bOLtubsWiZV",
+            "count": 1
+          },
+          {
+            "uuid": "Compendium.draw-steel.summons.Actor.QOYeoaKgoueyh7aA",
+            "count": 1
+          }
+        ],
+        "dsid": ""
+      },
+      "RPABOAk6UF2Py3H0": {
+        "sort": 400000,
+        "name": "The Boil",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 2
+        },
+        "_id": "RPABOAk6UF2Py3H0",
+        "description": "<p>The boil arises from the chaotic depths of the Abyssal Waste, concentrated into a heaving mass by the pressure of a coherent reality. As it slushes and threatens to burst, the noises drive nearby demons into a frenzy.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.V8cAcPRg1XoFejcO"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "9LUJ52YTdnGzGTyn": {
+        "sort": 500000,
+        "name": "3-Essence Minion",
+        "img": "systems/draw-steel/assets/roles/minion.webp",
+        "type": "summon",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "9LUJ52YTdnGzGTyn",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "cost": 3,
+        "chooseN": 2,
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.summons.Actor.eOKqqXeinZxZejEL",
+            "count": 2
+          },
+          {
+            "uuid": "Compendium.draw-steel.summons.Actor.HhzdAteFTVH4bJYS",
+            "count": 2
+          },
+          {
+            "uuid": "Compendium.draw-steel.summons.Actor.a9YKT6xoII95LRt3",
+            "count": 2
+          }
+        ],
+        "dsid": ""
+      }
+    },
+    "classLink": "summoner"
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587435343,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!6eXjS07IMWYzngpX"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Graves_7xWNgdvi2WCpnvvg.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Graves_7xWNgdvi2WCpnvvg.json
@@ -1,0 +1,86 @@
+{
+  "folder": "6Y13aMFGfU2d6Akf",
+  "name": "Circle of Graves",
+  "type": "subclass",
+  "_id": "7xWNgdvi2WCpnvvg",
+  "img": "icons/magic/death/hand-undead-skeleton-fire-pink.webp",
+  "system": {
+    "description": {
+      "value": "<p>You are a necromancer who raises undead creatures from the Necropolitan Ruin. The corporeal and incorporeal creatures under your command are hardy and many. You can communicate with creatures that have the Undead keyword even if you don't share a language.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "circle-of-graves",
+    "advancements": {
+      "ACU49m62n9HNbRLE": {
+        "sort": 100000,
+        "name": "Dead Men Tell All Tales",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "ACU49m62n9HNbRLE",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.25kP5GUvC2Upo8qT"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "BeG2YXP2BnxSBZXI": {
+        "sort": 200000,
+        "name": "Rise!",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "BeG2YXP2BnxSBZXI",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.XgMEJWhms54dEqKO"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      }
+    },
+    "classLink": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587451265,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!7xWNgdvi2WCpnvvg"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Spring_Bp7Oo96dW76P1C8t.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Spring_Bp7Oo96dW76P1C8t.json
@@ -1,0 +1,86 @@
+{
+  "folder": "6Y13aMFGfU2d6Akf",
+  "name": "Circle of Spring",
+  "type": "subclass",
+  "_id": "Bp7Oo96dW76P1C8t",
+  "img": "icons/magic/nature/root-vine-thorns-poison-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>You are a feybright who beckons pixies, nixies, and sprites from Arcadia. Your portfolio features ephemeral fey spirits surrounded by weird and powerful magic. You can communicate with creatures that have the Fey keyword even if you don't share a language.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "circle-of-spring",
+    "advancements": {
+      "TUmPeETyvYALhWeX": {
+        "sort": 100000,
+        "name": "Fairy Whispers",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "TUmPeETyvYALhWeX",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.qXQDlQErzIY7izNQ"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "JEOqoxNu0gSyeU0L": {
+        "sort": 200000,
+        "name": "Pixie Dust",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "JEOqoxNu0gSyeU0L",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.yV1cQbm41Y6kkVnL"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      }
+    },
+    "classLink": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587460150,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!Bp7Oo96dW76P1C8t"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Storms_IkbHP7jgzhoDiHBq.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/Subclasses_6Y13aMFGfU2d6Akf/subclass_Circle_of_Storms_IkbHP7jgzhoDiHBq.json
@@ -1,0 +1,86 @@
+{
+  "folder": "6Y13aMFGfU2d6Akf",
+  "name": "Circle of Storms",
+  "type": "subclass",
+  "_id": "IkbHP7jgzhoDiHBq",
+  "img": "icons/magic/lightning/projectile-orb-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You are a storm caster who summons elementals from Quintessence. This portfolio contains forces of nature that leave a big impact on the environment. You can communicate with creatures that have the Elemental keyword even if you don't share a language.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "circle-of-storms",
+    "advancements": {
+      "Q3WOKFg4XKXG5CE2": {
+        "sort": 100000,
+        "name": "Elemental Affinity",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "Q3WOKFg4XKXG5CE2",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.isQ1maSZjrX3r50h"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "x3ipQmsNd8pCZubg": {
+        "sort": 200000,
+        "name": "Heart of Nature",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "x3ipQmsNd8pCZubg",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.QhlmpOp9XKcgNvCV"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      }
+    },
+    "classLink": ""
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787587468910,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!IkbHP7jgzhoDiHBq"
+}

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/class_Summoner_JN8lWhy6NeojQhgk.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/class_Summoner_JN8lWhy6NeojQhgk.json
@@ -313,7 +313,7 @@
       "ibwO4F16OZxw2SKs": {
         "sort": 756000,
         "name": "5 Essence Ability",
-        "img": "icons/magic/symbols/runes-star-magenta.webp",
+        "img": "icons/magic/lightning/barrier-wall-shield-gray.webp",
         "type": "itemGrant",
         "requirements": {
           "level": 1
@@ -784,7 +784,7 @@
       },
       "afQLML5GeKnEtkqf": {
         "sort": 2556000,
-        "name": "Essence Salvage",
+        "name": "Font of Creation",
         "img": null,
         "type": "itemGrant",
         "requirements": {
@@ -792,7 +792,9 @@
         },
         "_id": "afQLML5GeKnEtkqf",
         "description": "",
-        "repick": {},
+        "repick": {
+          "respite": ""
+        },
         "pool": [
           {
             "uuid": "Compendium.draw-steel.classes.Item.5phy7YJFwhNNy0I3"
@@ -931,7 +933,7 @@
       },
       "EJPColUipgddh1M1": {
         "sort": 3156000,
-        "name": "11-Essence Feature",
+        "name": "11-Essence Ability",
         "img": "icons/magic/lightning/bolts-forked-large-blue.webp",
         "type": "itemGrant",
         "requirements": {
@@ -1115,6 +1117,29 @@
         "skills": {
           "groups": [],
           "choices": []
+        }
+      },
+      "k1jIrPznvbxNldW8": {
+        "sort": 3856000,
+        "name": "Steward of Two Worlds",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 9
+        },
+        "_id": "k1jIrPznvbxNldW8",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.j32fFgN0QCWcw8wH"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
         }
       }
     },

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/class_Summoner_JN8lWhy6NeojQhgk.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/class_Summoner_JN8lWhy6NeojQhgk.json
@@ -539,7 +539,7 @@
         }
       },
       "mRlnqNkT7VSVqb4V": {
-        "sort": 1456000,
+        "sort": 1656000,
         "name": "Minion Chain",
         "img": null,
         "type": "itemGrant",
@@ -584,6 +584,537 @@
           "type": "",
           "perkType": [],
           "cost": null
+        }
+      },
+      "vQysxPB087tNNE1G": {
+        "sort": 1756000,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 4
+        },
+        "_id": "vQysxPB087tNNE1G",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [],
+        "chooseN": 1,
+        "additional": {
+          "type": "perk",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "ganKjiVEPkZ1JDbp": {
+        "sort": 1856000,
+        "name": "",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 4
+        },
+        "_id": "ganKjiVEPkZ1JDbp",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "chooseN": 1,
+        "skills": {
+          "groups": [],
+          "choices": []
+        }
+      },
+      "twH0wONCJQIbkojx": {
+        "sort": 1956000,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 6
+        },
+        "_id": "twH0wONCJQIbkojx",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [],
+        "chooseN": null,
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "interpersonal",
+            "lore",
+            "supernatural"
+          ],
+          "cost": null
+        }
+      },
+      "5BgkxJ1cQjPT1ua3": {
+        "sort": 2056000,
+        "name": "Return to the Source",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 6
+        },
+        "_id": "5BgkxJ1cQjPT1ua3",
+        "description": "<p>You gain a feature</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.k4wWB8OMKPt6ImgP"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "KxNfF0SgWZRw7OUM": {
+        "sort": 2156000,
+        "name": "Minion Machinations",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 6
+        },
+        "_id": "KxNfF0SgWZRw7OUM",
+        "description": "<p>You gain a feature</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.Y8DMj8KKnZ3E5jgY"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "vYq1S6qlD0pFf3jF": {
+        "sort": 2256000,
+        "name": "Summoner's Kit - New Ward",
+        "img": "icons/magic/defensive/shield-barrier-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 6
+        },
+        "_id": "vYq1S6qlD0pFf3jF",
+        "description": "<p>You can choose an additional ward for your Summoner's Kit.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.Zd9UX2zuL2fpRh44"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.WReW0HmGtiFCwN1j"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.ZTr4xl77Wsm5ZoEe"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.1AcgDv7W1MAViZlF"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "OrTSXCvuDQN8jOZv": {
+        "sort": 2356000,
+        "name": "",
+        "img": null,
+        "type": "characteristic",
+        "requirements": {
+          "level": 7
+        },
+        "_id": "OrTSXCvuDQN8jOZv",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "characteristics": {
+          "might": 1,
+          "agility": 1,
+          "reason": 1,
+          "intuition": 1,
+          "presence": 1
+        },
+        "max": 4
+      },
+      "guvLPkxJT5Fmdqvi": {
+        "sort": 2456000,
+        "name": "Minion Improvement II",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 7
+        },
+        "_id": "guvLPkxJT5Fmdqvi",
+        "description": "<p>Your minions improve.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.fuMT5jy0UM8lUMfM"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "afQLML5GeKnEtkqf": {
+        "sort": 2556000,
+        "name": "Essence Salvage",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 7
+        },
+        "_id": "afQLML5GeKnEtkqf",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.5phy7YJFwhNNy0I3"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "84LMOkJsodBP1xYQ": {
+        "sort": 2656000,
+        "name": "Their Life for Mine",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 7
+        },
+        "_id": "84LMOkJsodBP1xYQ",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.SzorRJDyUw7Wp6gY"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "hAw14an7a0ZtBvUQ": {
+        "sort": 2756000,
+        "name": "",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 7
+        },
+        "_id": "hAw14an7a0ZtBvUQ",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "chooseN": 1,
+        "skills": {
+          "groups": [],
+          "choices": []
+        }
+      },
+      "FpnXIWEsp7X3nqnS": {
+        "sort": 2856000,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 8
+        },
+        "_id": "FpnXIWEsp7X3nqnS",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [],
+        "chooseN": 1,
+        "additional": {
+          "type": "perk",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "T2tHaWyaxDQ6bNGk": {
+        "sort": 2956000,
+        "name": "Kit Improvement - Level 9",
+        "img": "icons/weapons/wands/wand-gem-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 9
+        },
+        "_id": "T2tHaWyaxDQ6bNGk",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.DpFcT8Qz2ekoSBFP"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "G6AQjbQ2aKNERnzb": {
+        "sort": 3056000,
+        "name": "Summoner's Kit - New Ward",
+        "img": "icons/magic/defensive/shield-barrier-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 9
+        },
+        "_id": "G6AQjbQ2aKNERnzb",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.Zd9UX2zuL2fpRh44"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.WReW0HmGtiFCwN1j"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.ZTr4xl77Wsm5ZoEe"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.1AcgDv7W1MAViZlF"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "EJPColUipgddh1M1": {
+        "sort": 3156000,
+        "name": "11-Essence Feature",
+        "img": "icons/magic/lightning/bolts-forked-large-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 9
+        },
+        "_id": "EJPColUipgddh1M1",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.0FPo2KsO0J1rhApj"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.NzzLb4acXXv2N7vt"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.knNxGM7E5zeQB6UU"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.kmBykCfbj4cFxJFO"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "0hJk6RnzMncsuk1B": {
+        "sort": 3256000,
+        "name": "9-Essence Ability",
+        "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 6
+        },
+        "_id": "0hJk6RnzMncsuk1B",
+        "description": "<p>You can summon the assistance of your future champion (see Portfolio Champion) and allow them to show off a brief display of their power. Select one of the following heroic abilities.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.qhNa8pGpVyxdObOH"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.1gAOmN6RR3mpPCmA"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.Jp3p68JwTNAiLsUB"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.IaVte8boP37MRubS"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "dheumpCn9zv5MtHs": {
+        "sort": 3356000,
+        "name": "",
+        "img": null,
+        "type": "characteristic",
+        "requirements": {
+          "level": 10
+        },
+        "_id": "dheumpCn9zv5MtHs",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "characteristics": {
+          "might": 0,
+          "agility": 0,
+          "reason": 1,
+          "intuition": 0,
+          "presence": 0
+        },
+        "max": 5
+      },
+      "41GzKs6EaMcWjnuu": {
+        "sort": 3456000,
+        "name": "Minion Improvement III",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 10
+        },
+        "_id": "41GzKs6EaMcWjnuu",
+        "description": "<p>Your minions improve.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.cIlXEK8zpRuf6PMM"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "srYApcc5rpX8GDRF": {
+        "sort": 3556000,
+        "name": "Features",
+        "img": "icons/magic/symbols/runes-triangle-magenta.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 10
+        },
+        "_id": "srYApcc5rpX8GDRF",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.QzC2N2P8GY42uXFi"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.5ekZqcLufu9qjlIB"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.Ol3Ucb5Uh9mXXUOo"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "1DadwRPHC0KKUJa0": {
+        "sort": 3656000,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 10
+        },
+        "_id": "1DadwRPHC0KKUJa0",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [],
+        "chooseN": 1,
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "interpersonal",
+            "intrigue",
+            "supernatural"
+          ],
+          "cost": null
+        }
+      },
+      "Zhy4hopewCzTHGVj": {
+        "sort": 3756000,
+        "name": "",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 10
+        },
+        "_id": "Zhy4hopewCzTHGVj",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "chooseN": 1,
+        "skills": {
+          "groups": [],
+          "choices": []
         }
       }
     },

--- a/src/packs/classes/Summoner_looxdjOWIKafFCDq/class_Summoner_JN8lWhy6NeojQhgk.json
+++ b/src/packs/classes/Summoner_looxdjOWIKafFCDq/class_Summoner_JN8lWhy6NeojQhgk.json
@@ -1,0 +1,624 @@
+{
+  "folder": "looxdjOWIKafFCDq",
+  "name": "Summoner",
+  "type": "class",
+  "_id": "JN8lWhy6NeojQhgk",
+  "img": "icons/magic/movement/portal-vortex-orange.webp",
+  "system": {
+    "description": {
+      "value": "<p>You are the armada. The kings of old would trade armies for your abilities. You've undertaken the tradition that conjures an endless supply of warriors. You are the summoner, the mage who takes their dreams and makes them manifest. </p><p>You call forth minions to trudge fearlessly into the fray and provide support, holding the enemy at bay while you and your fellow heroes ready the counteroffensive. Your minions serve unflinchingly, unerringly, to their death or to yours. </p><p>You can also take advantage of powerful magic to buff your allies, whittle down your enemies, or enlist the fallen into your ranks. And when push comes to shove, you can call upon your champion to finish the fight.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "summoner",
+    "advancements": {
+      "s50tsGiYpsBA03es": {
+        "sort": -94000,
+        "name": "",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "s50tsGiYpsBA03es",
+        "description": "<p>You gain the Magic and Strategy skills.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "chooseN": null,
+        "skills": {
+          "groups": [],
+          "choices": [
+            "magic",
+            "strategy"
+          ]
+        }
+      },
+      "S8bFbwuZpdmvsVDL": {
+        "sort": -44000,
+        "name": "Skills",
+        "img": null,
+        "type": "skill",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "S8bFbwuZpdmvsVDL",
+        "description": "<p>Choose any two skills from the intrigue or lore skill groups. (<em>Quick Build:</em> Eavesdrop, Monsters)</p>",
+        "repick": {
+          "respite": ""
+        },
+        "chooseN": 2,
+        "skills": {
+          "groups": [
+            "intrigue",
+            "lore"
+          ],
+          "choices": []
+        }
+      },
+      "9IxqMCUuQwNNO6ro": {
+        "sort": 56000,
+        "name": "Minions",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "9IxqMCUuQwNNO6ro",
+        "description": "<p>The creatures you control are called minions. You can summon and maintain up to a maximum of 8 minions. Your minions are considered allies at your level.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.M1nvpPDxewehEK0b"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "lMjNrI6KVscYbKO0": {
+        "sort": 156000,
+        "name": "Essence",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "lMjNrI6KVscYbKO0",
+        "description": "<p>You and your minions have a unique reserve of essence as your Heroic Resource. You use this magic to sculpt your forces and maintain control over the battlefield.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.bpmpevbhJM9m3dS6"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "cbiRXGzvpwDD5ZTa": {
+        "sort": 256000,
+        "name": "Summoner Circle",
+        "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "cbiRXGzvpwDD5ZTa",
+        "description": "<p>You've learned the art of summoning from a member of a loose network of summoners called a circle. Each circle specializes in a distinct portfolio of creatures you can call into existence. Choose a summoner circle from the following options, each of which grants you a communication feature (<em>Quick Build</em>: Circle of Graves.)</p><p>Your choice of circle decides the portfolio from which you summon minions, as well as many of the features you'll gain from this class. Your circle is your subclass.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.6eXjS07IMWYzngpX"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.7xWNgdvi2WCpnvvg"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.Bp7Oo96dW76P1C8t"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.IkbHP7jgzhoDiHBq"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "EkiMeKfLQEypwKR3": {
+        "sort": 356000,
+        "name": "Summoner Strike",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "EkiMeKfLQEypwKR3",
+        "description": "<p>You have the following ability, which replaces both your melee and ranged free strikes.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.9wYvFs6YIWgsFepg"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "LKb4vmPEiJ7tz5CJ": {
+        "sort": 456000,
+        "name": "Strike For Me",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "LKb4vmPEiJ7tz5CJ",
+        "description": "<p>You have the following free triggered action.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.WAzv6xku3g4d4WBj"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "d7HL7Be4tE0n8cGh": {
+        "sort": 556000,
+        "name": "Formation",
+        "img": "icons/skills/melee/spear-tips-quintuple-orange.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "d7HL7Be4tE0n8cGh",
+        "description": "<p>You've practiced a specific formation for your minions. Choose one of the following formations: horde, platoon, elite, or leader. You can change your formation along with your quick command (see Quick Command) by performing intense study as a respite activity. (<em>Quick Build</em>: Platoon Formation.)</p>",
+        "repick": {
+          "respite": "activity"
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.MJzpVrjJyRII6T9o"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.y08lJF0egFWBGvLr"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.RRCS6CjABw12BEDA"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.avYIowv4d5i2h3Uy"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "w8iBHA0fpDLYtvjb": {
+        "sort": 656000,
+        "name": "Quick Command",
+        "img": "icons/skills/melee/unarmed-punch-fist.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "w8iBHA0fpDLYtvjb",
+        "description": "<p>You have a special command you can issue to your minions. Choose one of the following quick commands. You can change your quick command along with your formation (see Formation) by performing intense study as a respite activity. (<em>Quick Build:</em> Shield!)</p>",
+        "repick": {
+          "respite": "activity"
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.K6TaJ3C98yjmeA3d"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.0LjJ5YWxuC1qJTII"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.fzcUwf43Mq6ezXmp"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.XbbJ3rqIJt4Rt9d2"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "1le5KwDLt8qtE3SI": {
+        "sort": 506000,
+        "name": "Call Forth",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "1le5KwDLt8qtE3SI",
+        "description": "<p>You have the following ability.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.czHTOVQ7Xi9WReqK"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "m829rzlEbye1vz0k": {
+        "sort": 531000,
+        "name": "Minion Bridge",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "m829rzlEbye1vz0k",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.vKzCZPA68o2CA2VB"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "ibwO4F16OZxw2SKs": {
+        "sort": 756000,
+        "name": "5 Essence Ability",
+        "img": "icons/magic/symbols/runes-star-magenta.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 1
+        },
+        "_id": "ibwO4F16OZxw2SKs",
+        "description": "<p>Choose one heroic ability from the following options, each of which costs 5 essence to use. (Quick Build: <em>Rallying Cry.</em>)</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.iC4Fu7TxWbMZK3Zx"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.JRQwfgHgfYZzPtgv"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.09Tz5XBzvI2uNUKb"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.vDb2t7duOcIl1w9R"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.17F57a0z1uONFLbj"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.yzp3J1MPcRLogYjI"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "T6NiNGVcFwxc5gBa": {
+        "sort": 856000,
+        "name": "Perk",
+        "img": "icons/magic/symbols/fleur-de-lis-yellow.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 2
+        },
+        "_id": "T6NiNGVcFwxc5gBa",
+        "description": "<p>You gain an intrigue, lore, or supernatural perk of your choice.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [],
+        "chooseN": 1,
+        "additional": {
+          "type": "perk",
+          "perkType": [
+            "intrigue",
+            "lore",
+            "supernatural"
+          ],
+          "cost": null
+        }
+      },
+      "Tj4qKXdISFxILwl3": {
+        "sort": 956000,
+        "name": "Summoner's Dominion",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 2
+        },
+        "_id": "Tj4qKXdISFxILwl3",
+        "description": "",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.b18SPv6xoCkQ8B69"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "mcHSfQTpt2q88qQ9": {
+        "sort": 1056000,
+        "name": "Summoner Kit - Ward",
+        "img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 3
+        },
+        "_id": "mcHSfQTpt2q88qQ9",
+        "description": "<p>You conjure a kit for yourself. This kit includes an implement, such as a rod or a baton</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.Zd9UX2zuL2fpRh44"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.WReW0HmGtiFCwN1j"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.ZTr4xl77Wsm5ZoEe"
+          },
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.1AcgDv7W1MAViZlF"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "Ir8FLJZO8fOIrnas": {
+        "sort": 956000,
+        "name": "Summoner's Kit",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 3
+        },
+        "_id": "Ir8FLJZO8fOIrnas",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.9FF5MeuFsNEsTBMt"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "ryybASiis69WGfwE": {
+        "sort": 1156000,
+        "name": "7-Essence Ability",
+        "img": "icons/magic/lightning/bolt-forked-large-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 3
+        },
+        "_id": "ryybASiis69WGfwE",
+        "description": "<p>Choose one heroic ability from the following options, each of which costs 7 essence to use.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.EyAlK3DH58yu8oGM"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.WDmcLwlvdCYQ0PeJ"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.mmE5hWF4wBr7hZOK"
+          },
+          {
+            "uuid": "Compendium.draw-steel.abilities.Item.Jhx5LrSQSgqT4SV5"
+          }
+        ],
+        "chooseN": 1,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "11a6uJgsqKdQZUi6": {
+        "sort": 1256000,
+        "name": "",
+        "img": null,
+        "type": "characteristic",
+        "requirements": {
+          "level": 4
+        },
+        "_id": "11a6uJgsqKdQZUi6",
+        "description": "<p>Your Reason score becomes 3. Additionally, you can increase one of your characteristic scores by 1, to a maximum score of 3.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "characteristics": {
+          "might": 0,
+          "agility": 0,
+          "reason": 1,
+          "intuition": 0,
+          "presence": 0
+        },
+        "max": 3
+      },
+      "73MVaFIa2zMbJOfV": {
+        "sort": 1356000,
+        "name": "Minion Improvement",
+        "img": "icons/magic/control/energy-stream-link-blue.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 4
+        },
+        "_id": "73MVaFIa2zMbJOfV",
+        "description": "<p>Your minions grow stronger</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.g4rRmUDlo68usfif"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "mRlnqNkT7VSVqb4V": {
+        "sort": 1456000,
+        "name": "Minion Chain",
+        "img": null,
+        "type": "itemGrant",
+        "requirements": {
+          "level": 4
+        },
+        "_id": "mRlnqNkT7VSVqb4V",
+        "description": "",
+        "repick": {},
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.XhbUQ3YuC5166bS6"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      },
+      "OttVX7Po1hx4Nuwr": {
+        "sort": 1556000,
+        "name": "Essence Salvage",
+        "img": "icons/magic/symbols/runes-star-magenta.webp",
+        "type": "itemGrant",
+        "requirements": {
+          "level": 4
+        },
+        "_id": "OttVX7Po1hx4Nuwr",
+        "description": "<p>The first time each combat round that any minion unwillingly dies within your Summoner's Range, you gain 2 essence instead of 1.</p>",
+        "repick": {
+          "respite": ""
+        },
+        "pool": [
+          {
+            "uuid": "Compendium.draw-steel.classes.Item.d3ulV2Amw6cT3UiX"
+          }
+        ],
+        "chooseN": null,
+        "additional": {
+          "type": "",
+          "perkType": [],
+          "cost": null
+        }
+      }
+    },
+    "level": 0,
+    "primary": "Essence",
+    "epic": "Eidos",
+    "turnGain": "2",
+    "minimum": "0",
+    "characteristics": {
+      "core": [
+        "reason"
+      ]
+    },
+    "stamina": {
+      "starting": 15,
+      "level": 6
+    },
+    "recoveries": 8
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787584441355,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!JN8lWhy6NeojQhgk"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/3_Essence_Minions_grTBqFuzUL7VN4Ju/npc_Archer_Spittlich_eOKqqXeinZxZejEL.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/3_Essence_Minions_grTBqFuzUL7VN4Ju/npc_Archer_Spittlich_eOKqqXeinZxZejEL.json
@@ -1,0 +1,352 @@
+{
+  "folder": "grTBqFuzUL7VN4Ju",
+  "name": "Archer Spittlich",
+  "type": "npc",
+  "_id": "eOKqqXeinZxZejEL",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 5,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "S"
+      },
+      "stability": 2,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>These minor demons resemble larger pitlings. They can spit a nerve-numbing phlegm at long distance that makes it easy to catch their next meal.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 0
+      },
+      "agility": {
+        "value": 2
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": 0
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "14",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 5,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "artillery",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Archer Spittlich",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Splash Strike",
+      "type": "feature",
+      "_id": "ZBpLQG6JQSr7Uh1X",
+      "img": "icons/magic/acid/projectile-bolts-salvo-green.webp",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s ranged free strikes have a distance of 10 and deal 2 poison damage to an enemy adjacent to the target. Creatures that take poison damage from this [[lookup @name]] can't shift until the start of the [[lookup @name]]'s next turn.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731277,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!eOKqqXeinZxZejEL.ZBpLQG6JQSr7Uh1X"
+    },
+    {
+      "name": "Poison Free Strikes",
+      "type": "feature",
+      "_id": "xxpvEdqJkB4YNJyq",
+      "img": "icons/magic/acid/dissolve-pool-bubbles.webp",
+      "system": {
+        "description": {
+          "value": "<p>You can choose for this creature's free strikes to deal poison damage.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731277,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!eOKqqXeinZxZejEL.xxpvEdqJkB4YNJyq"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.4gzlvFuzEdD0ErSd.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731277
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!eOKqqXeinZxZejEL.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 100000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731277,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!eOKqqXeinZxZejEL"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/3_Essence_Minions_grTBqFuzUL7VN4Ju/npc_Fanged_Musilex_HhzdAteFTVH4bJYS.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/3_Essence_Minions_grTBqFuzUL7VN4Ju/npc_Fanged_Musilex_HhzdAteFTVH4bJYS.json
@@ -1,0 +1,308 @@
+{
+  "folder": "grTBqFuzUL7VN4Ju",
+  "name": "Fanged Musilex",
+  "type": "npc",
+  "_id": "HhzdAteFTVH4bJYS",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 6,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "L"
+      },
+      "stability": 1,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>Ensnarers knot and twist their bodies together to form heaving, heavy musilexes. They're compelled to drag everything in toward their body.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 6,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 2
+      },
+      "agility": {
+        "value": 1
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": 0
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "14",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 5,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "brute",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Fanged Musilex",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Mawful Strike",
+      "type": "feature",
+      "_id": "XlIfAqCYR0lbHpl8",
+      "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s melee free strikes have a distance of 2 + (your R) and inflict pull 2. The pull distance increases by 2 for each additional [[lookup @name]] striking the same target. Choose the [[lookup @name]] that the target is being pulled to before applying forced movement. If the target is pulled adjacent to the [[lookup @name]], the [[lookup @name]] either deals an additional [[/damage 2]] or [[/apply grabbed]]{grabs them}.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731262,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!HhzdAteFTVH4bJYS.XlIfAqCYR0lbHpl8"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.4gzlvFuzEdD0ErSd.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731262
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!HhzdAteFTVH4bJYS.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731262,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!HhzdAteFTVH4bJYS"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/3_Essence_Minions_grTBqFuzUL7VN4Ju/npc_Twisted_Bengrul_a9YKT6xoII95LRt3.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/3_Essence_Minions_grTBqFuzUL7VN4Ju/npc_Twisted_Bengrul_a9YKT6xoII95LRt3.json
@@ -1,0 +1,567 @@
+{
+  "folder": "grTBqFuzUL7VN4Ju",
+  "name": "Twisted Bengrul",
+  "type": "npc",
+  "_id": "a9YKT6xoII95LRt3",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 5,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "L"
+      },
+      "stability": 1,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>The bengrul is an undulating heap of glass and flesh. They shatter pieces of themselves to disrupt senses and inflict grisly wounds on their prey.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 2
+      },
+      "agility": {
+        "value": 1
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": 0
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "14",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 4,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "hexer",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Twisted Bengrul",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.eOKqqXeinZxZejEL.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731276
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!a9YKT6xoII95LRt3.6J9lMMqHMOR8zWyO"
+    },
+    {
+      "name": "Psychic Free Strikes",
+      "type": "feature",
+      "_id": "xxpvEdqJkB4YNJyq",
+      "img": "icons/magic/perception/orb-crystal-ball-scrying-blue.webp",
+      "system": {
+        "description": {
+          "value": "<p>You can choose for this creature's free strikes to deal psychic damage.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "poison-free-strikes",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731276,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.eOKqqXeinZxZejEL.Item.xxpvEdqJkB4YNJyq",
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!a9YKT6xoII95LRt3.xxpvEdqJkB4YNJyq"
+    },
+    {
+      "name": "Mind Twist",
+      "type": "ability",
+      "system": {
+        "type": "main",
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        },
+        "story": "",
+        "keywords": [
+          "magic",
+          "ranged",
+          "strike"
+        ],
+        "category": "signature",
+        "resource": null,
+        "trigger": "",
+        "distance": {
+          "type": "ranged",
+          "primary": "5",
+          "secondary": "1",
+          "tertiary": "1"
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "creatureObject",
+          "custom": "One creature or object per minion",
+          "value": null
+        },
+        "power": {
+          "roll": {
+            "reactive": false,
+            "formula": "@chr",
+            "characteristics": []
+          },
+          "effects": {
+            "ajEO3s5jsbT0RCmm": {
+              "sort": 100000,
+              "name": "",
+              "img": null,
+              "type": "damage",
+              "_id": "ajEO3s5jsbT0RCmm",
+              "damage": {
+                "tier1": {
+                  "value": "4",
+                  "types": [],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "value": "6",
+                  "types": [],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "value": "8",
+                  "types": [],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            },
+            "WQoMuRxmq6TLyPQh": {
+              "sort": 200000,
+              "name": "",
+              "img": null,
+              "type": "applied",
+              "_id": "WQoMuRxmq6TLyPQh",
+              "applied": {
+                "tier1": {
+                  "display": "[[op P weak]] twisted (save ends)",
+                  "effects": {
+                    "08nHHtTl3taQyDsj": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "save"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "display": "[[op P average]] twisted (save ends)",
+                  "effects": {},
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "display": "[[op P average]] twisted (save ends)",
+                  "effects": {},
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            }
+          }
+        },
+        "effects": {
+          "after00000000000": {
+            "_id": "after00000000000",
+            "type": "base",
+            "description": "<p>A twisted target can't take advantage of edges or search for hidden creatures until the condition ends.</p>",
+            "name": "",
+            "img": null,
+            "sort": 0,
+            "before": false
+          }
+        }
+      },
+      "_id": "PWGpHKzAFsasZr9P",
+      "img": "icons/svg/item-bag.svg",
+      "effects": [
+        {
+          "name": "Twisted",
+          "img": "icons/svg/item-bag.svg",
+          "origin": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.a9YKT6xoII95LRt3.Item.PWGpHKzAFsasZr9P",
+          "transfer": true,
+          "_id": "08nHHtTl3taQyDsj",
+          "type": "base",
+          "system": {
+            "changes": [],
+            "end": {
+              "roll": "1d10 + @combat.save.bonus"
+            },
+            "project": {
+              "prerequisites": "",
+              "source": "",
+              "rollCharacteristic": [],
+              "yield": {
+                "kind": "weapon",
+                "amount": "1",
+                "display": ""
+              }
+            }
+          },
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>A twisted target can't take advantage of edges or search for hidden creatures until the condition ends.</p>",
+          "tint": "#ffffff",
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "coreVersion": "14.367",
+            "systemId": "draw-steel",
+            "systemVersion": "1.2",
+            "createdTime": 1787599731276,
+            "modifiedTime": 1787599731276,
+            "lastModifiedBy": null,
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "exportSource": null
+          },
+          "_key": "!actors.items.effects!a9YKT6xoII95LRt3.PWGpHKzAFsasZr9P.08nHHtTl3taQyDsj"
+        },
+        {
+          "name": "Active Effect",
+          "img": "icons/svg/item-bag.svg",
+          "origin": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.a9YKT6xoII95LRt3.Item.PWGpHKzAFsasZr9P",
+          "transfer": false,
+          "_id": "PjB4ZfB87JJBgmdh",
+          "type": "base",
+          "system": {
+            "changes": [],
+            "end": {
+              "roll": "1d10 + @combat.save.bonus"
+            },
+            "project": {
+              "prerequisites": "",
+              "source": "",
+              "rollCharacteristic": [],
+              "yield": {
+                "kind": "weapon",
+                "amount": "1",
+                "display": ""
+              }
+            }
+          },
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "coreVersion": "14.367",
+            "systemId": "draw-steel",
+            "systemVersion": "1.2",
+            "createdTime": 1787599731276,
+            "modifiedTime": 1787599731276,
+            "lastModifiedBy": null,
+            "compendiumSource": null,
+            "duplicateSource": null,
+            "exportSource": null
+          },
+          "_key": "!actors.items.effects!a9YKT6xoII95LRt3.PWGpHKzAFsasZr9P.PjB4ZfB87JJBgmdh"
+        }
+      ],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731276,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!a9YKT6xoII95LRt3.PWGpHKzAFsasZr9P"
+    }
+  ],
+  "effects": [],
+  "sort": 300000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731276,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!a9YKT6xoII95LRt3"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/5_Essence_Minions_FaI2zUvxgzWIrwze/npc_Gushing_Spewler_2zP3SJlyV58JzUt8.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/5_Essence_Minions_FaI2zUvxgzWIrwze/npc_Gushing_Spewler_2zP3SJlyV58JzUt8.json
@@ -1,0 +1,396 @@
+{
+  "folder": "FaI2zUvxgzWIrwze",
+  "name": "Gushing Spewler",
+  "type": "npc",
+  "_id": "2zP3SJlyV58JzUt8",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 4,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "M"
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>A spewler's mouth makes up most of its size. They unleash torrents of acid and bile from their pitless stomachs before consuming their prey with bag-like maws.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": -2
+      },
+      "agility": {
+        "value": -1
+      },
+      "reason": {
+        "value": 0
+      },
+      "intuition": {
+        "value": 3
+      },
+      "presence": {
+        "value": 3
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "28",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 3,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "controller",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Gushing Spewler",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Acid Free Strikes",
+      "type": "feature",
+      "_id": "xxpvEdqJkB4YNJyq",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>You can choose for this creature's free strikes to deal acid damage.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "poison-free-strikes",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731257,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.eOKqqXeinZxZejEL.Item.xxpvEdqJkB4YNJyq",
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!2zP3SJlyV58JzUt8.xxpvEdqJkB4YNJyq"
+    },
+    {
+      "name": "Gushing Strike",
+      "type": "feature",
+      "_id": "gxruRC8QmqWz1SbV",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s ranged free strikes have a distance of 10 and slides the target (your R) + 2 squares.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731257,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!2zP3SJlyV58JzUt8.gxruRC8QmqWz1SbV"
+    },
+    {
+      "name": "Spew Slide",
+      "type": "feature",
+      "_id": "SoY8nWxJx5rJsA1s",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>Each time the [[lookup @name]] takes damage, the [[lookup @name]] shifts 2 after all effects resolve. Each square they exit during this movement is covered in slime until the end of the encounter. An enemy has a bane on strikes while occupying a slimed square.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731257,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!2zP3SJlyV58JzUt8.SoY8nWxJx5rJsA1s"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.eOKqqXeinZxZejEL.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731257
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!2zP3SJlyV58JzUt8.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731257,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!2zP3SJlyV58JzUt8"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/5_Essence_Minions_FaI2zUvxgzWIrwze/npc_Hulking_Chimor_mf0fAIHSRlkZzCCT.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/5_Essence_Minions_FaI2zUvxgzWIrwze/npc_Hulking_Chimor_mf0fAIHSRlkZzCCT.json
@@ -1,0 +1,352 @@
+{
+  "folder": "FaI2zUvxgzWIrwze",
+  "name": "Hulking Chimor",
+  "type": "npc",
+  "_id": "mf0fAIHSRlkZzCCT",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 7,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 2,
+        "letter": "M"
+      },
+      "stability": 3,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>Chimors have no true shape; their bodies restructure and change endlessly. Pieces of the chimor demon snap off inside their prey, causing their bodies to also restructure from the inside out.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 3
+      },
+      "agility": {
+        "value": 0
+      },
+      "reason": {
+        "value": 2
+      },
+      "intuition": {
+        "value": 1
+      },
+      "presence": {
+        "value": 1
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "28",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 3,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "defender",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Hulking Chimor",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 2,
+    "height": 2,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Mercurial Strike",
+      "type": "feature",
+      "_id": "K1Et80pwH6tZrbaW",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s melee free strikes inflict [[op M weak]] [[/apply weakened turn]]. The potency is increased by the current round number.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731285,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!mf0fAIHSRlkZzCCT.K1Et80pwH6tZrbaW"
+    },
+    {
+      "name": "Evershifting",
+      "type": "feature",
+      "_id": "lGg2dgS0oefuPJuS",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]] doesn't provoke opportunity attacks by moving.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731285,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!mf0fAIHSRlkZzCCT.lGg2dgS0oefuPJuS"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.2zP3SJlyV58JzUt8.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731285
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!mf0fAIHSRlkZzCCT.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 150000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731285,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!mf0fAIHSRlkZzCCT"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/5_Essence_Minions_FaI2zUvxgzWIrwze/npc_Violent_heaRr8snOnr3tgSs.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/5_Essence_Minions_FaI2zUvxgzWIrwze/npc_Violent_heaRr8snOnr3tgSs.json
@@ -1,0 +1,397 @@
+{
+  "folder": "FaI2zUvxgzWIrwze",
+  "name": "Violent",
+  "type": "npc",
+  "_id": "heaRr8snOnr3tgSs",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 7,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "M"
+      },
+      "stability": 1,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>The violents are lanky, oily bipeds with bright red flesh that contort and snap their bodies into unassuming objects. Their mimicry is particularly precise, to the point where it's unclear whether their victims die from the surprise or the violent transformation process first.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk",
+        "climb"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 2
+      },
+      "agility": {
+        "value": 3
+      },
+      "reason": {
+        "value": 0
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": -1
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "28",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 4,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "ambusher",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Violent",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Corruption Free Strikes",
+      "type": "feature",
+      "_id": "xxpvEdqJkB4YNJyq",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>You can choose for this creature's free strikes to deal corruption damage.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "poison-free-strikes",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731280,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.2zP3SJlyV58JzUt8.Item.xxpvEdqJkB4YNJyq",
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!heaRr8snOnr3tgSs.xxpvEdqJkB4YNJyq"
+    },
+    {
+      "name": "Transforming Strike",
+      "type": "feature",
+      "_id": "Dh2oaXbOET5VVHid",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s melee free strikes deal an additional [[/damage 2]] to each adjacent enemy from whom they were hidden. The [[lookup @name]] loses their disguise after striking.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731280,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!heaRr8snOnr3tgSs.Dh2oaXbOET5VVHid"
+    },
+    {
+      "name": "Mimicry",
+      "type": "feature",
+      "_id": "3mKEo15Xu7BRTaU2",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]] uses the Hide maneuver at the start of their turn as a free maneuver, disguising themselves as a a size 1M or smaller object.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731280,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!heaRr8snOnr3tgSs.3mKEo15Xu7BRTaU2"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.2zP3SJlyV58JzUt8.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731280
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!heaRr8snOnr3tgSs.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 100000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731280,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!heaRr8snOnr3tgSs"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/7_Essence_Minions_0eiiGiSawRy5iOtl/npc_Faded_Blightling_j8t7lDcmgdLYRliE.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/7_Essence_Minions_0eiiGiSawRy5iOtl/npc_Faded_Blightling_j8t7lDcmgdLYRliE.json
@@ -1,0 +1,527 @@
+{
+  "folder": "0eiiGiSawRy5iOtl",
+  "name": "Faded Blightling",
+  "type": "npc",
+  "_id": "j8t7lDcmgdLYRliE",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 17,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "L"
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>This cherubin creature is bloated and warped by demonic energy. The lights from their myriad eyes have all but gone out, now resembling pustules across their body.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk",
+        "fly"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 0
+      },
+      "agility": {
+        "value": 0
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": 4
+      },
+      "presence": {
+        "value": 3
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "34",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 7,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "support",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Faded Blightling",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "icons/svg/mystery-man.svg",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Corruption Free Strikes",
+      "type": "feature",
+      "_id": "xxpvEdqJkB4YNJyq",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>You can choose for this creature's free strikes to deal corruption damage.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "poison-free-strikes",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731282,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": "Compendium.world.summoner-minions.Actor.eOKqqXeinZxZejEL.Item.xxpvEdqJkB4YNJyq",
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!j8t7lDcmgdLYRliE.xxpvEdqJkB4YNJyq"
+    },
+    {
+      "name": "Wilted Wings",
+      "type": "feature",
+      "_id": "H8WV5eAZ4jlNcAcz",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]] must land on the ground at the end of their turn or fall prone.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731282,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!j8t7lDcmgdLYRliE.H8WV5eAZ4jlNcAcz"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.world.summoner-minions.Actor.a9YKT6xoII95LRt3.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731282
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!j8t7lDcmgdLYRliE.6J9lMMqHMOR8zWyO"
+    },
+    {
+      "name": "Blighted Strike",
+      "type": "ability",
+      "system": {
+        "type": "main",
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        },
+        "story": "",
+        "keywords": [
+          "magic",
+          "ranged",
+          "strike"
+        ],
+        "category": "signature",
+        "resource": null,
+        "trigger": "",
+        "distance": {
+          "type": "ranged",
+          "primary": "5",
+          "secondary": "1",
+          "tertiary": "1"
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "creatureObject",
+          "custom": "One creature or object per minion",
+          "value": null
+        },
+        "power": {
+          "roll": {
+            "reactive": false,
+            "formula": "@chr",
+            "characteristics": []
+          },
+          "effects": {
+            "w7ViFXLexBlJtdxs": {
+              "sort": 100000,
+              "name": "",
+              "img": null,
+              "type": "damage",
+              "_id": "w7ViFXLexBlJtdxs",
+              "damage": {
+                "tier1": {
+                  "value": "7",
+                  "types": [
+                    "corruption"
+                  ],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "value": "11",
+                  "types": [
+                    "corruption"
+                  ],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "value": "16",
+                  "types": [
+                    "corruption"
+                  ],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            },
+            "9SCRjS02RS6P2j3A": {
+              "sort": 200000,
+              "name": "",
+              "img": null,
+              "type": "applied",
+              "_id": "9SCRjS02RS6P2j3A",
+              "applied": {
+                "tier1": {
+                  "display": "[[op P weak]] bleeding (EoT)",
+                  "effects": {
+                    "bleeding": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "turn"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "display": "[[op P average]] bleeding (EoT)",
+                  "effects": {
+                    "bleeding": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "turn"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "display": "[[op P strong]] bleeding (EoT)",
+                  "effects": {
+                    "bleeding": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "turn"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            }
+          }
+        },
+        "effects": {
+          "after00000000000": {
+            "_id": "after00000000000",
+            "type": "base",
+            "description": "<p>Instead of taking damage, you or an ally targeted by this ability impose a double bane on the next strike that targets them.</p>",
+            "name": "",
+            "img": null,
+            "sort": 0,
+            "before": false
+          }
+        }
+      },
+      "_id": "S3WizRMSjCDvG6Qj",
+      "img": "icons/svg/item-bag.svg",
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731282,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!j8t7lDcmgdLYRliE.S3WizRMSjCDvG6Qj"
+    }
+  ],
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731282,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!j8t7lDcmgdLYRliE"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/7_Essence_Minions_0eiiGiSawRy5iOtl/npc_Gorrre_hPPVmQXFeK6M3qZO.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/7_Essence_Minions_0eiiGiSawRy5iOtl/npc_Gorrre_hPPVmQXFeK6M3qZO.json
@@ -1,0 +1,352 @@
+{
+  "folder": "0eiiGiSawRy5iOtl",
+  "name": "Gorrre",
+  "type": "npc",
+  "_id": "hPPVmQXFeK6M3qZO",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 17,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 2,
+        "letter": "M"
+      },
+      "stability": 2,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>The gorrre demons evoke features of rhino and orangutan while clad in heavy armor. They've been utilized as jail guards by devils, as few prisoners can ever hope to outrun a monster with unlimited endurance.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 4
+      },
+      "agility": {
+        "value": 3
+      },
+      "reason": {
+        "value": 0
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": 0
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "35",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 8,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "brute",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Gorrre",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 2,
+    "height": 2,
+    "depth": 1,
+    "texture": {
+      "src": "icons/svg/mystery-man.svg",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.world.summoner-minions.Actor.j8t7lDcmgdLYRliE.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731279
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!hPPVmQXFeK6M3qZO.6J9lMMqHMOR8zWyO"
+    },
+    {
+      "name": "Gorrring Strike",
+      "type": "feature",
+      "_id": "mM8ZlVI8THOov6Bn",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]] must charge before making a strike. The target is [[op M strong]] [[/apply prone]]{knocked prone} if the [[lookup @name]] moved through an enemy or object other than the target during the charge.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731279,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!hPPVmQXFeK6M3qZO.mM8ZlVI8THOov6Bn"
+    },
+    {
+      "name": "Devastating Charge",
+      "type": "feature",
+      "_id": "IRa8eD8DTQwcD6jj",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]] ignores difficult terrain while charging and destroys unattended, size 1 objects in their path. Each enemy they move through during a charge takes [[/damage 3]].</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731279,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!hPPVmQXFeK6M3qZO.IRa8eD8DTQwcD6jj"
+    }
+  ],
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731279,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!hPPVmQXFeK6M3qZO"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/7_Essence_Minions_0eiiGiSawRy5iOtl/npc_Vicisittante_lzliZfauMilJoQX1.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/7_Essence_Minions_0eiiGiSawRy5iOtl/npc_Vicisittante_lzliZfauMilJoQX1.json
@@ -1,0 +1,480 @@
+{
+  "folder": "0eiiGiSawRy5iOtl",
+  "name": "Vicisittante",
+  "type": "npc",
+  "_id": "lzliZfauMilJoQX1",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 17,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 2,
+        "letter": "M"
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>It's difficult to identify the base nature of a vicisittante apart from an ever-changing mass of burning flesh. Any surface they touch immediately scars as the demon leaves parts of themselves behind.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 10,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 3
+      },
+      "agility": {
+        "value": 4
+      },
+      "reason": {
+        "value": 0
+      },
+      "intuition": {
+        "value": 0
+      },
+      "presence": {
+        "value": -1
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "35",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 4,
+    "monster": {
+      "freeStrike": 7,
+      "keywords": [],
+      "level": 1,
+      "role": "",
+      "organization": "",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Vicisittante",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 2,
+    "height": 2,
+    "depth": 1,
+    "texture": {
+      "src": "icons/svg/mystery-man.svg",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Psychic Free Strikes",
+      "type": "feature",
+      "_id": "xxpvEdqJkB4YNJyq",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>You can choose for this creature's free strikes to deal psychic damage.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "poison-free-strikes",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731283,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": "Compendium.world.summoner-minions.Actor.a9YKT6xoII95LRt3.Item.xxpvEdqJkB4YNJyq",
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!lzliZfauMilJoQX1.xxpvEdqJkB4YNJyq"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.world.summoner-minions.Actor.a9YKT6xoII95LRt3.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731283
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!lzliZfauMilJoQX1.6J9lMMqHMOR8zWyO"
+    },
+    {
+      "name": "Cerebral Flay",
+      "type": "ability",
+      "system": {
+        "type": "main",
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        },
+        "story": "",
+        "keywords": [
+          "melee",
+          "psionic",
+          "strike"
+        ],
+        "category": "signature",
+        "resource": null,
+        "trigger": "",
+        "distance": {
+          "type": "melee",
+          "primary": "1",
+          "secondary": "1",
+          "tertiary": "1"
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "creatureObject",
+          "custom": "One creature or object per minion",
+          "value": null
+        },
+        "power": {
+          "roll": {
+            "reactive": false,
+            "formula": "@chr",
+            "characteristics": []
+          },
+          "effects": {
+            "5wrFcqUQIcKS4gpD": {
+              "sort": 100000,
+              "name": "",
+              "img": null,
+              "type": "damage",
+              "_id": "5wrFcqUQIcKS4gpD",
+              "damage": {
+                "tier1": {
+                  "value": "7",
+                  "types": [
+                    "psychic"
+                  ],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "value": "11",
+                  "types": [
+                    "psychic"
+                  ],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "value": "16",
+                  "types": [
+                    "psychic"
+                  ],
+                  "ignoredImmunities": [],
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            },
+            "UbFBeSOQA0TdCpo3": {
+              "sort": 200000,
+              "name": "",
+              "img": null,
+              "type": "applied",
+              "_id": "UbFBeSOQA0TdCpo3",
+              "applied": {
+                "tier1": {
+                  "display": "[[op P weak]] weakened (save ends)",
+                  "effects": {
+                    "weakened": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "save"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.weak",
+                    "characteristic": "none"
+                  }
+                },
+                "tier2": {
+                  "display": "[[op P average]] weakened (save ends)",
+                  "effects": {
+                    "weakened": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "save"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.average",
+                    "characteristic": ""
+                  }
+                },
+                "tier3": {
+                  "display": "[[op P strong]] weakened (save ends)",
+                  "effects": {
+                    "weakened": {
+                      "condition": "failure",
+                      "properties": [],
+                      "end": "save"
+                    }
+                  },
+                  "potency": {
+                    "value": "@potency.strong",
+                    "characteristic": ""
+                  }
+                }
+              }
+            }
+          }
+        },
+        "effects": {
+          "after00000000000": {
+            "_id": "after00000000000",
+            "type": "base",
+            "description": "<p>A target weakened by this ability is always considered flanked by the [[lookup @name]] regardless of position until the condition ends.</p>",
+            "name": "",
+            "img": null,
+            "sort": 0,
+            "before": false
+          }
+        }
+      },
+      "_id": "07cfNG7DtYN4a7D7",
+      "img": "icons/svg/item-bag.svg",
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731283,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!lzliZfauMilJoQX1.07cfNG7DtYN4a7D7"
+    }
+  ],
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731283,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!lzliZfauMilJoQX1"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_3_Essence_Minions_grTBqFuzUL7VN4Ju.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_3_Essence_Minions_grTBqFuzUL7VN4Ju.json
@@ -1,0 +1,23 @@
+{
+  "type": "Actor",
+  "folder": "4s16kzGmXOlNNjMf",
+  "name": "3-Essence Minions",
+  "color": null,
+  "sorting": "a",
+  "_id": "grTBqFuzUL7VN4Ju",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731128,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!grTBqFuzUL7VN4Ju"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_5_Essence_Minions_FaI2zUvxgzWIrwze.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_5_Essence_Minions_FaI2zUvxgzWIrwze.json
@@ -1,0 +1,23 @@
+{
+  "type": "Actor",
+  "folder": "4s16kzGmXOlNNjMf",
+  "name": "5-Essence Minions",
+  "color": null,
+  "sorting": "a",
+  "_id": "FaI2zUvxgzWIrwze",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731128,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!FaI2zUvxgzWIrwze"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_7_Essence_Minions_0eiiGiSawRy5iOtl.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_7_Essence_Minions_0eiiGiSawRy5iOtl.json
@@ -1,0 +1,23 @@
+{
+  "type": "Actor",
+  "folder": "4s16kzGmXOlNNjMf",
+  "name": "7-Essence Minions",
+  "color": null,
+  "sorting": "a",
+  "_id": "0eiiGiSawRy5iOtl",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731128,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!0eiiGiSawRy5iOtl"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_Signature_Minions_c96z1PaTmAzJQAug.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Folder_Signature_Minions_c96z1PaTmAzJQAug.json
@@ -1,0 +1,23 @@
+{
+  "type": "Actor",
+  "folder": "4s16kzGmXOlNNjMf",
+  "name": "Signature Minions",
+  "color": null,
+  "sorting": "a",
+  "_id": "c96z1PaTmAzJQAug",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731128,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!c96z1PaTmAzJQAug"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Signature_Minions_c96z1PaTmAzJQAug/npc_Ensnarer_4gzlvFuzEdD0ErSd.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Signature_Minions_c96z1PaTmAzJQAug/npc_Ensnarer_4gzlvFuzEdD0ErSd.json
@@ -1,0 +1,308 @@
+{
+  "folder": "c96z1PaTmAzJQAug",
+  "name": "Ensnarer",
+  "type": "npc",
+  "_id": "4gzlvFuzEdD0ErSd",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 2,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "M"
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>This vaguely humanoid form is warped and distorted by a demon nestled inside them. They extend long tongues from multiple orifices to drag victims in close.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 2
+      },
+      "agility": {
+        "value": 0
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": -1
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "13",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 2,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "brute",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Ensnarer",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Extended Barbed Sight",
+      "type": "feature",
+      "_id": "c4gFRWDdgqYwbDeU",
+      "img": "icons/magic/perception/eye-slit-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s melee free strikes have a distance of 3 and inflict pull 1. The pull distance increases by 1 for each additional [[lookup @name]] striking the same target. Choose the [[lookup @name]] that the target is being pulled to before applying forced movement.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731259,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!4gzlvFuzEdD0ErSd.c4gFRWDdgqYwbDeU"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.draw-steel.monsters.Actor.E3cI02r1zBQaBr1i.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731259
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!4gzlvFuzEdD0ErSd.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 100000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731259,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!4gzlvFuzEdD0ErSd"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Signature_Minions_c96z1PaTmAzJQAug/npc_Rasquine_WiHk1bOLtubsWiZV.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Signature_Minions_c96z1PaTmAzJQAug/npc_Rasquine_WiHk1bOLtubsWiZV.json
@@ -1,0 +1,309 @@
+{
+  "folder": "c96z1PaTmAzJQAug",
+  "name": "Rasquine",
+  "type": "npc",
+  "_id": "WiHk1bOLtubsWiZV",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 2,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "S"
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>The rasquine are skulking demons that shimmer in the light. They teleport into position before biting the necks of their prey.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 4,
+      "types": [
+        "walk",
+        "teleport"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": -1
+      },
+      "agility": {
+        "value": 0
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": 2
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "13",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 2,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "ambusher",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Rasquine",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Skulker",
+      "type": "feature",
+      "_id": "LmBmT89KWGkrenMr",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>Once per turn, the [[lookup @name]] can hide as a free maneuver after teleporting.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731265,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!WiHk1bOLtubsWiZV.LmBmT89KWGkrenMr"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.4gzlvFuzEdD0ErSd.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731265
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!WiHk1bOLtubsWiZV.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 150000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731265,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!WiHk1bOLtubsWiZV"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Signature_Minions_c96z1PaTmAzJQAug/npc_Razor_QOYeoaKgoueyh7aA.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/Signature_Minions_c96z1PaTmAzJQAug/npc_Razor_QOYeoaKgoueyh7aA.json
@@ -1,0 +1,308 @@
+{
+  "folder": "c96z1PaTmAzJQAug",
+  "name": "Razor",
+  "type": "npc",
+  "_id": "QOYeoaKgoueyh7aA",
+  "img": "systems/draw-steel/assets/roles/minion.webp",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 2,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 1,
+        "letter": "M"
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>Razors appear to be a diminutive variant of the ruinant demon. Their bodies are swift, tumbling mounds of scarred flesh and deadly claws.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 6,
+      "types": [
+        "walk"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 1,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 0
+      },
+      "agility": {
+        "value": 2
+      },
+      "reason": {
+        "value": -1
+      },
+      "intuition": {
+        "value": -1
+      },
+      "presence": {
+        "value": -1
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "13",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 1,
+      "keywords": [
+        "abyssal"
+      ],
+      "level": 1,
+      "role": "harrier",
+      "organization": "minion",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Razor",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 1,
+    "height": 1,
+    "depth": 1,
+    "texture": {
+      "src": "systems/draw-steel/assets/roles/minion.webp",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Teeth!",
+      "type": "feature",
+      "_id": "fzIcgS3r9piDfipn",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>Once per turn, whenever an adjacent enemy grabs the [[lookup @name]] or uses a melee ability against them, that enemy takes 1 damage for each [[lookup @name]] adjacent to them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731263,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!QOYeoaKgoueyh7aA.fzIcgS3r9piDfipn"
+    },
+    {
+      "name": "Soulsight",
+      "type": "feature",
+      "img": "https://assets.forge-vtt.com/bazaar/core/icons/creatures/unholy/demon-hairy-winged-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each creature adjacent to the [[lookup @name]] can't be hidden from them.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "Monsters",
+          "license": "Draw Steel Creator License",
+          "page": "62"
+        },
+        "_dsid": "soulsight",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "_id": "6J9lMMqHMOR8zWyO",
+      "effects": [],
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.forge-vtt-shared-compendiums-shared-things.actor-2-monsters.Actor.4gzlvFuzEdD0ErSd.Item.6J9lMMqHMOR8zWyO",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "lastModifiedBy": null,
+        "modifiedTime": null,
+        "createdTime": 1787599731263
+      },
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "folder": null,
+      "sort": 0,
+      "_key": "!actors.items!QOYeoaKgoueyh7aA.6J9lMMqHMOR8zWyO"
+    }
+  ],
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731263,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!QOYeoaKgoueyh7aA"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/npc_Demon_Lord_s_Aspect_YOSgMuboci7Tqotp.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/npc_Demon_Lord_s_Aspect_YOSgMuboci7Tqotp.json
@@ -1,0 +1,515 @@
+{
+  "folder": "4s16kzGmXOlNNjMf",
+  "name": "Demon Lord's Aspect",
+  "type": "npc",
+  "_id": "YOSgMuboci7Tqotp",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 0,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 2,
+        "letter": "M"
+      },
+      "stability": 2,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>Your champion is an Aspect of a demon lord. They have borne witness to your exploits and struck a deal with you: Allow their children to feed and you can call forth a modicum of their power. Morality is none of their concern, but certainly a hero is enough of an arbiter of whose souls deserve to be fed to demons, right?</p><p>The demon lord's Aspect enjoys bringing enemies in close with their appendages or flinging victims and throwing them to the gnashing horde. They're willing to put your connection to this world at risk if it means taking one more bite.</p>",
+      "director": "",
+      "languages": []
+    },
+    "movement": {
+      "value": 5,
+      "types": [
+        "walk",
+        "teleport"
+      ],
+      "hover": false,
+      "disengage": 1
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 5,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "characteristics": {
+      "might": {
+        "value": 2
+      },
+      "agility": {
+        "value": 5
+      },
+      "reason": {
+        "value": 5
+      },
+      "intuition": {
+        "value": 2
+      },
+      "presence": {
+        "value": 2
+      }
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "41",
+      "license": "Draw Steel Creator License"
+    },
+    "negotiation": {
+      "interest": 5,
+      "patience": 5,
+      "motivations": [],
+      "pitfalls": [],
+      "impression": 1
+    },
+    "ev": 0,
+    "monster": {
+      "freeStrike": 9,
+      "keywords": [],
+      "level": 1,
+      "role": "",
+      "organization": "",
+      "withCaptainEffect": null
+    }
+  },
+  "prototypeToken": {
+    "name": "Demon Lord's Aspect",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 2,
+    "height": 2,
+    "depth": 1,
+    "texture": {
+      "src": "icons/svg/mystery-man.svg",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Your Stamina",
+      "type": "feature",
+      "_id": "y2RL39GKEKYjERro",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>This creature's maximum stamina is equal to your maximum stamina.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731266,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!YOSgMuboci7Tqotp.y2RL39GKEKYjERro"
+    },
+    {
+      "name": "Warping Strike",
+      "type": "feature",
+      "_id": "xmVA7bYIPkGmyQG6",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The [[lookup @name]]'s free strikes teleport the target 5 squares.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731266,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!YOSgMuboci7Tqotp.xmVA7bYIPkGmyQG6"
+    },
+    {
+      "name": "Champion's Ire",
+      "type": "feature",
+      "_id": "WYI5Q2RNrIuQAghV",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>If the [[lookup @name]] only targets one creature or object with a strike, they deal additional damage to the target equal to your Reason.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731266,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!YOSgMuboci7Tqotp.WYI5Q2RNrIuQAghV"
+    },
+    {
+      "name": "Frenzy",
+      "type": "feature",
+      "_id": "pLOzwKcN2f1uabUg",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>When the [[lookup @name]] is reduced to 0 Stamina, they make a free strike against each adjacent enemy before dying.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731266,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!YOSgMuboci7Tqotp.pLOzwKcN2f1uabUg"
+    },
+    {
+      "name": "I Like Your Taste",
+      "type": "ability",
+      "system": {
+        "type": "freeTriggered",
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        },
+        "story": "",
+        "keywords": [],
+        "category": "",
+        "resource": null,
+        "trigger": "The aspect takes damage from an enemy.",
+        "distance": {
+          "type": "self",
+          "primary": "1",
+          "secondary": "1",
+          "tertiary": "1"
+        },
+        "damageDisplay": "melee",
+        "target": {
+          "type": "self",
+          "custom": "",
+          "value": null
+        },
+        "power": {
+          "roll": {
+            "reactive": false,
+            "formula": "@chr",
+            "characteristics": []
+          },
+          "effects": {}
+        },
+        "effects": {
+          "before0000000000": {
+            "_id": "before0000000000",
+            "type": "base",
+            "description": "<p>The [[lookup @name]] has a double edge on their next power roll. They can choose to give this benefit to an ally within your Summoner's Range instead.</p>",
+            "before": true,
+            "name": "",
+            "img": null,
+            "sort": 0
+          }
+        }
+      },
+      "_id": "uIOhf08ZZLEHpSQg",
+      "img": "icons/svg/item-bag.svg",
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731266,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!YOSgMuboci7Tqotp.uIOhf08ZZLEHpSQg"
+    },
+    {
+      "name": "Corruption Free Strike",
+      "type": "feature",
+      "_id": "Vk3SD33fq6wSEdfm",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>This creature can choose to deal corruption damage on their free strikes.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731266,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!YOSgMuboci7Tqotp.Vk3SD33fq6wSEdfm"
+    }
+  ],
+  "effects": [],
+  "sort": 200000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731266,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!YOSgMuboci7Tqotp"
+}

--- a/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/object_The_Boil_Gp4L6WwluGhd5olm.json
+++ b/src/packs/summons/Demon_Portfolio_4s16kzGmXOlNNjMf/object_The_Boil_Gp4L6WwluGhd5olm.json
@@ -1,0 +1,437 @@
+{
+  "folder": "4s16kzGmXOlNNjMf",
+  "name": "The Boil",
+  "type": "object",
+  "_id": "Gp4L6WwluGhd5olm",
+  "img": "icons/svg/tower.svg",
+  "system": {
+    "stamina": {
+      "value": null,
+      "max": 20,
+      "temporary": 0
+    },
+    "combat": {
+      "save": {
+        "threshold": 6,
+        "bonus": ""
+      },
+      "size": {
+        "value": 2,
+        "letter": "M",
+        "text": "",
+        "direction": "",
+        "typical": "",
+        "shapes": []
+      },
+      "stability": 0,
+      "turns": 1
+    },
+    "biography": {
+      "value": "<p>The boil arises from the chaotic depths of the Abyssal Waste, concentrated into a heaving mass by the pressure of a coherent reality. As it slushes and threatens to burst, the noises drive nearby demons into a frenzy.</p>",
+      "director": ""
+    },
+    "movement": {
+      "value": null,
+      "types": [],
+      "hover": false,
+      "disengage": null
+    },
+    "damage": {
+      "immunities": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      },
+      "weaknesses": {
+        "all": 0,
+        "acid": 0,
+        "cold": 0,
+        "corruption": 0,
+        "fire": 0,
+        "holy": 0,
+        "lightning": 0,
+        "poison": 0,
+        "psychic": 0,
+        "sonic": 0
+      }
+    },
+    "statuses": {
+      "immunities": []
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "26",
+      "license": "Draw Steel Creator License"
+    },
+    "ev": null,
+    "object": {
+      "level": 2,
+      "category": "hazard",
+      "role": "support",
+      "area": "",
+      "squareStamina": false
+    }
+  },
+  "prototypeToken": {
+    "name": "The Boil",
+    "displayName": 0,
+    "actorLink": false,
+    "width": 2,
+    "height": 2,
+    "depth": 1,
+    "texture": {
+      "src": "icons/svg/tower.svg",
+      "anchorX": 0.5,
+      "anchorY": 0.5,
+      "fit": "contain",
+      "scaleX": 1,
+      "scaleY": 1,
+      "tint": "#ffffff",
+      "alphaThreshold": 0.75
+    },
+    "lockRotation": true,
+    "rotation": 0,
+    "alpha": 1,
+    "disposition": -1,
+    "displayBars": 0,
+    "bar1": {
+      "attribute": "stamina"
+    },
+    "bar2": {
+      "attribute": "hero.primary.value"
+    },
+    "light": {
+      "negative": false,
+      "priority": 0,
+      "alpha": 0.5,
+      "angle": 360,
+      "bright": 0,
+      "color": null,
+      "coloration": 1,
+      "dim": 0,
+      "attenuation": 0.5,
+      "luminosity": 0.5,
+      "saturation": 0,
+      "contrast": 0,
+      "shadows": 0,
+      "animation": {
+        "type": null,
+        "speed": 5,
+        "intensity": 5,
+        "reverse": false
+      },
+      "darkness": {
+        "min": 0,
+        "max": 1
+      }
+    },
+    "sight": {
+      "enabled": false,
+      "range": 0,
+      "angle": 360,
+      "visionMode": "basic",
+      "color": null,
+      "attenuation": 0.1,
+      "brightness": 0,
+      "saturation": 0,
+      "contrast": 0
+    },
+    "detectionModes": {},
+    "occludable": {
+      "radius": 0
+    },
+    "ring": {
+      "enabled": false,
+      "colors": {
+        "ring": null,
+        "background": null
+      },
+      "effects": 1,
+      "subject": {
+        "scale": 1,
+        "texture": null
+      }
+    },
+    "turnMarker": {
+      "mode": 1,
+      "animation": null,
+      "src": null,
+      "disposition": false
+    },
+    "movementAction": null,
+    "flags": {},
+    "randomImg": false,
+    "appendNumber": false,
+    "prependAdjective": false
+  },
+  "items": [
+    {
+      "name": "Hunger Thrush",
+      "type": "feature",
+      "_id": "6xmBNp2REGEkrvGP",
+      "img": "icons/creatures/tentacles/tentacles-suctioncups-pink.webp",
+      "system": {
+        "description": {
+          "value": "<p>Each enemy that starts their turn within 3 squares of [[lookup @name]] is [[potency I average]] [[/apply taunted turn]] by [[lookup @name]], or [[potency I weak]] [[/apply taunted turn]] by the boil and can't move further from it.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731261,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!Gp4L6WwluGhd5olm.6xmBNp2REGEkrvGP"
+    },
+    {
+      "name": "Oh, It Pops",
+      "type": "feature",
+      "_id": "7vsCWMHUei95mT4m",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>When [[lookup @name]] is destroyed, each enemy within 3 squares of [[lookup @name]] takes acid damage equal to your level and is [[op A strong]] [[/apply weakened save]].</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": ""
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "bULgfeSVOL2yapd0": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787599731261,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!Gp4L6WwluGhd5olm.7vsCWMHUei95mT4m"
+    },
+    {
+      "name": "Soul Rancor",
+      "type": "feature",
+      "_id": "oO5R1tbuuYk8uqRu",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>You gain a surge the first time in a round that your demon minions deal 3 or more damage to a creature while you have line of effect to the boil. You can choose to give the surge to an ally who also has line of effect to the boil.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": "Draw Steel Creator License"
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": 5
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "H3JTtZ7ZHtjM7TW8": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787602734790,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!Gp4L6WwluGhd5olm.oO5R1tbuuYk8uqRu"
+    },
+    {
+      "name": "Size Increase",
+      "type": "feature",
+      "_id": "XMmsbVn7DB4iPJaj",
+      "img": "icons/svg/item-bag.svg",
+      "system": {
+        "description": {
+          "value": "<p>The boil is now size 3.</p>",
+          "director": ""
+        },
+        "source": {
+          "book": "",
+          "page": "",
+          "license": "Draw Steel Creator License"
+        },
+        "_dsid": "",
+        "advancements": {},
+        "prerequisites": {
+          "value": "",
+          "dsid": [],
+          "level": null
+        }
+      },
+      "effects": [],
+      "folder": null,
+      "sort": 0,
+      "ownership": {
+        "default": 0,
+        "H3JTtZ7ZHtjM7TW8": 3
+      },
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787602795464,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.items!Gp4L6WwluGhd5olm.XMmsbVn7DB4iPJaj"
+    }
+  ],
+  "effects": [
+    {
+      "name": "Level 5 - Size Increase",
+      "img": "icons/svg/aura.svg",
+      "type": "base",
+      "origin": "Compendium.draw-steel.summons.Actor.Gp4L6WwluGhd5olm",
+      "disabled": true,
+      "_id": "1niXkk1gn8kXwdwH",
+      "system": {
+        "changes": [
+          {
+            "key": "system.combat.size.value",
+            "type": "upgrade",
+            "value": 3,
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": false,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1787602847666,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!actors.effects!Gp4L6WwluGhd5olm.1niXkk1gn8kXwdwH"
+    }
+  ],
+  "sort": 100000,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731261,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!actors!Gp4L6WwluGhd5olm"
+}

--- a/src/packs/summons/Folder_Demon_Portfolio_4s16kzGmXOlNNjMf.json
+++ b/src/packs/summons/Folder_Demon_Portfolio_4s16kzGmXOlNNjMf.json
@@ -1,0 +1,23 @@
+{
+  "type": "Actor",
+  "folder": null,
+  "name": "Demon Portfolio",
+  "color": null,
+  "sorting": "a",
+  "_id": "4s16kzGmXOlNNjMf",
+  "description": "",
+  "sort": 100000,
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1787599731128,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!folders!4s16kzGmXOlNNjMf"
+}


### PR DESCRIPTION
With thanks to @Speedrace4 for use of their Summoner Compendium.

This pull:
1. Adds every core feature and ability of the Summoner Class, trying to implement enrichers where possible.
2. Makes an item for every subclass and implements their first level features.
3. Adds the Demon Portfolio into the Summons Compendium (Imported from Speedrace's compendium)

Things this pull does not add or needs to be changed later:
1. Call forth cannot summon minions from portfolio
2. The minion portfolio cannot currently be modified from Minion Improvements (which is why they are currently features)
3. The summoner's kit changes the Effect of an ability line by line, which is not possible to currently upgrade.