### PR TITLE
[#604] Factored in Highground

### DIFF
--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -772,7 +772,8 @@ export default class AbilityModel extends BaseItemModel {
       // Flanking checks
       if (this.keywords.has("melee") && this.keywords.has("strike") && token.isFlanking(target)) modifiers.edges += 1;
       // High Ground Check - targeting (Target's Size) Squares Lower gets an edge.
-      if ((token.document.elevation - target.document.elevation) >= targetActor.system.combat.size.value) modifiers.edges += 1;
+      
+      if (((token.document.elevation - target.document.elevation) >= targetActor.system.combat.size.value) && !(this.actor.statuses.has("flying"))) modifiers.edges += 1;
     }
 
     // Modifiers requiring both a controlled token and the targeted token to have an actor

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -771,6 +771,8 @@ export default class AbilityModel extends BaseItemModel {
     if (token) {
       // Flanking checks
       if (this.keywords.has("melee") && this.keywords.has("strike") && token.isFlanking(target)) modifiers.edges += 1;
+      // High Ground Check - targeting (Target's Size) Squares Lower gets an edge.
+      if ((token.document.elevation - target.document.elevation) >= targetActor.system.combat.size.value) modifiers.edges += 1;
     }
 
     // Modifiers requiring both a controlled token and the targeted token to have an actor

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -772,8 +772,7 @@ export default class AbilityModel extends BaseItemModel {
       // Flanking checks
       if (this.keywords.has("melee") && this.keywords.has("strike") && token.isFlanking(target)) modifiers.edges += 1;
       // High Ground Check - targeting (Target's Size) Squares Lower gets an edge.
-      
-      if (((token.document.elevation - target.document.elevation) >= targetActor.system.combat.size.value) && !(this.actor.statuses.has("flying"))) modifiers.edges += 1;
+      if (((token.document.elevation - target.document.elevation) >= target.document.depth) && !(this.actor.statuses.has("flying"))) modifiers.edges += 1;
     }
 
     // Modifiers requiring both a controlled token and the targeted token to have an actor


### PR DESCRIPTION
High Ground Advantage checks the difference between two elevations is bigger or equal to the actor's size. If it's higher for the originating attack and the actor isn't flying it adds an edge. Resolves #604