### PR TITLE
[#1320] Squad Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Increased foundry minimum to 14.367.
 - "With Captain" effects will automatically be enabled/disabled based on the changing status of a minion's captain. (#348)
 - Implemented summoning as a new type of special effect. (#583)
   - Added new Companions and Summons advancement type to integrate with summoning. (#584)
+- Added support for specifying the number of minions joining in a squad attack. (#1320)
 - Added new header button to repick items granted by advancements. (#1513)
 - Added support for Companions as a new actor type. (#2011)
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -2226,7 +2226,8 @@
               "one": "Bane",
               "other": "Banes"
             }
-          }
+          },
+          "Minions": "Minions"
         },
         "TestDifficulty": {
           "easy": "Easy",

--- a/src/module/applications/apps/ability-configuration-dialog.mjs
+++ b/src/module/applications/apps/ability-configuration-dialog.mjs
@@ -4,7 +4,7 @@ import { systemPath } from "../../constants.mjs";
 
 /**
  * @import AbilityModel from "../../data/item/ability.mjs";
- * @import { DrawSteelActor, DrawSteelItem } from "../../documents/_module.mjs";
+ * @import { DrawSteelActor, DrawSteelCombatantGroup, DrawSteelItem } from "../../documents/_module.mjs";
  * @import DrawSteelToken  from "../../canvas/placeables/token.mjs"
  * @import RegionDocument from "@client/documents/region.mjs";
  */
@@ -93,6 +93,17 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
 
   /* -------------------------------------------------- */
 
+  /**
+   * A possible squad for this actor.
+   * @returns {DrawSteelCombatantGroup | null}
+   */
+  get squad() {
+    if (!this.actor.isMinion) return null;
+    return this.actor.system.combatGroup;
+  }
+
+  /* -------------------------------------------------- */
+
   /** @inheritdoc */
   _initializeApplicationOptions(options) {
     const initializedOptions = super._initializeApplicationOptions(options);
@@ -124,6 +135,7 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
 
     switch (partId) {
       case "roll":
+        context.squad = this.squad;
         context.targets ??= {};
         this._prepareTargets(context);
         break;
@@ -148,6 +160,7 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
     for (const target of Object.values(context.targets)) {
       target.actor ??= fromUuidSync(target.uuid);
       target.token ??= fromUuidSync(target.tokenUuid);
+      if (this.squad) target.minions ??= 1;
 
       target.combinedModifiers = {
         edges: Math.clamp(target.modifiers.edges + context.modifiers.edges, 0, PowerRoll.MAX_EDGE),
@@ -243,7 +256,7 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
     const fd = foundry.utils.expandObject(formData.object);
 
     const targets = Object.values(this.options.context.targets ?? {});
-    if (targets?.length) config.rolls = targets.map(target => ({ ...target.combinedModifiers, target: target.uuid }));
+    if (targets?.length) config.rolls = targets.map(target => ({ ...target.combinedModifiers, target: target.uuid, minions: target.minions }));
 
     if (fd["damage-selection"]) config.damage = fd["damage-selection"];
     if ("resource" in fd) config.resource = fd.resource;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -667,6 +667,7 @@ export default class AbilityModel extends BaseItemModel {
             const damageRoll = damageEffect.toDamageRoll(roll.product, {
               damageSelection: fd.damage,
               spend: Object.values(fd.spend ?? {}),
+              squadMinions: roll.options.minions,
             });
             if (!damageRoll) continue;
             await damageRoll.evaluate();
@@ -674,6 +675,8 @@ export default class AbilityModel extends BaseItemModel {
             // If there's a roll, add it to the base message data for DSN purposes
             if (!damageRoll.isDeterministic) messageData.rolls.push(damageRoll);
           }
+
+          delete roll.options.minions;
 
           messageData.system.parts[partId] = rollPart;
         }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -211,6 +211,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
    * @param {object} [options]
    * @param {string} [options.damageSelection] Pick between this damage effect's multiple damage types.
    * @param {number[]} [options.spend] Spend data from an ability configuration form.
+   * @param {number} [options.squadMinions] A number of squad minions joining in the attack. Base 1 for no extra damage.
    * @returns {DamageRoll | null} Returns null if there would be no damage from that tier.
    */
   toDamageRoll(tier, options = {}) {
@@ -229,9 +230,15 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
 
     const rollData = this.item.getRollData();
 
-    if (options.spend) rollData.spend = options.spend;
+    let formula = String(effectTier.value);
 
-    return new DamageRoll(String(effectTier.value), rollData, {
+    if (options.spend) rollData.spend = options.spend;
+    if (options.squadMinions) {
+      formula += "+(@squadMinions * @monster.freeStrike)";
+      rollData.squadMinions = options.squadMinions - 1;
+    }
+
+    return new DamageRoll(formula, rollData, {
       flavor,
       type: damageType,
       ignoredImmunities,

--- a/templates/apps/ability-configuration-dialog/roll.hbs
+++ b/templates/apps/ability-configuration-dialog/roll.hbs
@@ -54,6 +54,12 @@
         {{numberInput target.modifiers.bonuses name=(concat "targets." tokenId ".modifiers.bonuses") step=1}}
         <span class="total-bonuses">{{localize "DRAW_STEEL.ROLL.Power.Prompt.Total" number=target.combinedModifiers.bonuses}}</span>
       </label>
+      {{#if @root.squad}}
+      <label>
+        {{numberInput target.minions name=(concat "targets." tokenId ".minions") step=1 min=1 max=@root.squad.members.size}}
+        <span>{{localize "DRAW_STEEL.ROLL.Power.Modifier.Minions"}}</span>
+      </label>
+      {{/if}}
     </div>
   </div>
   {{/each}}


### PR DESCRIPTION
Using an ability with a minion prompts for how many minions are joining in the attack, adding their free strike value. The rules here are *slightly* ambiguous as to how captain bonuses to strikes should be processed, I am interpreting that the bonus some minions like War Dog Conscript get to "strikes" is only added once here.

<img width="680" height="348" alt="image" src="https://github.com/user-attachments/assets/bb7135cd-bfa1-4127-a82b-e872fb42b8d3" />

<img width="293" height="677" alt="image" src="https://github.com/user-attachments/assets/7eadc65f-2769-4be2-8cce-0b9ab7afaca6" />

References

<img width="500" height="368" alt="image" src="https://github.com/user-attachments/assets/422af038-ca65-459f-bea2-2edc6bef66ed" />

<img width="997" height="801" alt="image" src="https://github.com/user-attachments/assets/db3573f1-9328-427e-9a71-92fe327f87ae" />

Closes #1320