### PR TITLE
[#1093] Ability Modifier matching by DSID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Increased foundry minimum to 14.367.
   - Added new Companions and Summons advancement type to integrate with summoning. (#584)
   - Added new Summoning and Portfolio Summoning special effects. (#2021)
 - Added a new Minion Sheet. You can switch to this for any NPC but it is optimized for minions. (#585)
+- Ability modifiers can now target specific abilities by their DSID. (#1093)
 - Added support for specifying the number of minions joining in a squad attack. (#1320)
 - Added new header button to repick items granted by advancements. (#1513)
 - Resource growth over a turn is now tracked under `system.hero.primary.tracking`. (#1871)

--- a/lang/en.json
+++ b/lang/en.json
@@ -2065,7 +2065,11 @@
             "label": "Filters",
             "keywords": {
               "label": "Keywords",
-              "hint": "All keywords that an ability must have to receive these modifications."
+              "hint": "All keywords that an ability must have to receive these modifications. If this is empty all abilities will be affected."
+            },
+            "dsid": {
+              "label": "DSID",
+              "hint": "Specific abilities to adjust, matching by DSID. If the keyword filters are empty then abilities not listed here will not be affected."
             }
           }
         }

--- a/src/module/data/_types.d.ts
+++ b/src/module/data/_types.d.ts
@@ -13,6 +13,7 @@ import "./settings/_types";
 
 export type AbilityFilters = {
   keywords: Set<string>;
+  dsid: Set<string>;
 };
 
 export type AbilityBonus = foundry.documents.types.EffectChangeData & {

--- a/src/module/data/effect/ability-modifier.mjs
+++ b/src/module/data/effect/ability-modifier.mjs
@@ -32,6 +32,7 @@ export default class AbilityModifier extends BaseEffectModel {
 
     schema.filters = new fields.SchemaField({
       keywords: new fields.SetField(setOptions()),
+      dsid: new fields.SetField(setOptions()),
     });
 
     return schema;

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -15,6 +15,7 @@ import enrichHTML from "../../utils/enrich-html.mjs";
  * @import { AbilityEmbedConfig, EmbedDisplayFlags } from "./_types";
  * @import RegionDocument from "@client/documents/region.mjs";
  * @import { PowerRollModifiers } from "../../_types";
+ * @import { AbilityBonus } from "../_types";
  * @import { PlaceAbilityOptions } from "./_types";
  * @import DrawSteelToken from "../../canvas/placeables/token.mjs";
  * @import { DrawSteelActor, DrawSteelTokenDocument } from "../../documents/_module.mjs";
@@ -223,8 +224,14 @@ export default class AbilityModel extends BaseItemModel {
       this.keywords.add(bonus.value);
     }
 
-    for (const bonus of (this.actor.system._abilityBonuses ?? [])) {
-      if (!bonus.filters.keywords.isSubsetOf(this.keywords)) continue;
+    for (const bonus of /** @type {AbilityBonus[]} */ (this.actor.system._abilityBonuses ?? [])) {
+      // Specifically targeted abilities are always affected
+      if (!bonus.filters.dsid.has(this.parent.dsid)) {
+        // Keyword filter can be additive to the DSID matching.
+        if (!bonus.filters.keywords.isSubsetOf(this.keywords)) continue;
+        // If there's no keyword filters, then we only care about the DSID matching.
+        else if (!bonus.filters.keywords.size && bonus.filters.dsid.size) continue;
+      }
 
       if (bonus.key === "distance") {
         // All distance value fields are structured identically so the field can be used regardless of which it actually modifies

--- a/templates/sheets/active-effect/details.hbs
+++ b/templates/sheets/active-effect/details.hbs
@@ -4,6 +4,7 @@
   <fieldset class="filters">
     <legend>{{localize "DRAW_STEEL.ActiveEffect.Filters"}}</legend>
     {{formGroup systemFields.filters.fields.keywords value=source.system.filters.keywords options=keywordOptions}}
+    {{formGroup systemFields.filters.fields.dsid value=source.system.filters.dsid}}
   </fieldset>
   {{/if}}
   {{formGroup fields.description value=source.description rootId=rootId}}


### PR DESCRIPTION
Added new filter field to Ability Modifiers so they can target specific abilities, e.g. "You gain an edge on the Grab and Knockback maneuvers"

<img width="526" height="242" alt="image" src="https://github.com/user-attachments/assets/65a98c25-323d-4519-b289-3d274237fa8c" />

Closes #1093