### PR TITLE
[#2060] Store and forward spend amounts to enrichment

### DIFF
--- a/src/docs/Roll-Data.md
+++ b/src/docs/Roll-Data.md
@@ -81,7 +81,7 @@ Most actors support the following roll attributes
 
 ### Statuses
 Value indicates if actor currently has status (1/yes, 0/no). Use with multiplication.
-+ Asleep:`@statuses.sleep`
++ Asleep: `@statuses.sleep`
 + Bleeding: `@statuses.bleeding`
 + Burning: `@statuses.burning`
 + Dazed: `@statuses.dazed`
@@ -144,5 +144,5 @@ Value indicates if actor currently has status (1/yes, 0/no). Use with multiplica
 ### Spend Info
 
 The amount of heroic resource/malice spent on an ability is available in both the Power Roll Effect as well as the text for the spend.
-- In the power roll effect, use `@spend.0` to reference the amount spent on the first spend effect, `@spend.0` for the second, etc.
+- In the power roll effect, use `@spend.0` to reference the amount spent on the first spend effect, `@spend.1` for the second, etc.
 - In the text of the individual effect, `@spend` is the amount spent on that effect.

--- a/src/docs/Roll-Data.md
+++ b/src/docs/Roll-Data.md
@@ -80,7 +80,7 @@ Most actors support the following roll attributes
 </details>
 
 ### Statuses
-Value indicates if actor currently has status (1/yes, 0/no)
+Value indicates if actor currently has status (1/yes, 0/no). Use with multiplication.
 + Asleep:`@statuses.sleep`
 + Bleeding: `@statuses.bleeding`
 + Burning: `@statuses.burning`
@@ -139,5 +139,10 @@ Value indicates if actor currently has status (1/yes, 0/no)
 + Ability Power Roll Characteristic: `@item.powerRoll.characteristics`
 + Ability Power Roll Characteristic formula: `@item.powerRoll.formula`
 + Ability Heroic Resource/Malice Cost:`@item.resource`
-+ Ability Additional Heroic Resource/Malice Cost: `@item.spend.value`
 + Number of targets: `@item.target.value`
+
+### Spend Info
+
+The amount of heroic resource/malice spent on an ability is available in both the Power Roll Effect as well as the text for the spend.
+- In the power roll effect, use `@spend.0` to reference the amount spent on the first spend effect, `@spend.0` for the second, etc.
+- In the text of the individual effect, `@spend` is the amount spent on that effect.

--- a/src/module/applications/apps/ability-configuration-dialog.mjs
+++ b/src/module/applications/apps/ability-configuration-dialog.mjs
@@ -186,7 +186,7 @@ export default class AbilityConfigurationDialog extends PowerRollDialog {
       context.resource.name = coreResource.name;
       context.resource.max = foundry.utils.getProperty(coreResource.target, coreResource.path) - coreResource.minimum;
 
-      context.spendConfig = this.item.system.effects.documentsByType.spend.map(e => ({
+      context.spendConfig = this.item.system.effects.documentsByType.spend.toSorted((a, b) => a.sort - b.sort).map(e => ({
         id: e.id,
         multiple: e.resource.multiple,
         value: e.resource.value,

--- a/src/module/data/item/_types.d.ts
+++ b/src/module/data/item/_types.d.ts
@@ -1,6 +1,7 @@
 import { AppliedPowerRollEffect, DamagePowerRollEffect, ForcedMovementPowerRollEffect, OtherPowerRollEffect } from "../pseudo-documents/power-roll-effects/_module.mjs";
 import { BaseSpecialEffect, SpendSpecialEffect } from "../pseudo-documents/special-effect/_module.mjs";
 import { CharacteristicAdvancement, EffectGrantAdvancement, ItemGrantAdvancement, LanguageAdvancement, SkillAdvancement } from "../pseudo-documents/advancements/_module.mjs";
+import { DocumentHTMLEmbedConfig } from "@client/applications/ux/text-editor.mjs";
 import DrawSteelItem from "../../documents/item.mjs";
 import ModelCollection from "../../utils/model-collection.mjs";
 import { PowerRollModifiers } from "../../_types.js";
@@ -35,6 +36,10 @@ export interface EmbedDisplayFlags {
   readonly displayAtEnd?: boolean;
 }
 
+export interface DSItemEmbedConfig extends DocumentHTMLEmbedConfig {
+  includeName?: boolean;
+}
+
 declare module "./base-item.mjs" {
   export default interface BaseItemModel {
     parent: DrawSteelItem;
@@ -51,6 +56,14 @@ declare module "./base-item.mjs" {
 export interface PlaceAbilityOptions extends RegionPlacementOptions {
   /** Whether to update the user's targets based off of tokens included in the region. A falsy value means do not adjust targets. */
   setTargets?: "acquire" | "replace";
+}
+
+export interface AbilityEmbedConfig extends DSItemEmbedConfig {
+  tier1?: boolean;
+  tier2?: boolean;
+  tier3?: boolean;
+  effects?: Set<string>;
+  spendAmounts: Record<string, number>;
 }
 
 declare module "./ability.mjs" {

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -9,10 +9,10 @@ import PowerRoll from "../../rolls/power.mjs";
 import enrichHTML from "../../utils/enrich-html.mjs";
 
 /**
- * @import { DocumentHTMLEmbedConfig, EnrichmentOptions } from "@client/applications/ux/text-editor.mjs";
+ * @import { EnrichmentOptions } from "@client/applications/ux/text-editor.mjs";
  * @import { ApplicationConfiguration } from "@client/applications/_types.mjs";
  * @import { DatabaseCreateOperation } from "@common/abstract/_types.mjs";
- * @import { EmbedDisplayFlags } from "./_types";
+ * @import { AbilityEmbedConfig, EmbedDisplayFlags } from "./_types";
  * @import RegionDocument from "@client/documents/region.mjs";
  * @import { PowerRollModifiers } from "../../_types";
  * @import { PlaceAbilityOptions } from "./_types";
@@ -311,7 +311,7 @@ export default class AbilityModel extends BaseItemModel {
 
   /**
    * @inheritdoc
-   * @param {DocumentHTMLEmbedConfig} config
+   * @param {AbilityEmbedConfig} config
    * @param {EnrichmentOptions} options
    */
   async toEmbed(config, options = {}) {
@@ -333,6 +333,7 @@ export default class AbilityModel extends BaseItemModel {
     if (config.tier2) context.tier2 = true;
     if (config.tier3) context.tier3 = true;
     if (config.effects) context.limitEffects = config.effects;
+    if (config.spendAmounts) context.spendAmounts = config.spendAmounts;
     await this.getSheetContext(context);
     const abilityBody = await foundry.applications.handlebars.renderTemplate(systemPath("templates/embeds/item/ability.hbs"), context);
     embed.insertAdjacentHTML("beforeend", abilityBody);
@@ -488,9 +489,13 @@ export default class AbilityModel extends BaseItemModel {
     context.afterEffects = [];
     for (const effect of this.effects.sortedContents) {
       if (context.limitEffects && !context.limitEffects.has(effect.id)) continue;
+
+      const rollData = {};
+      if (context.spendAmounts) rollData.spend = context.spendAmounts[effect.id];
+
       const displayData = {
         label: effect.label,
-        text: await enrichHTML(effect.description, { relativeTo: this.parent }),
+        text: await enrichHTML(effect.description, { relativeTo: this.parent, rollData }),
       };
       context[effect.before ? "beforeEffects" : "afterEffects"].push(displayData);
     }
@@ -589,6 +594,7 @@ export default class AbilityModel extends BaseItemModel {
               if (e.showUse(fd)) arr.push(e.id);
               return arr;
             }, []),
+            spendAmounts: fd.spend,
           },
         },
       },
@@ -681,7 +687,6 @@ export default class AbilityModel extends BaseItemModel {
     }
 
     let resourceSpend = fd.resource ?? 0;
-
     for (const spend of Object.values(fd.spend ?? {})) resourceSpend += spend;
 
     if (resourceSpend) {

--- a/src/module/data/pseudo-documents/message-parts/_types.d.ts
+++ b/src/module/data/pseudo-documents/message-parts/_types.d.ts
@@ -1,5 +1,5 @@
-import { DrawSteelChatMessage } from "../../../documents/_module.mjs";
 import DSRoll from "../../../rolls/base.mjs";
+import { DrawSteelChatMessage } from "../../../documents/_module.mjs";
 import StandardModel from "../../message/standard.mjs";
 
 declare module "./ability-result.mjs" {
@@ -12,6 +12,8 @@ declare module "./ability-result.mjs" {
 declare module "./ability-use.mjs" {
   export default interface AbilityUse {
     abilityUuid: string;
+    effects: Set<string>;
+    spendAmounts: Record<string, number>;
   }
 }
 

--- a/src/module/data/pseudo-documents/message-parts/ability-use.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-use.mjs
@@ -7,7 +7,7 @@ import { systemPath } from "../../../constants.mjs";
  * @import AbilityData from "../../item/ability.mjs";
  */
 
-const { DocumentUUIDField, SetField } = foundry.data.fields;
+const { DocumentUUIDField, NumberField, SetField, TypedObjectField } = foundry.data.fields;
 
 /**
  * A part that displays the main text of the ability.
@@ -39,6 +39,7 @@ export default class AbilityUsePart extends BaseMessagePart {
     return Object.assign(super.defineSchema(), {
       abilityUuid: new DocumentUUIDField({ nullable: false, type: "Item" }),
       effects: new SetField(setOptions({ validate: foundry.data.validators.isValidId })),
+      spendAmounts: new TypedObjectField(new NumberField()),
     });
   }
 
@@ -78,7 +79,9 @@ export default class AbilityUsePart extends BaseMessagePart {
       tier2: false,
       tier3: false,
       effects: this.effects,
+      spendAmounts: this.spendAmounts,
     };
+
     context.ctx.embed = await item.toEmbed(embedConfig);
 
     if (item.isOwner && item.system.hasTemplate) {

--- a/src/module/utils/enrich-html.mjs
+++ b/src/module/utils/enrich-html.mjs
@@ -12,7 +12,8 @@ export default async function enrichHTML(content, options = {}) {
   if (options.relativeTo) {
     // Don't reveal secrets of unowned documents, but allow explicit false to prevent sharing secrets of owned documents
     if (options.secrets !== false) options.secrets = options.relativeTo.isOwner;
-    if (typeof options.relativeTo.getRollData === "function") options.rollData = options.relativeTo.getRollData();
+    // Allow possibly passing in extra roll data like `@spend`
+    if (typeof options.relativeTo.getRollData === "function") Object.assign(options.rollData ?? {}, options.relativeTo.getRollData());
   }
   return foundry.applications.ux.TextEditor.implementation.enrichHTML(content, options);
 }


### PR DESCRIPTION
- Ability Use messages now store the amount of each spend
- This info is forwarded to enrichment
- This required a slight adjustment to our `enrichHTML` utility method to only override properties rather than fully clobber the incoming `rollData`. This should be safe within our own logic but theoretically has side effects if people were passing in roll data they expected to be fully clobbered.

<img width="294" height="568" alt="image" src="https://github.com/user-attachments/assets/7ac3974a-4f87-4fc8-99db-f58ccecf4697" />

Closes #2060