### PR TITLE
[#702] Added suppression logic for HR levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Increased foundry minimum to 14.367.
   - Added new Companions and Summons advancement type to integrate with summoning. (#584)
   - Added new Summoning and Portfolio Summoning special effects. (#2021)
 - Added a new Minion Sheet. You can switch to this for any NPC but it is optimized for minions. (#585)
+- Added suppression logic based on heroic resource quantities (e.g. the Null's Discipline Mastery). (#702)
 - Added support for specifying the number of minions joining in a squad attack. (#1320)
 - Added new header button to repick items granted by advancements. (#1513)
 - Resource growth over a turn is now tracked under `system.hero.primary.tracking`. (#1871)

--- a/lang/en.json
+++ b/lang/en.json
@@ -1944,6 +1944,7 @@
     "ActiveEffect": {
       "Name": "Effect",
       "Filters": "Filters",
+      "Requirements": "Requirements",
       "StatusConditions": "Status Conditions",
       "ComplexStatus": "This condition cannot be toggled here because it is added by a non-standard effect. Open the actor sheet to adjust.",
       "Source": "Source",
@@ -2029,6 +2030,12 @@
             },
             "roll": {
               "label": "Saving Throw Formula"
+            }
+          },
+          "requirements": {
+            "resource": {
+              "label": "Resources",
+              "hint": "If a hero has less of their heroic resource than this the effect will be suppressed."
             }
           },
           "project": {

--- a/src/module/data/actor/hero.mjs
+++ b/src/module/data/actor/hero.mjs
@@ -455,10 +455,11 @@ export default class HeroModel extends CreatureModel {
     if (classModel) minimum = ds.utils.evaluateFormula(classModel.minimum, classModel.parent.getRollData());
 
     return {
-      name: this.class?.system.primary ?? _loc("DRAW_STEEL.Actor.hero.FIELDS.hero.primary.value.label"),
+      minimum,
+      name: this.hero.primary.label,
       target: this.parent,
       path: "system.hero.primary.value",
-      minimum,
+      tracking: this.hero.primary.tracking,
     };
   }
 

--- a/src/module/data/effect/_types.d.ts
+++ b/src/module/data/effect/_types.d.ts
@@ -7,8 +7,21 @@ declare module "./base-effect.mjs" {
     parent: DrawSteelActiveEffect;
     changes: EffectChangeData[];
     end: {
-      type: keyof typeof ds["CONFIG"]["effectEnds"] | "";
       roll: string;
+    }
+    requirements: {
+      resource: number;
+    }
+    project: {
+      prerequisites: string;
+      source: string;
+      rollCharacteristic: Set<string>;
+      goal: number;
+      yield: {
+        kind: string;
+        amount: string;
+        display: string;
+      };
     }
   }
 }

--- a/src/module/data/effect/base-effect.mjs
+++ b/src/module/data/effect/base-effect.mjs
@@ -6,6 +6,10 @@ import enrichHTML from "../../utils/enrich-html.mjs";
 import { setOptions } from "../helpers.mjs";
 
 /**
+ * @import { CoreResource } from "../actor/_types";
+ */
+
+/**
  * A data model used by default effects with properties to control the expiration behavior.
  */
 export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataModel {
@@ -38,6 +42,10 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
       roll: new FormulaField({ initial: "1d10 + @combat.save.bonus" }),
     });
 
+    schema.requirements = new fields.SchemaField({
+      resource: new fields.NumberField({ min: 0, integer: true, initial: null }),
+    });
+
     schema.project = new fields.SchemaField({
       prerequisites: new fields.StringField({ required: true }),
       source: new fields.StringField({ required: true }),
@@ -57,12 +65,19 @@ export default class BaseEffectModel extends foundry.data.ActiveEffectTypeDataMo
 
   /**
    * Is this effect suppressed due to some system-specific behavior?
-   * @type {boolean}
+   * @type {boolean | null}
    */
   get isSuppressed() {
-    const target = this.parent.target ?? {};
+    const target = this.parent.target;
+    if (!target) return null;
     const invalidTypes = this.constructor.metadata[`invalid${target.documentName}Types`] ?? [];
-    return invalidTypes.includes(target.type);
+    if (invalidTypes.includes(target.type)) return true;
+
+    /** @type {CoreResource} */
+    const resourceInfo = target.system?.coreResource;
+    if (resourceInfo && (resourceInfo.tracking < this.requirements.resource)) return true;
+
+    return null;
   }
 
   /* -------------------------------------------------- */

--- a/src/module/documents/active-effect.mjs
+++ b/src/module/documents/active-effect.mjs
@@ -33,16 +33,6 @@ export default class DrawSteelActiveEffect extends foundry.documents.ActiveEffec
 
   /* -------------------------------------------------- */
 
-  /**
-   * Prefer falsy fall through to expired rather than null coalescing; expiration can always suppress an AE.
-   * @inheritdoc
-   */
-  get isSuppressed() {
-    return this.system.isSuppressed || this.duration.expired;
-  }
-
-  /* -------------------------------------------------- */
-
   /** @inheritdoc */
   isExpiryEvent(event, context) {
     const dsEvents = new Set("save", "respite");

--- a/templates/sheets/active-effect/details.hbs
+++ b/templates/sheets/active-effect/details.hbs
@@ -6,6 +6,12 @@
     {{formGroup systemFields.filters.fields.keywords value=source.system.filters.keywords options=keywordOptions}}
   </fieldset>
   {{/if}}
+  {{#if systemFields.requirements}}
+  <fieldset class="filters">
+    <legend>{{localize "DRAW_STEEL.ActiveEffect.Requirements"}}</legend>
+    {{formGroup systemFields.requirements.fields.resource value=source.system.requirements.resource}}
+  </fieldset>
+  {{/if}}
   {{formGroup fields.description value=source.description rootId=rootId}}
   {{formGroup fields.disabled value=source.disabled rootId=rootId}}
 


### PR DESCRIPTION
Several classes have features that are based on how much of their HR they're holding onto. 

> As you advance in your chosen null tradition, you gain certain benefits in combat, including benefits based on the amount of discipline you have. Benefits based on how much discipline you have last until the end of your turn, even if a benefit would become unavailable to you because of the amount of discipline you spend during your turn.

This also sets up the Beastheart, whose companion has Rampage which is updated slightly differently (which can be handled at the data model level).

> Your companion has a resource called rampage. Whenever you or your companion spends ferocity, your companion gains rampage equal to the ferocity spent. Your companion loses their rampage and its effects at the end of an encounter.

<img width="526" height="103" alt="image" src="https://github.com/user-attachments/assets/cdc27e50-f443-4012-b605-be6ad757f383" />

Closes #702