### PR TITLE
Add applied effect tier 1 copy

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -319,6 +319,7 @@
           "originDuration": "Origin-based Duration"
         },
         "AddEffect": "Add Effect",
+        "CopyTierOneEffect": "Copy Tier 1 Effect",
         "CreateCustomEffect": "Create Custom Effect",
         "CustomEffects": "Custom Effects"
       },

--- a/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
@@ -15,7 +15,7 @@ export default class PowerRollEffectSheet extends PseudoDocumentSheet {
   static DEFAULT_OPTIONS = {
     actions: {
       addAppliedEffect: this.#addAppliedEffect,
-      addTierOneEffect: this.#addTierOneEffect,
+      copyTierOneEffect: this.#copyTierOneEffect,
       deleteAppliedEffectEntry: this.#deleteAppliedEffectEntry,
       editAppliedEffect: this.#editAppliedEffect,
     },
@@ -112,13 +112,15 @@ export default class PowerRollEffectSheet extends PseudoDocumentSheet {
     }
   }
 
+  /* -------------------------------------------------- */
+
   /**
    * Add an entry to `applied.effects`.
    * @this PowerRollEffectSheet
    * @param {PointerEvent} event        The initiating click event.
    * @param {HTMLButtonElement} target  The capturing HTML element which defined a [data-action].
    */
-  static async #addTierOneEffect(event, target) {
+  static async #copyTierOneEffect(event, target) {
     const path = target.dataset.path;
     if (path.includes("1")) return;
     this.pseudoDocument.update({ [`${path}`]: this.pseudoDocument.applied.tier1.effects });

--- a/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/power-roll-effect-sheet.mjs
@@ -15,6 +15,7 @@ export default class PowerRollEffectSheet extends PseudoDocumentSheet {
   static DEFAULT_OPTIONS = {
     actions: {
       addAppliedEffect: this.#addAppliedEffect,
+      addTierOneEffect: this.#addTierOneEffect,
       deleteAppliedEffectEntry: this.#deleteAppliedEffectEntry,
       editAppliedEffect: this.#editAppliedEffect,
     },
@@ -109,6 +110,18 @@ export default class PowerRollEffectSheet extends PseudoDocumentSheet {
         this.pseudoDocument.update({ [`${path}.${effect.id}.condition`]: "failure" });
       }
     }
+  }
+
+  /**
+   * Add an entry to `applied.effects`.
+   * @this PowerRollEffectSheet
+   * @param {PointerEvent} event        The initiating click event.
+   * @param {HTMLButtonElement} target  The capturing HTML element which defined a [data-action].
+   */
+  static async #addTierOneEffect(event, target) {
+    const path = target.dataset.path;
+    if (path.includes("1")) return;
+    this.pseudoDocument.update({ [`${path}`]: this.pseudoDocument.applied.tier1.effects });
   }
 
   /* -------------------------------------------------- */

--- a/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_1_9cPQyQCXUIXRme9R/5_Ferocity_9iT8OXz2ZLsuyduZ/ability_Blood_for_Blood__CD27c6U0GUSIJPDT.json
+++ b/src/packs/abilities/Fury_NsE50OrdFsIk4ND2/Level_1_9cPQyQCXUIXRme9R/5_Ferocity_9iT8OXz2ZLsuyduZ/ability_Blood_for_Blood__CD27c6U0GUSIJPDT.json
@@ -100,7 +100,13 @@
             },
             "tier2": {
               "display": "",
-              "effects": {},
+              "effects": {
+                "smsxzpXNKk6UkIC5": {
+                  "condition": "failure",
+                  "end": "save",
+                  "properties": []
+                }
+              },
               "potency": {
                 "value": "@potency.average",
                 "characteristic": ""
@@ -108,7 +114,13 @@
             },
             "tier3": {
               "display": "",
-              "effects": {},
+              "effects": {
+                "smsxzpXNKk6UkIC5": {
+                  "condition": "failure",
+                  "end": "save",
+                  "properties": []
+                }
+              },
               "potency": {
                 "value": "@potency.strong",
                 "characteristic": ""
@@ -203,9 +215,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "14.365",
+    "coreVersion": "14.367",
     "systemId": "draw-steel",
-    "systemVersion": "1.1.0",
+    "systemVersion": "1.2",
     "createdTime": 1755579974551,
     "modifiedTime": null,
     "lastModifiedBy": null

--- a/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
+++ b/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
@@ -33,7 +33,9 @@
       </select>
     </div>
     <button type="button" class="icon fa-solid fa-plus" data-action="addAppliedEffect" data-path="{{effects.name}}"></button>
-    <button type="button" class="icon fa-solid fa-copy" data-action="addTierOneEffect" data-path="{{effects.name}}" data-tooltip="DRAW_STEEL.POWER_ROLL_EFFECT.APPLIED.CopyTierOneEffect" data-tooltip-direction="UP"></button>
+    {{#unless (eq ../tab.id "tier1")}}
+    <button type="button" class="icon fa-solid fa-copy" data-action="copyTierOneEffect" data-path="{{effects.name}}" data-tooltip="DRAW_STEEL.POWER_ROLL_EFFECT.APPLIED.CopyTierOneEffect" data-tooltip-direction="UP"></button>
+    {{/unless}}
   </div>
   {{#each effects.entries as |appliedEffect|}}
   <fieldset data-effect-id="{{appliedEffect.id}}" data-path="{{../effects.name}}">

--- a/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
+++ b/templates/sheets/pseudo-documents/power-roll-effect-sheet/details-tiers.hbs
@@ -33,6 +33,7 @@
       </select>
     </div>
     <button type="button" class="icon fa-solid fa-plus" data-action="addAppliedEffect" data-path="{{effects.name}}"></button>
+    <button type="button" class="icon fa-solid fa-copy" data-action="addTierOneEffect" data-path="{{effects.name}}" data-tooltip="DRAW_STEEL.POWER_ROLL_EFFECT.APPLIED.CopyTierOneEffect" data-tooltip-direction="UP"></button>
   </div>
   {{#each effects.entries as |appliedEffect|}}
   <fieldset data-effect-id="{{appliedEffect.id}}" data-path="{{../effects.name}}">


### PR DESCRIPTION
Adds a button to the "Power Roll Effect: Applied Effect" sheet that will copy the applied effects for Tier 1 to the current Tier. This should speed up creating abilities that apply effects on their power roll, since most power rolls apply the same effects on all 3 tiers (often even with the same duration).

Also includes a minor compendium fix for "Blood for Blood" applied effects (this was used to test the button).

Picture of button as added (with tooltip shown):

<img width="609" height="301" alt="Foundry_Virtual_Tabletop_NT0exdozUA" src="https://github.com/user-attachments/assets/b7d55684-db73-4307-9f47-12cb31abf292" />
