### PR TITLE
Fixed saving throw message construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Increased foundry minimum to 14.367.
   - Fixed With Captain effect on Dwarf Driver. (#2062)
 - Updating an actor's size will now also update their prototype token's depth, in addition to height and width. (#2024)
 - Deleting an entry from a configuration page now works correctly. (#2042)
+- Fixed saving throw rolls not properly being contained in a saving throw message part.
 
 ## 1.1.2
 

--- a/src/module/data/effect/_types.d.ts
+++ b/src/module/data/effect/_types.d.ts
@@ -2,7 +2,7 @@ import { DrawSteelActiveEffect, DrawSteelCombat } from "../../documents/_module.
 import { AbilityFilters } from "../_types";
 import { EffectChangeData } from "@common/documents/_types.mjs";
 
-declare module "./base.mjs" {
+declare module "./base-effect.mjs" {
   export default interface BaseEffectModel {
     parent: DrawSteelActiveEffect;
     changes: EffectChangeData[];

--- a/src/module/data/effect/base-effect.mjs
+++ b/src/module/data/effect/base-effect.mjs
@@ -122,8 +122,6 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
     if (rollConfig.situationalBonus) formula += ` + ${rollConfig.situationalBonus}`;
     rollOptions.successThreshold = rollConfig.successThreshold;
 
-    messageOptions.messageMode = messageMode;
-
     const roll = new SavingThrowRoll(formula, rollData, rollOptions);
 
     await roll.evaluate();
@@ -134,7 +132,9 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
 
     const savingThrowId = "savingThrow".padEnd(16, "0");
 
-    foundry.utils.mergeObject(messageData, {
+    DrawSteelChatMessage.applyMode(messageData, messageMode);
+
+    const finalMessageData = foundry.utils.mergeObject({
       rolls: [roll],
       type: "standard",
       system: {
@@ -143,13 +143,19 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
             _id: savingThrowId,
             type: "savingThrow",
             effectUuid: this.parent.uuid,
+            flavor: this.parent.name,
             rolls: [roll],
           },
         },
       },
-    });
+      author: game.user.id,
+      sound: CONFIG.sounds.dice,
+      speaker: DrawSteelChatMessage.getSpeaker({ actor: this.parent.actor }),
+      title: this.parent.name,
+      flags: { core: { canPopout: true } },
+    }, messageData);
 
-    return roll.toMessage(messageData, messageOptions);
+    return DrawSteelChatMessage.create(finalMessageData, messageOptions);
   }
 
   /* -------------------------------------------------- */

--- a/src/module/rolls/project.mjs
+++ b/src/module/rolls/project.mjs
@@ -1,9 +1,5 @@
 import DSRoll from "./base.mjs";
-import DrawSteelChatMessage from "../documents/chat-message.mjs";
-import PowerRollDialog from "../applications/apps/power-roll-dialog.mjs";
 import { systemPath } from "../constants.mjs";
-
-/** @import { RollPromptOptions, ProjectRollPrompt } from "../_types.js" */
 
 /**
  * A special test a hero makes while working on a downtime project during a respite.


### PR DESCRIPTION
Turns out our refactor in a previous release fucked up how we generated saving throw messages. I'm frankly shocked this wasn't reported it broke the hero token button display.