### PR TITLE
[#583] Added summoning button to ability use messages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2514,7 +2514,8 @@
       },
       "PARTS": {
         "abilityUse": {
-          "performTest": "{characteristic} Test"
+          "performTest": "{characteristic} Test",
+          "performSummon": "Summon"
         },
         "savingThrow": {
           "Buttons": {

--- a/src/module/data/pseudo-documents/message-parts/ability-use.mjs
+++ b/src/module/data/pseudo-documents/message-parts/ability-use.mjs
@@ -25,6 +25,7 @@ export default class AbilityUsePart extends BaseMessagePart {
     ...super.ACTIONS,
     rollTest: this.#rollTest,
     placeTemplate: this.#placeTemplate,
+    performSummon: this.#performSummon,
   };
 
   /* -------------------------------------------------- */
@@ -105,6 +106,12 @@ export default class AbilityUsePart extends BaseMessagePart {
         }));
       }
     }
+
+    for (const effectId of this.effects) {
+      const specialEffect = item.system.effects.get(effectId);
+      const buttons = specialEffect.constructButtons();
+      if (buttons) context.ctx.buttons.push(...buttons);
+    }
   }
 
   /* -------------------------------------------------- */
@@ -135,5 +142,21 @@ export default class AbilityUsePart extends BaseMessagePart {
    */
   static async #placeTemplate(event, target) {
     this.ability.system.placeTemplate();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Perform a given effect's summoning.
+   * @this AbilityUsePart
+   * @param {PointerEvent} event   The originating click event.
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action].
+   */
+  static async #performSummon(event, target) {
+    const item = this.ability;
+    if (!item) return void console.error("Source item no longer exists!");
+    const { specialEffectId } = target.dataset;
+    const specialEffect = item.system.effects.get(specialEffectId);
+    await specialEffect.performSummon();
   }
 }

--- a/src/module/data/pseudo-documents/special-effect/base-special-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/base-special-effect.mjs
@@ -80,4 +80,14 @@ export default class BaseSpecialEffect extends TypedPseudoDocument {
   showUse(formData) {
     return true;
   }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Constructs buttons for an Ability Use chat message.
+   * @returns {HTMLButtonElement[] | null} An array of buttons to add to the footer of the message, or null if there are none.
+   */
+  constructButtons() {
+    return null;
+  }
 }

--- a/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
@@ -21,6 +21,20 @@ export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  constructButtons() {
+    return [ds.utils.constructHTMLButton({
+      label: _loc("DRAW_STEEL.ChatMessage.PARTS.abilityUse.performSummon"),
+      icon: "fa-solid fa-transporter-2",
+      dataset: {
+        specialEffectId: this.id,
+        action: "performSummon",
+      },
+    })];
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Places summons.
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.

--- a/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/summon-effect.mjs
@@ -40,6 +40,20 @@ export default class SummonSpecialEffect extends BaseSpecialEffect {
 
   /* -------------------------------------------------- */
 
+  /** @inheritdoc */
+  constructButtons() {
+    return [ds.utils.constructHTMLButton({
+      label: _loc("DRAW_STEEL.ChatMessage.PARTS.abilityUse.performSummon"),
+      icon: "fa-solid fa-transporter-2",
+      dataset: {
+        specialEffectId: this.id,
+        action: "performSummon",
+      },
+    })];
+  }
+
+  /* -------------------------------------------------- */
+
   /**
    * Places summons.
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.

--- a/templates/sidebar/chat/parts/ability-use.hbs
+++ b/templates/sidebar/chat/parts/ability-use.hbs
@@ -1,6 +1,7 @@
 <div class="message-part-html">
   {{{ctx.embed.outerHTML}}}
 </div>
+{{log ctx.buttons}}
 {{#if ctx.buttons}}
 <footer class="message-part-buttons">
   {{#each ctx.buttons as |button|}}{{{button.outerHTML}}}{{/each}}

--- a/templates/sidebar/chat/parts/ability-use.hbs
+++ b/templates/sidebar/chat/parts/ability-use.hbs
@@ -1,7 +1,6 @@
 <div class="message-part-html">
   {{{ctx.embed.outerHTML}}}
 </div>
-{{log ctx.buttons}}
 {{#if ctx.buttons}}
 <footer class="message-part-buttons">
   {{#each ctx.buttons as |button|}}{{{button.outerHTML}}}{{/each}}


### PR DESCRIPTION
I think we're in the home stretch. This implements a generalized way for special effects to add buttons, taken advantage of by our new summoning effects. Like most data-action tricks, modules just need to add to the part's `static ACTIONS`

<img width="292" height="278" alt="image" src="https://github.com/user-attachments/assets/006d2ddd-ca05-41a7-8638-a3cdcc607707" />
