### PR TITLE
[#2073] Summoner Echelon 2 features 

### DIFF
--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Shaping_t9UuZY6U3Urrqdc5.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Shaping_t9UuZY6U3Urrqdc5.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "34",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "shaping",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Shaping_t9UuZY6U3Urrqdc5.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Shaping_t9UuZY6U3Urrqdc5.json
@@ -1,0 +1,43 @@
+{
+  "folder": "wCFV3Thp2tIrZ4lR",
+  "name": "Shaping",
+  "type": "feature",
+  "_id": "t9UuZY6U3Urrqdc5",
+  "img": "icons/magic/unholy/hands-circle-light-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can spend 1 uninterrupted minute to perform a ritual that causes one of your minions to fold their shape and disguise themself to look like a duplicate of you, including speaking basic Caelian, allowing them to (potentially) freely move through civilization while completing their tasks. You can have a number of minions disguised at the same time equal to [[lookup @R]]{your Reason score}.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "shaping",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470219691,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!t9UuZY6U3Urrqdc5"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Soul_Flense_awtcSXvQnCE9B8oq.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Soul_Flense_awtcSXvQnCE9B8oq.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "34",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "soul-flense",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Soul_Flense_awtcSXvQnCE9B8oq.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Blight_wCFV3Thp2tIrZ4lR/feature_Soul_Flense_awtcSXvQnCE9B8oq.json
@@ -1,0 +1,43 @@
+{
+  "folder": "wCFV3Thp2tIrZ4lR",
+  "name": "Soul Flense",
+  "type": "feature",
+  "_id": "awtcSXvQnCE9B8oq",
+  "img": "icons/magic/unholy/hand-light-pink.webp",
+  "system": {
+    "description": {
+      "value": "<p>As a maneuver, you can command one or more of your demon minions to each deal damage equal to their free strike value to an adjacent ally. This damage can't be reduced. The ally then ends a condition affecting them and confers it to the demon that attacked them.</p><p>Additionally, whenever one of your demon minions Death Snaps, their target is [[potency P WEAK]] affected by a condition the minion was suffering from. The potency increases by 1 on each subsequent Death Snap the target takes damage from in the same turn (maximum +2).</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "soul-flense",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470302072,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!awtcSXvQnCE9B8oq"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Channel_gTyZHrSnBjw3hwij.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Channel_gTyZHrSnBjw3hwij.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JWReLw3CCg9VVdKI",
+  "name": "Channel",
+  "type": "feature",
+  "_id": "gTyZHrSnBjw3hwij",
+  "img": "icons/magic/death/skeleton-skull-soul-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can spend 1 uninterrupted minute to perform a ritual and use your body as a host for a willing spirit of a creature who died in the area. While hosting the spirit, you have access to their memories of the 24 hours leading up to their death and any skills they knew in life. You can also magically change your appearance to look like them while they were alive.</p><p>You can attempt to stop channeling the spirit at any time. If the spirit is hostile to you or you've hosted them for at least 1 hour, you must make a medium Presence test. On success, the spirit leaves your body. On failure, you become fully possessed by a haunt; you have no access to your skills and you can't get above a tier 2 result on power rolls until you exorcise the haunt either by completing the @UUID[Compendium.draw-steel.rewards.Item.gqsR0OwsCIYyb84R]{Find a Cure} downtime project in Draw Steel: Heroes or taking a respite with an exorcist.</p><p>After you stop channeling their spirit, you can't use this feature to channel the same creature again.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "channel",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470394034,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!gTyZHrSnBjw3hwij"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Channel_gTyZHrSnBjw3hwij.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Channel_gTyZHrSnBjw3hwij.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "33",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "channel",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Dread_March_GxBC2JNudZ0MOe4t.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Dread_March_GxBC2JNudZ0MOe4t.json
@@ -1,0 +1,43 @@
+{
+  "folder": "JWReLw3CCg9VVdKI",
+  "name": "Dread March",
+  "type": "feature",
+  "_id": "GxBC2JNudZ0MOe4t",
+  "img": "icons/magic/death/undead-skeleton-deformed-red.webp",
+  "system": {
+    "description": {
+      "value": "<p>You and your undead minions don't spend additional speed to move through difficult terrain. If one or more of your undead minions would die while using their move action, they can choose to not die until the end of your turn.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "dread-march",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470484029,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!GxBC2JNudZ0MOe4t"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Dread_March_GxBC2JNudZ0MOe4t.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Graves_JWReLw3CCg9VVdKI/feature_Dread_March_GxBC2JNudZ0MOe4t.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "33",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "dread-march",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Flash_Powder_HNyrR7TdYrFEuv7z.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Flash_Powder_HNyrR7TdYrFEuv7z.json
@@ -1,0 +1,103 @@
+{
+  "folder": "98RDMwbeC32dWWgN",
+  "name": "Flash Powder",
+  "type": "feature",
+  "_id": "HNyrR7TdYrFEuv7z",
+  "img": "icons/tools/laboratory/mortar-powder-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>Each ally that gains temporary Stamina from your Pixie Dust feature also gains one of the following effects until the end of their next turn (or for 10 minutes if used outside of combat):</p><ul><li><p>[[/apply 7eR2d2xOfIigi7gG]]{Flight}: Their speed gains the Fly keyword.</p></li><li><p> [[/apply invisible turn]]{Vanish}: They become invisible.</p></li><li><p>Water Weird: As a free maneuver once per turn, they can teleport to a body of water within 5 squares of them.</p></li><li><p>Panacea: They can end one condition affecting them or stand up.</p></li></ul>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "flash-powder",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Pixie Flight",
+      "img": "icons/tools/laboratory/mortar-powder-green.webp",
+      "type": "base",
+      "origin": "Compendium.draw-steel.classes.Item.HNyrR7TdYrFEuv7z",
+      "transfer": false,
+      "_id": "7eR2d2xOfIigi7gG",
+      "system": {
+        "changes": [
+          {
+            "key": "system.movement.types",
+            "type": "add",
+            "value": "fly",
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": "turnEnd",
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1788470659633,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!HNyrR7TdYrFEuv7z.7eR2d2xOfIigi7gG"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470578919,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!HNyrR7TdYrFEuv7z"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Flash_Powder_HNyrR7TdYrFEuv7z.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Flash_Powder_HNyrR7TdYrFEuv7z.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "33",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "flash-powder",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Pixie_Lift_baGj8rtP2XpsNY3F.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Pixie_Lift_baGj8rtP2XpsNY3F.json
@@ -39,9 +39,9 @@
             "priority": null
           },
           {
-            "key": "system.movement.types",
-            "type": "add",
-            "value": "hover",
+            "key": "system.movement.hover",
+            "type": "override",
+            "value": true,
             "phase": "initial",
             "priority": null
           }

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Pixie_Lift_baGj8rtP2XpsNY3F.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Pixie_Lift_baGj8rtP2XpsNY3F.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "34",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "pixie-lift",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Pixie_Lift_baGj8rtP2XpsNY3F.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Spring_98RDMwbeC32dWWgN/feature_Pixie_Lift_baGj8rtP2XpsNY3F.json
@@ -1,0 +1,110 @@
+{
+  "folder": "98RDMwbeC32dWWgN",
+  "name": "Pixie Lift",
+  "type": "feature",
+  "_id": "baGj8rtP2XpsNY3F",
+  "img": "icons/creatures/abilities/wings-birdlike-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Your speed gains the Fly and Hover keywords. You lose the Hover keyword from this feature while you are dazed, dying, or you fly more than 1 square above the surface of the ground.</p><p>If your speed previously had the Fly keyword, you can now fly while sneaking an additional number of squares equal to your Reason.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "pixie-lift",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [
+    {
+      "name": "Pixie Lift",
+      "img": "icons/creatures/abilities/wings-birdlike-blue.webp",
+      "type": "base",
+      "origin": "Compendium.draw-steel.classes.Item.baGj8rtP2XpsNY3F",
+      "_id": "6DvtXZJ4gKigjkz2",
+      "system": {
+        "changes": [
+          {
+            "key": "system.movement.types",
+            "type": "add",
+            "value": "fly",
+            "phase": "initial",
+            "priority": null
+          },
+          {
+            "key": "system.movement.types",
+            "type": "add",
+            "value": "hover",
+            "phase": "initial",
+            "priority": null
+          }
+        ],
+        "end": {
+          "roll": "1d10 + @combat.save.bonus"
+        },
+        "project": {
+          "prerequisites": "",
+          "source": "",
+          "rollCharacteristic": [],
+          "yield": {
+            "kind": "weapon",
+            "amount": "1",
+            "display": ""
+          }
+        }
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.367",
+        "systemId": "draw-steel",
+        "systemVersion": "1.2",
+        "createdTime": 1788471188767,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "_key": "!items.effects!baGj8rtP2XpsNY3F.6DvtXZJ4gKigjkz2"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788471134951,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!baGj8rtP2XpsNY3F"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Nature_Watch_QItrCBwuQaIg2L7k.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Nature_Watch_QItrCBwuQaIg2L7k.json
@@ -1,0 +1,43 @@
+{
+  "folder": "ukLUk8SWVtTuI7eq",
+  "name": "Nature Watch",
+  "type": "feature",
+  "_id": "QItrCBwuQaIg2L7k",
+  "img": "icons/magic/nature/stealth-hide-eyes-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can spend 1 uninterrupted minute each day to perform a ritual and summon a special elemental mote called a beacon to patrol the area. This mote telepathically communicates any hostile creatures, hazards, or traps within 20 squares of them to you no matter how far away you are. You know the number of nearby hazards and which direction they're in relative to where the beacon is, but not their exact position. You can have a number of beacons active equal to [[lookup @level]]{your level}</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "nature-watch",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788471263377,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!QItrCBwuQaIg2L7k"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Nature_Watch_QItrCBwuQaIg2L7k.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Nature_Watch_QItrCBwuQaIg2L7k.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "33",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "nature-watch",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Split_hjzQ0X74fU1S3wyZ.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Split_hjzQ0X74fU1S3wyZ.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "34",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "shaping",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Split_hjzQ0X74fU1S3wyZ.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/Circle_of_Storms_ukLUk8SWVtTuI7eq/feature_Split_hjzQ0X74fU1S3wyZ.json
@@ -1,0 +1,43 @@
+{
+  "folder": "ukLUk8SWVtTuI7eq",
+  "name": "Split",
+  "type": "feature",
+  "_id": "hjzQ0X74fU1S3wyZ",
+  "img": "icons/magic/water/pseudopod-swirl-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Once during your turn, you can use a free maneuver to deal damage to one of your elemental minions equal to half their maximum Stamina in order to create one additional copy of that minion in an adjacent unoccupied space and add them to their squad, even if you're at your minion maximum. You can't use this feature if it would kill one or more of the minions in the squad.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "shaping",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788471346580,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!hjzQ0X74fU1S3wyZ"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Essence_Salvage_d3ulV2Amw6cT3UiX.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Essence_Salvage_d3ulV2Amw6cT3UiX.json
@@ -1,0 +1,43 @@
+{
+  "folder": "5RSLtzlfFq7oEHaM",
+  "name": "Essence Salvage",
+  "type": "feature",
+  "_id": "d3ulV2Amw6cT3UiX",
+  "img": "icons/magic/symbols/runes-star-magenta.webp",
+  "system": {
+    "description": {
+      "value": "<p>The first time each combat round that any minion unwillingly dies within your Summoner's Range, you [[/gain 2 hr]]{gain 2 essence} instead of 1.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "33",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "essence-salvage",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470103956,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 600000,
+  "_key": "!items!d3ulV2Amw6cT3UiX"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Essence_bpmpevbhJM9m3dS6.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Essence_bpmpevbhJM9m3dS6.json
@@ -38,6 +38,6 @@
     "duplicateSource": null,
     "exportSource": null
   },
-  "sort": 0,
+  "sort": 400000,
   "_key": "!items!bpmpevbhJM9m3dS6"
 }

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Kit_Improvement___Level_6_b5KLYFSMETwF0Jeh.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Kit_Improvement___Level_6_b5KLYFSMETwF0Jeh.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "33",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "kit-improvement-level-6",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Kit_Improvement___Level_6_b5KLYFSMETwF0Jeh.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Kit_Improvement___Level_6_b5KLYFSMETwF0Jeh.json
@@ -1,0 +1,43 @@
+{
+  "folder": "5RSLtzlfFq7oEHaM",
+  "name": "Kit Improvement - Level 6",
+  "type": "feature",
+  "_id": "b5KLYFSMETwF0Jeh",
+  "img": "icons/weapons/wands/wand-gem-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever you reduce an enemy to 0 Stamina with your Summoner Strike ability, you can use Call Forth as a free maneuver. Minions summoned this way are unable to act during this turn.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "kit-improvement-level-6",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788471629332,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "_key": "!items!b5KLYFSMETwF0Jeh"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minion_Chain_XhbUQ3YuC5166bS6.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minion_Chain_XhbUQ3YuC5166bS6.json
@@ -1,0 +1,43 @@
+{
+  "folder": "5RSLtzlfFq7oEHaM",
+  "name": "Minion Chain",
+  "type": "feature",
+  "_id": "XhbUQ3YuC5166bS6",
+  "img": "icons/magic/control/debuff-chains-blue.webp",
+  "system": {
+    "description": {
+      "value": "<p>Whenever you use Minion Bridge as a maneuver, each of your minions within [[lookup 5+@R]]{your Summoner's Range} can shift up to their speed before the maneuver takes effect, as long as each minion that shifts ends their movement adjacent to another one of your minions.</p><p>Additionally, your minions can chain themselves together to function as a ladder or a swinging rope. When your minions move as a part of using Minion Bridge, each minion can use this movement to shift into a position directly beneath another one of your minions, hoisting them and each other minion they have hoisted, until they form a chain. The chain can then choose to fall across an unoccupied space and/or the topmost minion grabs an object to keep the chain steady.</p><p>The chain lasts until the start of your next turn or until the chain is no longer steady. The chain can also end when a minion in the chain is destroyed or when you command your minions to let go as a free maneuver. All size 1 minions count as one square when determining the chain's length.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "Summoner",
+      "page": "33",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-chain",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788470125554,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 500000,
+  "_key": "!items!XhbUQ3YuC5166bS6"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minion_Machinations_Y8DMj8KKnZ3E5jgY.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minion_Machinations_Y8DMj8KKnZ3E5jgY.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "39",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "minion-machinations",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minion_Machinations_Y8DMj8KKnZ3E5jgY.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minion_Machinations_Y8DMj8KKnZ3E5jgY.json
@@ -1,0 +1,43 @@
+{
+  "folder": "5RSLtzlfFq7oEHaM",
+  "name": "Minion Machinations",
+  "type": "feature",
+  "_id": "Y8DMj8KKnZ3E5jgY",
+  "img": "icons/magic/unholy/silhouette-robe-evil-power.webp",
+  "system": {
+    "description": {
+      "value": "<p>Your maximum number of followers increases by 2.</p><p>You can summon and recruit an artisan follower and a sage follower that share a keyword with a minion you can summon. These followers can be creatures from your portfolio or preexisting denizens of your circle's source manifold. See Follower Types under Attract Followers in Draw Steel: Heroes for information on constructing your followers' stats.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "minion-machinations",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788471475888,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 0,
+  "_key": "!items!Y8DMj8KKnZ3E5jgY"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minions_M1nvpPDxewehEK0b.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Minions_M1nvpPDxewehEK0b.json
@@ -58,6 +58,6 @@
     "duplicateSource": null,
     "exportSource": null
   },
-  "sort": 0,
+  "sort": 200000,
   "_key": "!items!M1nvpPDxewehEK0b"
 }

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Return_to_the_Source_k4wWB8OMKPt6ImgP.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Return_to_the_Source_k4wWB8OMKPt6ImgP.json
@@ -1,0 +1,43 @@
+{
+  "folder": "5RSLtzlfFq7oEHaM",
+  "name": "Return to the Source",
+  "type": "feature",
+  "_id": "k4wWB8OMKPt6ImgP",
+  "img": "icons/magic/time/arrows-circling-green.webp",
+  "system": {
+    "description": {
+      "value": "<p>You can translate yourself and your allies into the space that your minions come from, as if summoning in reverse.</p><p>When you take a respite, you teleport to your circle's source manifold or point of origin, as shown on the Circle's Source Manifold table. You can bring along any allies to gather resources or research details about that location's denizens. You are seen as a native resident of the location, but your allies might be seen as intruders.</p><p>At the end of the respite, you and everyone you brought with you immediately teleports back into the same location from which you made the portal.</p>",
+      "director": ""
+    },
+    "source": {
+      "book": "",
+      "page": "",
+      "license": "Draw Steel Creator License"
+    },
+    "_dsid": "return-to-the-source",
+    "advancements": {},
+    "prerequisites": {
+      "value": "",
+      "dsid": [],
+      "level": null
+    }
+  },
+  "effects": [],
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "14.367",
+    "systemId": "draw-steel",
+    "systemVersion": "1.2",
+    "createdTime": 1788471540743,
+    "modifiedTime": null,
+    "lastModifiedBy": null,
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null
+  },
+  "sort": 0,
+  "_key": "!items!k4wWB8OMKPt6ImgP"
+}

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Return_to_the_Source_k4wWB8OMKPt6ImgP.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Return_to_the_Source_k4wWB8OMKPt6ImgP.json
@@ -10,8 +10,8 @@
       "director": ""
     },
     "source": {
-      "book": "",
-      "page": "",
+      "book": "Summoner",
+      "page": "39",
       "license": "Draw Steel Creator License"
     },
     "_dsid": "return-to-the-source",

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Summoner_s_Dominion_b18SPv6xoCkQ8B69.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Summoner_s_Dominion_b18SPv6xoCkQ8B69.json
@@ -38,6 +38,6 @@
     "duplicateSource": null,
     "exportSource": null
   },
-  "sort": 0,
+  "sort": 300000,
   "_key": "!items!b18SPv6xoCkQ8B69"
 }

--- a/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Summoner_s_Kit_9FF5MeuFsNEsTBMt.json
+++ b/src/packs/classes/Summoner_TrLqPlP21S4pdZr2/Features_5RSLtzlfFq7oEHaM/feature_Summoner_s_Kit_9FF5MeuFsNEsTBMt.json
@@ -38,6 +38,6 @@
     "duplicateSource": null,
     "exportSource": null
   },
-  "sort": 0,
+  "sort": 100000,
   "_key": "!items!9FF5MeuFsNEsTBMt"
 }


### PR DESCRIPTION
Second Echelon Features for the Summoner. Things to consider:
- No easy way to add more text to the Summoner's Strike. Open to suggestions.
- Return to the Source simply refers to the table, as it's mostly fluff.