### PR TITLE
[#2021] Apply effects to fresh summons

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -160,6 +160,19 @@
           }
         }
       },
+      "SUMMON": {
+        "FIELDS": {
+          "effects": {
+            "label": "Effects Applied On Summon",
+            "hint": "Actors summoned from this portfolio entry will be created with these active effects based on the summoner's level. Roll data in the effects is evaluated at the moment of summoning.",
+            "element": {
+              "level": {
+                "label": "Summoner Level"
+              }
+            }
+          }
+        }
+      },
       "TRAIT": {
         "FIELDS": {
           "chooseN": {
@@ -206,7 +219,8 @@
         "requirePack": "Granted documents must come from a compendium pack.",
         "forbidParent": "Granted documents cannot be embedded in an actor.",
         "restrictedTypeSummon": "{type} actors cannot be added as summon choices.",
-        "requirePackSummon": "Summonable Actors must come from a compendium pack."
+        "requirePackSummon": "Summonable Actors must come from a compendium pack.",
+        "requireStandaloneSummonEffect": "Effects for summoned actors must come from a compendium pack and not be embedded in another document."
       },
       "FillTrait": {
         "button": "Pick Unchosen {type}",

--- a/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
+++ b/src/module/applications/sheets/pseudo-documents/advancement-sheet.mjs
@@ -18,6 +18,7 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
       deletePoolActor: AdvancementSheet.#deletePoolDocument,
       deletePoolEffect: AdvancementSheet.#deletePoolDocument,
       deletePoolItem: AdvancementSheet.#deletePoolDocument,
+      deleteSummonEffect: AdvancementSheet.#deleteSummonEffect,
     },
     classes: ["advancement"],
   };
@@ -36,6 +37,7 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
     details: {
       template: "systems/draw-steel/templates/sheets/pseudo-documents/advancement/details.hbs",
       classes: ["tab", "standard-form"],
+      scrollable: [""],
     },
   };
 
@@ -130,5 +132,20 @@ export default class AdvancementSheet extends PseudoDocumentSheet {
     const pool = foundry.utils.deepClone(this.pseudoDocument._source.pool);
     pool.splice(index, 1);
     this.pseudoDocument.update({ pool });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Delete an entry from the summon effects.
+   * @this {AdvancementSheet}
+   * @param {PointerEvent} event    The initiating click event.
+   * @param {HTMLElement} target    The capturing HTML element which defined a [data-action].
+   */
+  static async #deleteSummonEffect(event, target) {
+    const index = Number(target.closest("[data-effects-index]").dataset.effectsIndex);
+    const effects = foundry.utils.deepClone(this.pseudoDocument._source.effects);
+    effects.splice(index, 1);
+    this.pseudoDocument.update({ effects });
   }
 }

--- a/src/module/canvas/layers/tokens.mjs
+++ b/src/module/canvas/layers/tokens.mjs
@@ -69,7 +69,10 @@ export default class DrawSteelTokenLayer extends foundry.canvas.layers.TokenLaye
       await tokenDocument.actor.updateEmbeddedDocuments("ActiveEffect", oldEffects);
       await tokenDocument.actor.createEmbeddedDocuments("ActiveEffect", newEffects, { keepId: true });
     } else {
-      tokenDocument.delta.updateSource(actorUpdates);
+      if (!foundry.utils.isEmpty(actorUpdates)) {
+        tokenDocument.updateSource({ delta: {} });
+        tokenDocument.delta.updateSource(actorUpdates);
+      }
       // Foundry will automatically increment but we need to add in our indices
       if (actor.prototypeToken.appendNumber) {
         const regex = new RegExp(/\((\d+)\)$/);

--- a/src/module/data/actor/_types.d.ts
+++ b/src/module/data/actor/_types.d.ts
@@ -64,7 +64,8 @@ interface Skills {
 export interface SummonPortfolio {
   uuid: string;
   count: string;
-  cost: number | null
+  cost: number | null;
+  advancementUuid: string;
 }
 
 declare module "./base-actor.mjs" {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -933,9 +933,10 @@ export default class AbilityModel extends BaseItemModel {
    * @param {string} uuid               The UUID of the actor to summon. If this points to a compendium actor a copy will be imported.
    * @param {Object} options
    * @param {number} [options.count=1]  How many tokens to summon.
+   * @param {DrawSteelActiveEffect[]} [options.effects] Effects to add to the summoned actors, evaluating based on this actor's roll data.
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
    */
-  async performSummon(uuid, { count = 1 } = {}) {
+  async performSummon(uuid, { count = 1, effects = [] } = {}) {
     /** @type {DrawSteelActor} */
     const sourceActor = await fromUuid(uuid);
 
@@ -956,6 +957,19 @@ export default class AbilityModel extends BaseItemModel {
       }, { keepId: true });
     }
 
-    return canvas.tokens.placeActor(worldActor, { count });
+    const actorUpdates = { effects: [] };
+
+    const replacementData = this.parent.getRollData();
+
+    for (const e of effects) {
+      const data = game.items.fromCompendium(e, { keepId: true, clearFolder: true });
+      for (const change of data.system.changes) {
+        if (typeof change.value !== "string") continue;
+        change.value = DrawSteelActiveEffect.implementation._replaceDataRefs(change.value, replacementData);
+      }
+      actorUpdates.effects.push(data);
+    }
+
+    return canvas.tokens.placeActor(worldActor, { count, actorUpdates });
   }
 }

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -965,7 +965,7 @@ export default class AbilityModel extends BaseItemModel {
       const data = game.items.fromCompendium(e, { keepId: true, clearFolder: true });
       for (const change of data.system.changes) {
         if (typeof change.value !== "string") continue;
-        change.value = DrawSteelActiveEffect.implementation._replaceDataRefs(change.value, replacementData);
+        change.value = DrawSteelActiveEffect._replaceDataRefs(change.value, replacementData);
       }
       actorUpdates.effects.push(data);
     }

--- a/src/module/data/item/advancement.mjs
+++ b/src/module/data/item/advancement.mjs
@@ -80,7 +80,7 @@ export default class AdvancementModel extends BaseItemModel {
       } else if (advancement.type === "summon") {
         const options = advancement.pool
           .filter(o => flags[advancement.id]?.selected.includes(o.uuid))
-          .map(o => ({ ...o, cost: advancement.cost }));
+          .map(o => ({ ...o, cost: advancement.cost, advancementUuid: advancement.uuid }));
         const portfolio = this.actor.system._summonPortfolios[advancement.dsid] ??= [];
         portfolio.push(...options);
       }

--- a/src/module/data/pseudo-documents/advancements/_types.d.ts
+++ b/src/module/data/pseudo-documents/advancements/_types.d.ts
@@ -17,6 +17,11 @@ interface SummonChoicePool {
   count: number;
 }
 
+interface SummonEffectPool {
+  uuid: string;
+  level: number;
+}
+
 export type ActorChoice = {
   /** The UUID of the actor. */
   uuid: string;
@@ -27,7 +32,8 @@ declare module "./summon-choice-advancement.mjs" {
     cost: number;
     /** If `null`, then this is explicitly a "choose all" - but also if the number is equal to or greater than the pool. */
     chooseN: number | null;
-    pool: SummonChoicePool[]
+    pool: SummonChoicePool[];
+    effects: SummonEffectPool[];
   }
 }
 

--- a/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
@@ -2,7 +2,7 @@ import ActorChoiceAdvancement from "./actor-choice-advancement.mjs";
 import { requiredInteger } from "../../helpers.mjs";
 
 /**
- * @import DrawSteelActor from "../../../documents/actor.mjs";
+ * @import { DrawSteelActiveEffect, DrawSteelActor } from "../../../documents/actor.mjs";
  */
 
 const { ArrayField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
@@ -20,6 +20,10 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
         uuid: new DocumentUUIDField({ embedded: false, type: "Actor" }),
         count: requiredInteger({ initial: 2, min: 1 }),
       })),
+      effects: new ArrayField(new SchemaField({
+        uuid: new DocumentUUIDField({ embedded: false, type: "ActiveEffect" }),
+        level: new NumberField({ min: 1, integer: true, max: 10, required: true }),
+      })),
     });
   }
 
@@ -29,6 +33,11 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
   static get TYPE() {
     return "summon";
   }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = super.LOCALIZATION_PREFIXES.concat("DRAW_STEEL.ADVANCEMENT.SUMMON");
 
   /* -------------------------------------------------- */
 
@@ -49,11 +58,19 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
 
     ctx.actorPool = [];
     for (const [i, pool] of this.pool.entries()) {
-      const actor = await fromUuid(pool.uuid);
       ctx.actorPool.push({
         ...pool,
         index: i,
-        link: actor ? actor.toAnchor() : _loc("DRAW_STEEL.ADVANCEMENT.SHEET.unknownActor"),
+        link: ds.utils.createDocumentLink(pool.uuid)?.outerHTML ?? _loc("DRAW_STEEL.ADVANCEMENT.SHEET.unknownActor"),
+      });
+    }
+
+    ctx.summonEffects = [];
+    for (const [i, effect] of this.effects.entries()) {
+      ctx.summonEffects.push({
+        ...effect,
+        index: i,
+        link: ds.utils.createDocumentLink(effect.uuid)?.outerHTML ?? _loc("DRAW_STEEL.ADVANCEMENT.SHEET.unknownEffect"),
       });
     }
 
@@ -63,22 +80,51 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
   /* -------------------------------------------------- */
 
   /**
+   * Process a dropped actor or active effect.
+   * @param {DrawSteelActor | DrawSteelActiveEffect} document
+   * @returns {Promise<DrawSteelActor>}
+   */
+  handleDrop(document) {
+    switch (document.documentName) {
+      case "ActiveEffect": return this.#handleActiveEffectDrop(document);
+      case "Actor": return this.#handleActorDrop(document);
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Process a dropped effect.
+   * @param {DrawSteelActiveEffect} effect
+   */
+  #handleActiveEffectDrop(effect) {
+    if (!effect.pack || effect.parent) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.requireStandaloneSummonEffect", { localize: true });
+    const exists = this.effects.some(k => k.uuid === effect.uuid);
+    if (exists) return;
+
+    const effects = foundry.utils.deepClone(this._source.effects);
+    effects.push({ uuid: effect.uuid });
+    return this.update({ effects });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
    * Process a dropped actor.
    * @param {DrawSteelActor} document
    * @returns {Promise<DrawSteelActor>}
    */
-  handleDrop(document) {
-    if (document.documentName !== "Actor") return;
-
-    if (document.type !== "npc") return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.restrictedTypeSummon", {
-      format: { type: _loc(CONFIG.Actor.typeLabels[document.type]) },
+  #handleActorDrop(actor) {
+    if (actor.type !== "npc") return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.restrictedTypeSummon", {
+      format: { type: _loc(CONFIG.Actor.typeLabels[actor.type]) },
     });
-    if (!document.pack) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.requirePackSummon", { localize: true });
-    const exists = this.pool.some(k => k.uuid === document.uuid);
+    if (!actor.pack) return void ui.notifications.error("DRAW_STEEL.ADVANCEMENT.WARNING.requirePackSummon", { localize: true });
+    const exists = this.pool.some(k => k.uuid === actor.uuid);
     if (exists) return;
 
     const pool = foundry.utils.deepClone(this._source.pool);
-    pool.push({ uuid: document.uuid });
+    pool.push({ uuid: actor.uuid });
     return this.update({ pool });
   }
+
 }

--- a/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
@@ -1,11 +1,10 @@
 import BaseSpecialEffect from "./base-special-effect.mjs";
 import DSDialog from "../../../applications/api/dialog.mjs";
-import { systemID } from "../../../constants.mjs";
 
 /**
- * @import { DrawSteelActor, DrawSteelTokenDocument } from "../../../documents/_module.mjs"
- * @import ActorChoiceAdvancement from "../advancements/actor-choice-advancement.mjs";
+ * @import { DrawSteelActiveEffect, DrawSteelTokenDocument } from "../../../documents/_module.mjs"
  * @import { SummonPortfolio } from "../../actor/_types";
+ * @import SummonChoiceAdvancement from "../advancements/summon-choice-advancement.mjs";
  */
 
 const { createFormGroup, createSelectInput, createNumberInput } = foundry.applications.fields;
@@ -111,12 +110,23 @@ export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
 
     const summonInfo = portfolio.find(o => o.uuid === fd.uuid);
 
+    /** @type {SummonChoiceAdvancement} */
+    const advancement = fromUuidSync(summonInfo.advancementUuid);
+
+    /** @type {DrawSteelActiveEffect[]} */
+    const effects = [];
+    for (const effectInfo of advancement.effects) {
+      if (hero.system.level < effectInfo.level) return;
+      const effect = await fromUuid(effectInfo.uuid);
+      if (effect) effects.push(effect);
+    }
+
     const cost = fd.cost;
 
     // Signature minions have a null count & cost and instead just directly scale with the # summoned
     const count = summonInfo.count ?? fd.count;
 
-    const tokens = await this.parent.performSummon(fd.uuid, { count });
+    const tokens = await this.parent.performSummon(fd.uuid, { count, effects });
 
     if (tokens?.length) {
       await hero.modifyTokenAttribute("hero.primary.value", -cost, true);

--- a/src/styles/system/applications/sheets/pseudo-documents.css
+++ b/src/styles/system/applications/sheets/pseudo-documents.css
@@ -1,12 +1,21 @@
 .draw-steel.advancement {
-  h4.section-header {
-    margin: 0;
-  }
-
   .drop-target-area {
     input[type="number"] {
       flex: 0 0 50px;
       text-align: center;
+    }
+    .summon-effects {
+      display: flex;
+      align-items: center;
+      .column-header {
+        flex: 0 0 50px;
+        text-align: center;
+      }
+      .section-header {
+        font-weight: bold;
+        flex: 1;
+        text-align: center;
+      }
     }
   }
 }

--- a/templates/sheets/pseudo-documents/advancement/details.hbs
+++ b/templates/sheets/pseudo-documents/advancement/details.hbs
@@ -41,10 +41,29 @@
     {{#each ctx.actorPool}}
     <div class="form-group" data-pool-index="{{@index}}">
       <input type="hidden" name="{{concat "pool." @index ".uuid"}}" value="{{uuid}}">
+      {{#if @root.source.cost}}
       {{formInput @root.fields.pool.element.fields.count value=count name=(concat "pool." @index ".count")}}
-      <label>{{{link.outerHTML}}}</label>
+      {{else}}
+      <input type="hidden" name="{{concat "pool." @index ".count"}}" value="{{count}}">
+      {{/if}}
+      <label>{{{link}}}</label>
       <div class="form-fields">
         <button type="button" data-action="deletePoolActor" class="icon fa-solid fa-trash"></button>
+      </div>
+    </div>
+    {{/each}}
+    <hr>
+    <div class="summon-effects" data-tooltip-text="{{@root.fields.effects.hint}}">
+      <div class="column-header">{{@root.fields.effects.element.fields.level.label}}</div>
+      <div class="section-header">{{@root.fields.effects.label}}</div>
+    </div>
+    {{#each ctx.summonEffects}}
+    <div class="form-group" data-effects-index="{{@index}}">
+      <input type="hidden" name="{{concat "effects." @index ".uuid"}}" value="{{uuid}}">
+      {{formInput @root.fields.effects.element.fields.level value=level name=(concat "effects." @index ".level") type="number"}}
+      <label>{{{link}}}</label>
+      <div class="form-fields">
+        <button type="button" data-action="deleteSummonEffect" class="icon fa-solid fa-trash"></button>
       </div>
     </div>
     {{/each}}


### PR DESCRIPTION
Summon Choice advancements can now specify level-gated effects to potentially apply to the summons, based on the summoner's level. This handles both "You use your own characteristics where a minion’s stat block refers to an R or uses a potency (such as m<w)." as well as the 4, 7, and 10 Minion Improvement features.

<img width="450" height="311" alt="image" src="https://github.com/user-attachments/assets/e6ef05bd-b04b-4a81-abb7-8c9b2d123dd3" />
<img width="443" height="151" alt="image" src="https://github.com/user-attachments/assets/2b9df28f-e244-4ab6-bc9b-3995f75d2cd6" />
