### PR TITLE
Fixed emanation handling for object sizes

### DIFF
--- a/src/module/applications/apps/object-sizes-input.mjs
+++ b/src/module/applications/apps/object-sizes-input.mjs
@@ -99,6 +99,7 @@ export default class ObjectSizesInput extends DocumentInput {
     // Prepare base shape context for emanations
     if (shape.type === "emanation") {
       shapeContext.baseContext = {
+        name: shapeContext.name + ".base",
         rootId: shapeContext.rootId,
         shape: shape.base,
         fields: shapeContext.fields.base.types[shape.base.type].fields,

--- a/templates/apps/object-sizes/token.hbs
+++ b/templates/apps/object-sizes/token.hbs
@@ -5,11 +5,12 @@
     </label>
     <div class="form-fields slim">
       <label for="{{rootId}}-token.width">X</label>
-      {{formInput fields.width name=(concat name ".base.width") value=source.width id=(concat rootId "-token.width")}}
+      {{formInput fields.width name=(concat name ".width") value=source.width id=(concat rootId "-token.width")}}
       <label for="{{rootId}}-token.height">Y</label>
-      {{formInput fields.height name=(concat name ".base.height") value=source.height id=(concat rootId "-token.height")}}
+      {{formInput fields.height name=(concat name ".height") value=source.height id=(concat rootId "-token.height")}}
     </div>
   </div>
+  <input type="hidden" name="{{concat name ".type"}}" value="token">
 
   {{#if fields.hole}}
   {{formField fields.hole name=(concat name ".hole") value=source.hole rootId=rootId}}


### PR DESCRIPTION
Editing shape inputs with emanations always failed due to the incorrect setup on the names.