### PR TITLE
[#2106] Summon Enricher

### DIFF
--- a/draw-steel.d.ts
+++ b/draw-steel.d.ts
@@ -2,8 +2,6 @@ import "./src/module/_types";
 import "@client/global.mjs";
 import "@common/global.mjs";
 import "@common/primitives/global.mjs";
-import Canvas from "@client/canvas/board.mjs";
-import DrawSteelTokenLayer from "./src/module/canvas/layers/tokens.mjs";
 
 // Foundry's use of `Object.assign(globalThis) means many globally available objects are not read as such
 // This declare global hopefully fixes that
@@ -24,4 +22,6 @@ declare global {
     const fromUuid = foundry.utils.fromUuid;
     const fromUuidSync = foundry.utils.fromUuidSync;
   }
+
+  type ClientDocument = InstanceType<ReturnType<typeof foundry.documents.abstract.ClientDocumentMixin>>;
 }

--- a/draw-steel.mjs
+++ b/draw-steel.mjs
@@ -236,6 +236,7 @@ Hooks.once("init", function () {
     applications.ux.enrichers.reference,
     applications.ux.enrichers.roll,
     applications.ux.enrichers.potency,
+    applications.ux.enrichers.summon,
   ];
 
   Object.assign(CONFIG.fontDefinitions, {

--- a/lang/en.json
+++ b/lang/en.json
@@ -497,6 +497,10 @@
           "LinkTooltip": "Apply {name} to selected tokens.",
           "NoSelection": "You must select tokens to apply the effect to.",
           "CreateText": "+Applied {name}"
+        },
+        "Summon": {
+          "DirectLabel": "Summon {name}",
+          "PortfolioLabel": "Portfolio Summon"
         }
       }
     },

--- a/src/module/_types.d.ts
+++ b/src/module/_types.d.ts
@@ -4,7 +4,7 @@ import "./data/_types";
 import "./documents/_types";
 import "./helpers/_types";
 import "./utils/advancement/_types";
-import { DrawSteelActor, DrawSteelChatMessage, DrawSteelItem } from "./documents/_module.mjs";
+import { DrawSteelActiveEffect, DrawSteelActor, DrawSteelChatMessage, DrawSteelItem } from "./documents/_module.mjs";
 import { PowerRoll, ProjectRoll } from "./rolls/_module.mjs";
 import FollowerModel from "./data/item/follower.mjs";
 
@@ -52,6 +52,13 @@ export interface ProjectRollPrompt {
 
 export interface ProjectRollPromptOptions extends RollPromptOptions {
   follower?: Omit<DrawSteelItem, "system"> & { system: FollowerModel }
+}
+
+export interface PerformSummonOptions {
+  /** How many tokens to summon. */
+  count: number;
+  /** Effects to add to the summoned actors, evaluating based on this actor's roll data. */
+  effects: DrawSteelActiveEffect[];
 }
 
 declare module "./utils/advancement/node.mjs" {

--- a/src/module/applications/api/_types.d.ts
+++ b/src/module/applications/api/_types.d.ts
@@ -1,13 +1,15 @@
-type ClientDocument = ReturnType<typeof foundry.documents.abstract.ClientDocumentMixin>;
+export {};
+
+type ClientDocument = InstanceType<ReturnType<typeof foundry.documents.abstract.ClientDocumentMixin>>;
 
 declare module "./document-input.mjs" {
   export default interface DocumentInput extends foundry.applications.api.DocumentSheet {
-    document: InstanceType<ClientDocument>;
+    document: ClientDocument;
   }
 }
 
 declare module "./document-sheet.mjs" {
   export default interface DSDocumentSheet extends foundry.applications.api.DocumentSheet {
-    document: InstanceType<ClientDocument>;
+    document: ClientDocument;
   }
 }

--- a/src/module/applications/ux/enrichers/_module.mjs
+++ b/src/module/applications/ux/enrichers/_module.mjs
@@ -7,6 +7,7 @@
 
 export * as applyEffect from "./apply-effect.mjs";
 export * as lookup from "./lookup.mjs";
+export * as potency from "./potency.mjs";
 export * as reference from "./reference.mjs";
 export * as roll from "./roll.mjs";
-export * as potency from "./potency.mjs";
+export * as summon from "./summon.mjs";

--- a/src/module/applications/ux/enrichers/_types.d.ts
+++ b/src/module/applications/ux/enrichers/_types.d.ts
@@ -1,0 +1,35 @@
+export interface GainResource {
+  /** The full i18n path used to label the resource. */
+  label: string;
+  /** The full path, relative to the actor, used to update the resource. */
+  resource: string;
+  /** Final key in the i18n path used for localization, relative to DRAW_STEEL.EDITOR.Enrichers.Gain.{MessageTitle|FormatString} (default: "Default"). */
+  resourceFormatString: string;
+}
+
+export interface SummonConfig {
+  /** UUID for the actor doing the summoning. */
+  summoner: string;
+  /** ID for the item that may be called upon to perform the summoning. */
+  summonItem: string;
+  /** Roll formula for actors to summon. */
+  count: string;
+  /** UUID for the document providing the enricher. */
+  origin: string;
+}
+
+export interface DirectSummonConfig extends SummonConfig {
+  type: "direct";
+  /** UUID for the actor being summoned. */
+  actor: string;
+}
+
+export interface PortfolioSummonConfig extends SummonConfig {
+  type: "portfolio";
+  /** DSID of the portfolio to use. */
+  portfolio: string;
+  /** Only show signature minions and don't display cost. */
+  signatureOnly: boolean;
+}
+
+export type AnySummonConfig = DirectSummonConfig | PortfolioSummonConfig;

--- a/src/module/applications/ux/enrichers/apply-effect.mjs
+++ b/src/module/applications/ux/enrichers/apply-effect.mjs
@@ -41,7 +41,7 @@ export async function enricher(match, options) {
   if (parsedConfig.originDuration) linkConfig.originDuration = parsedConfig.originDuration;
   if (options.relativeTo) linkConfig.origin = options.relativeTo.uuid;
 
-  /** @type {DrawSteelItem} */
+  /** @type {DrawSteelActor | DrawSteelItem} */
   const doc = (["Actor", "Item"].includes(options.relativeTo?.documentName)) ? options.relativeTo : null;
 
   for (const val of parsedConfig.values) {

--- a/src/module/applications/ux/enrichers/roll.mjs
+++ b/src/module/applications/ux/enrichers/roll.mjs
@@ -5,6 +5,7 @@ import DrawSteelChatMessage from "../../../documents/chat-message.mjs";
 
 /**
  * @import { ParsedConfig } from "../helpers.mjs";
+ * @import { GainResource } from "./_types";
  * @import { TextEditorEnricher, TextEditorEnricherConfig } from "@client/config.mjs";
  * @import HTMLEnrichedContentElement from "@client/applications/elements/enriched-content.mjs";
  */
@@ -24,10 +25,7 @@ export const id = "ds.roll";
 /**
  * Resource name to localization key and attribute path mappings for gain enricher.
  * Maps resource type identifiers to their i18n localization keys and actor attribute paths.
- *
- * @typedef {string} label - The full i18n path used to label the resource
- * @typedef {string} resource - The full path, relative to the actor, used to update the resource
- * @typedef {string} resourceFormatString - Final key in the i18n path used for localization, relative to DRAW_STEEL.EDITOR.Enrichers.Gain.{MessageTitle|FormatString} (Default: "Default")
+ * @type {Record<string, GainResource>}
  */
 const GAIN_RESOURCE_LOOKUP = {
   epic: {

--- a/src/module/applications/ux/enrichers/summon.mjs
+++ b/src/module/applications/ux/enrichers/summon.mjs
@@ -1,0 +1,155 @@
+import { createLink, parseConfig } from "../helpers.mjs";
+import DrawSteelActiveEffect from "../../../documents/active-effect.mjs";
+import SummonChoiceAdvancement from "../../../data/pseudo-documents/advancements/summon-choice-advancement.mjs";
+
+/**
+ * @import { TextEditorEnricher, TextEditorEnricherConfig } from "@client/config.mjs";
+ * @import HTMLEnrichedContentElement from "@client/applications/elements/enriched-content.mjs";
+ * @import { AnySummonConfig, DirectSummonConfig, PortfolioSummonConfig } from "./_types";
+ * @import { ParsedConfig } from "../helpers.mjs";
+ * @import { DrawSteelActor, DrawSteelItem } from "../../../documents/_module.mjs";
+ */
+
+/** @type {TextEditorEnricherConfig["id"]} */
+export const id = "ds.summon";
+
+/** @type {TextEditorEnricherConfig["pattern"]} */
+export const pattern = new RegExp("\\[\\[/(?<type>summon)(?<config> .*?)?]](?!])(?:{(?<label>[^}]+)})?", "gi");
+
+/* -------------------------------------------------- */
+
+/**
+ * Enricher function.
+ * @type {TextEditorEnricher}
+ */
+export async function enricher(match, options) {
+  let { config, label } = match.groups;
+
+  /** @type {ParsedConfig} */
+  const parsedConfig = parseConfig(config);
+  parsedConfig._input = match[0];
+
+  /** @type {AnySummonConfig} */
+  const linkConfig = {
+    type: null,
+  };
+
+  /** @type {DrawSteelActor} */
+  let summoner = fromUuidSync(parsedConfig.summoner, { relative: options.relativeTo });
+  switch (options.relativeTo?.documentName) {
+    case "Actor":
+      summoner ||= options.relativeTo;
+      break;
+    case "Item":
+      summoner ||= options.relativeTo.actor;
+      linkConfig.summonItem = options.relativeTo.uuid;
+      break;
+  }
+  if (summoner) linkConfig.summoner = summoner.uuid;
+
+  // Valid types: direct, portfolio
+  if (parsedConfig.type) linkConfig.type = parsedConfig.type;
+  if (parsedConfig.actor) {
+    linkConfig.type = "direct";
+    linkConfig.actor = parsedConfig.actor;
+  }
+  if (parsedConfig.portfolio) {
+    // portfolio summons require a summoner
+    if (!summoner) return null;
+    linkConfig.type = "portfolio";
+    linkConfig.portfolio = parsedConfig.portfolio;
+    const portfolioItem = summoner.items.find(i => i.dsid === parsedConfig.portfolio);
+    linkConfig.summonItem = portfolioItem;
+  }
+  if (parsedConfig.signatureOnly) linkConfig.signatureOnly = parsedConfig.signatureOnly;
+  if (parsedConfig.count) linkConfig.count = parsedConfig.count;
+  if (options.relativeTo) linkConfig.origin = options.relativeTo.uuid;
+
+  for (const val of parsedConfig.values) {
+    if (val.includes("Actor.")) {
+      const idx = fromUuidSync(val);
+      if (idx) {
+        linkConfig.type = "direct";
+        linkConfig.actor = idx.uuid;
+      }
+    }
+
+    if (summoner) {
+      const portfolioItem = summoner.items.find(i => i.dsid === val);
+      if (portfolioItem) {
+        linkConfig.type = "portfolio";
+        linkConfig.portfolio = val;
+        linkConfig.summonItem = portfolioItem.id;
+      }
+    }
+  }
+
+  switch (linkConfig.type) {
+    case null:
+      return null;
+    case "direct":
+      label ||= _loc("DRAW_STEEL.EDITOR.Enrichers.Summon.DirectLabel", { name: fromUuidSync(linkConfig.actor).name });
+      break;
+    case "portfolio":
+      label ||= _loc("DRAW_STEEL.EDITOR.Enrichers.Summon.PortfolioLabel");
+      break;
+  }
+
+  return createLink(label, linkConfig, {
+    icon: "fa-transporter-2",
+  });
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Called when the enriched content is added to the DOM.
+ * @param {HTMLEnrichedContentElement} element
+ */
+export async function onRender(element) {
+  const link = element.querySelector("a");
+
+  link.addEventListener("click", onClickAnchor);
+}
+
+/**
+ * Helper function to perform a summon.
+ * @this {HTMLAnchorElement}
+ */
+async function onClickAnchor() {
+  switch (this.dataset.type) {
+    case "direct": return void directSummon(this.dataset);
+    case "portfolio": return void portfolioSummon(this.dataset);
+  }
+}
+
+/**
+ * Helper function to perform a summon.
+ * @param {DirectSummonConfig} config
+ */
+async function directSummon(config) {
+  /** @type {DrawSteelItem} */
+  const summonItem = fromUuidSync(config.summoner)?.items.get(config.summonItem);
+  const origin = fromUuidSync(config.origin);
+  await ds.utils.performSummon(config.actor, summonItem ?? origin, { count: config.count ?? 1 });
+}
+
+/**
+ * Helper function to perform a summon.
+ * @param {PortfolioSummonConfig} config
+ */
+async function portfolioSummon(config) {
+  const hero = fromUuidSync(config.summoner);
+
+  const summonInfo = await SummonChoiceAdvancement.getSummonInfo(hero, config.portfolio, { signatureOnly: !!config.signatureOnly });
+
+  if (!summonInfo) return;
+
+  const summonItem = fromUuidSync(config.summoner)?.items.get(config.summonItem);
+
+  const tokens = await summonItem.system.performSummon(summonInfo.uuid, { count: summonInfo.count, effects: summonInfo.effects });
+
+  if (tokens?.length && summonInfo.cost) {
+    await hero.modifyTokenAttribute("hero.primary.value", -summonInfo.cost, true);
+  }
+}

--- a/src/module/data/item/ability.mjs
+++ b/src/module/data/item/ability.mjs
@@ -947,39 +947,6 @@ export default class AbilityModel extends BaseItemModel {
    * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
    */
   async performSummon(uuid, { count = 1, effects = [] } = {}) {
-    /** @type {DrawSteelActor} */
-    const sourceActor = await fromUuid(uuid);
-
-    if (!sourceActor) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
-
-    // TODO: Rework into registry or other service to improve performance with large actor collections
-    let worldActor = game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(systemID, "summonSource") === this.parent.uuid));
-
-    if (!worldActor) {
-      // Ensure the user has permission to drop the actor and create a Token.
-      if (!game.user.can("ACTOR_CREATE")) {
-        ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
-        return null;
-      }
-
-      worldActor = await game.actors.importFromCompendium(game.packs.get(sourceActor.pack), sourceActor.id, {
-        "flags.draw-steel.summonSource": this.parent.uuid,
-      }, { keepId: true });
-    }
-
-    const actorUpdates = { effects: [] };
-
-    const replacementData = this.parent.getRollData();
-
-    for (const e of effects) {
-      const data = game.items.fromCompendium(e, { keepId: true, clearFolder: true });
-      for (const change of data.system.changes) {
-        if (typeof change.value !== "string") continue;
-        change.value = DrawSteelActiveEffect._replaceDataRefs(change.value, replacementData);
-      }
-      actorUpdates.effects.push(data);
-    }
-
-    return canvas.tokens.placeActor(worldActor, { count, actorUpdates });
+    return ds.utils.performSummon(uuid, this, { count, effects });
   }
 }

--- a/src/module/data/item/advancement.mjs
+++ b/src/module/data/item/advancement.mjs
@@ -77,12 +77,6 @@ export default class AdvancementModel extends BaseItemModel {
           const chrInfo = this.actor.system.characteristics[chr];
           chrInfo.value = Math.min(chrInfo.value + 1, advancement.max);
         }
-      } else if (advancement.type === "summon") {
-        const options = advancement.pool
-          .filter(o => flags[advancement.id]?.selected.includes(o.uuid))
-          .map(o => ({ ...o, cost: advancement.cost, advancementUuid: advancement.uuid }));
-        const portfolio = this.actor.system._summonPortfolios[advancement.dsid] ??= [];
-        portfolio.push(...options);
       }
     }
   }

--- a/src/module/data/pseudo-documents/advancements/_types.d.ts
+++ b/src/module/data/pseudo-documents/advancements/_types.d.ts
@@ -22,6 +22,14 @@ interface SummonEffectPool {
   level: number;
 }
 
+interface SummonInfo {
+  effects: DrawSteelActiveEffect[];
+  uuid: string;
+  count: number;
+  /** Only included if signature. */
+  cost?: number;
+}
+
 export type ActorChoice = {
   /** The UUID of the actor. */
   uuid: string;

--- a/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
+++ b/src/module/data/pseudo-documents/advancements/summon-choice-advancement.mjs
@@ -1,11 +1,15 @@
 import ActorChoiceAdvancement from "./actor-choice-advancement.mjs";
+import DSDialog from "../../../applications/api/dialog.mjs";
 import { requiredInteger } from "../../helpers.mjs";
 
 /**
- * @import { DrawSteelActiveEffect, DrawSteelActor } from "../../../documents/actor.mjs";
+ * @import { DrawSteelActiveEffect, DrawSteelActor } from "../../../documents/_module.mjs";
+ * @import { SummonInfo } from "./_types";
+ * @import { SummonPortfolio } from "../../actor/_types";
  */
 
 const { ArrayField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
+const { createFormGroup, createSelectInput, createNumberInput } = foundry.applications.fields;
 
 /**
  * An advancement that selects other actors from a pool for the Summoner.
@@ -48,6 +52,33 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
       if (idx) options.push({ uuid: idx.uuid });
       return options;
     }, []);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+    // Signature minions don't have quantities
+    if (!this.cost) for (const actor of this.pool) actor.count = null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+
+    const hero = this.document.actor;
+    if (!hero) return;
+
+    const flags = this.document.getFlag(ds.CONST.systemID, "advancement") ?? {};
+
+    const options = this.pool
+      .filter(o => flags[this.id]?.selected.includes(o.uuid))
+      .map(o => ({ ...o, cost: this.cost, advancementUuid: this.uuid }));
+    const portfolio = hero.system._summonPortfolios[this.dsid] ??= [];
+    portfolio.push(...options);
   }
 
   /* -------------------------------------------------- */
@@ -127,4 +158,128 @@ export default class SummonChoiceAdvancement extends ActorChoiceAdvancement {
     return this.update({ pool });
   }
 
+  /* -------------------------------------------------- */
+
+  /**
+   * Parse summoning info for a given actor portfolio and present a dialog to make a choice.
+   * @param {DrawSteelActor} hero   The actor doing the summoning.
+   * @param {string} portfolioKey   The DSID of the ability that is doing the summoning.
+   * @param {Object} [options={}]
+   * @param {boolean} [options.signatureOnly=false] Only show signature minions and hide the cost input?
+   * @returns {Promise<SummonInfo | void>} Returns void if dialog canceled or no valid summoning options.
+   */
+  static async getSummonInfo(hero, portfolioKey, { signatureOnly = false } = {}) {
+    /** @type {SummonPortfolio[]} */
+    const portfolio = hero.system._summonPortfolios[portfolioKey] ?? [];
+
+    const summonOptions = portfolio.reduce((options, o) => {
+      if (signatureOnly && (o.cost !== null)) return options;
+      const idx = fromUuidSync(o.uuid);
+      if (idx) options.push({
+        label: _loc("DRAW_STEEL.Actor.Summoning.ActorSelectDialog.optionLabel", {
+          name: idx.name,
+          cost: o.cost ?? _loc("DRAW_STEEL.Actor.Summoning.ActorSelectDialog.signature"),
+        }),
+        value: idx.uuid,
+        cost: o.cost,
+      });
+      return options;
+      // Reverse sort by cost + alpha sort
+    }, []).sort((a, b) => b.cost - a.cost || a.label.localeCompare(b.label));
+
+    if (!summonOptions.length) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.NO_OPTIONS", { localize: true });
+    // Token permissions handled by placeActor
+
+    const content = document.createElement("div");
+
+    const uuidSelect = createFormGroup({
+      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.label",
+      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.hint",
+      input: createSelectInput({
+        name: "uuid",
+        options: summonOptions,
+      }),
+      localize: true,
+    });
+
+    const signatureCount = createFormGroup({
+      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.count.label",
+      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.count.hint",
+      input: createNumberInput({
+        name: "count",
+        min: 1,
+        value: 1,
+      }),
+      localize: true,
+    });
+
+    content.append(uuidSelect, signatureCount);
+
+    if (!signatureOnly) {
+      const resourceCost = createFormGroup({
+        label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.cost.label",
+        hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.cost.hint",
+        input: createNumberInput({
+          name: "cost",
+          min: 1,
+          max: hero.system.hero.primary.value,
+          value: portfolio[0].cost ?? 1,
+        }),
+        localize: true,
+      });
+
+      content.append(resourceCost);
+    }
+
+    const fd = await DSDialog.input({
+      content,
+      window: {
+        title: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.title",
+        icon: "fa-solid fa-transporter-2",
+      },
+      render: (ev, dialog) => {
+        /** @type {HTMLInputElement} */
+        const costInput = dialog.element.querySelector("[name=\"cost\"]");
+        if (!costInput) return;
+        /** @type {HTMLInputElement} */
+        const signatureInput = dialog.element.querySelector("[name=\"count\"]");
+        signatureInput.addEventListener("change", (e) => {
+          costInput.value = e.target.value;
+        });
+        /** @type {HTMLDivElement} */
+        const signatureGroup = signatureInput.closest(".form-group");
+        signatureGroup.hidden = summonOptions[0].cost !== null;
+        dialog.element.querySelector("[name=\"uuid\"]").addEventListener("change", (e) => {
+          const { cost } = portfolio.find(o => o.uuid === e.target.value);
+          signatureGroup.hidden = cost !== null;
+          costInput.value = cost ?? signatureInput.value;
+        });
+      },
+    });
+
+    if (!fd) return;
+
+    const summonInfo = portfolio.find(o => o.uuid === fd.uuid);
+
+    /** @type {SummonChoiceAdvancement} */
+    const advancement = fromUuidSync(summonInfo.advancementUuid);
+
+    /** @type {DrawSteelActiveEffect[]} */
+    const effects = [];
+    for (const effectInfo of advancement.effects) {
+      if (hero.system.level < effectInfo.level) return;
+      const effect = await fromUuid(effectInfo.uuid);
+      if (effect) effects.push(effect);
+    }
+
+    const returnInfo = {
+      effects,
+      uuid: fd.uuid,
+      count: summonInfo.count ?? fd.count,
+    };
+
+    if ("cost" in fd) returnInfo.cost = fd.cost;
+
+    return returnInfo;
+  }
 }

--- a/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
+++ b/src/module/data/pseudo-documents/special-effect/portfolio-summon-effect.mjs
@@ -1,13 +1,10 @@
 import BaseSpecialEffect from "./base-special-effect.mjs";
-import DSDialog from "../../../applications/api/dialog.mjs";
+import SummonChoiceAdvancement from "../advancements/summon-choice-advancement.mjs";
 
 /**
- * @import { DrawSteelActiveEffect, DrawSteelTokenDocument } from "../../../documents/_module.mjs"
- * @import { SummonPortfolio } from "../../actor/_types";
+ * @import { DrawSteelTokenDocument } from "../../../documents/_module.mjs";
  * @import SummonChoiceAdvancement from "../advancements/summon-choice-advancement.mjs";
  */
-
-const { createFormGroup, createSelectInput, createNumberInput } = foundry.applications.fields;
 
 /**
  * A type of effect that summons from a fixed list of options.
@@ -41,109 +38,14 @@ export default class PortfolioSummonSpecialEffect extends BaseSpecialEffect {
   async performSummon() {
     const hero = this.document.actor;
 
-    /** @type {SummonPortfolio[]} */
-    const portfolio = hero.system._summonPortfolios[this.document.dsid] ?? [];
+    const summonInfo = await SummonChoiceAdvancement.getSummonInfo(hero, this.document.dsid);
 
-    const summonOptions = portfolio.reduce((options, o) => {
-      const idx = fromUuidSync(o.uuid);
-      if (idx) options.push({
-        label: _loc("DRAW_STEEL.Actor.Summoning.ActorSelectDialog.optionLabel", {
-          name: idx.name,
-          cost: o.cost ?? _loc("DRAW_STEEL.Actor.Summoning.ActorSelectDialog.signature"),
-        }),
-        value: idx.uuid,
-      });
-      return options;
-    }, []);
+    if (!summonInfo) return;
 
-    if (!summonOptions.length) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.NO_OPTIONS", { localize: true });
-    // Token permissions handled by placeActor
-
-    const content = document.createElement("div");
-
-    const uuidSelect = createFormGroup({
-      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.label",
-      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.uuid.hint",
-      input: createSelectInput({
-        name: "uuid",
-        options: summonOptions,
-      }),
-      localize: true,
-    });
-
-    const signatureCount = createFormGroup({
-      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.count.label",
-      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.count.hint",
-      input: createNumberInput({
-        name: "count",
-        min: 1,
-        value: 1,
-      }),
-      localize: true,
-    });
-
-    const resourceCost = createFormGroup({
-      label: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.cost.label",
-      hint: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.cost.hint",
-      input: createNumberInput({
-        name: "cost",
-        min: 1,
-        max: hero.system.hero.primary.value,
-        value: portfolio[0].cost ?? 1,
-      }),
-      localize: true,
-    });
-
-    content.append(uuidSelect, signatureCount, resourceCost);
-
-    const fd = await DSDialog.input({
-      content,
-      window: {
-        title: "DRAW_STEEL.Actor.Summoning.ActorSelectDialog.title",
-        icon: "fa-solid fa-transporter-2",
-      },
-      render: (ev, dialog) => {
-        /** @type {HTMLInputElement} */
-        const costInput = dialog.element.querySelector("[name=\"cost\"]");
-        /** @type {HTMLInputElement} */
-        const signatureInput = dialog.element.querySelector("[name=\"count\"]");
-        signatureInput.addEventListener("change", (e) => {
-          costInput.value = e.target.value;
-        });
-        /** @type {HTMLDivElement} */
-        const signatureGroup = signatureInput.closest(".form-group");
-        dialog.element.querySelector("[name=\"uuid\"]").addEventListener("change", (e) => {
-          const { cost } = portfolio.find(o => o.uuid === e.target.value);
-          signatureGroup.hidden = cost !== null;
-          costInput.value = cost ?? signatureInput.value;
-        });
-      },
-    });
-
-    if (!fd) return null;
-
-    const summonInfo = portfolio.find(o => o.uuid === fd.uuid);
-
-    /** @type {SummonChoiceAdvancement} */
-    const advancement = fromUuidSync(summonInfo.advancementUuid);
-
-    /** @type {DrawSteelActiveEffect[]} */
-    const effects = [];
-    for (const effectInfo of advancement.effects) {
-      if (hero.system.level < effectInfo.level) return;
-      const effect = await fromUuid(effectInfo.uuid);
-      if (effect) effects.push(effect);
-    }
-
-    const cost = fd.cost;
-
-    // Signature minions have a null count & cost and instead just directly scale with the # summoned
-    const count = summonInfo.count ?? fd.count;
-
-    const tokens = await this.parent.performSummon(fd.uuid, { count, effects });
+    const tokens = await this.parent.performSummon(summonInfo.uuid, { count: summonInfo.count, effects: summonInfo.effects });
 
     if (tokens?.length) {
-      await hero.modifyTokenAttribute("hero.primary.value", -cost, true);
+      await hero.modifyTokenAttribute("hero.primary.value", -summonInfo.cost, true);
     }
 
     return tokens;

--- a/src/module/documents/_types.d.ts
+++ b/src/module/documents/_types.d.ts
@@ -36,61 +36,61 @@ type MessageModel = typeof ChatMessageModels[Exclude<keyof typeof ChatMessageMod
 type CombatantGroupModel = typeof CombatantGroupModels[keyof typeof CombatantGroupModels];
 type JournalEntryPageModel = typeof JEPModels[keyof typeof JEPModels];
 
-type ClientDocument = ReturnType<typeof foundry.documents.abstract.ClientDocumentMixin>;
+type ClientDocument = InstanceType<ReturnType<typeof foundry.documents.abstract.ClientDocumentMixin>>;
 type CanvasDocument = ReturnType<typeof foundry.documents.abstract.CanvasDocumentMixin>;
 
 declare module "@client/documents/_module.mjs" {
-  interface BaseActiveEffect<Model extends ActiveEffectModel = ActiveEffectModel> extends ActiveEffectData, InstanceType<ClientDocument> {
+  interface BaseActiveEffect<Model extends ActiveEffectModel = ActiveEffectModel> extends ActiveEffectData, ClientDocument {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
   }
 
-  interface BaseActor<Model extends ActorModel = ActorModel> extends ActorData, InstanceType<ClientDocument> {
+  interface BaseActor<Model extends ActorModel = ActorModel> extends ActorData, ClientDocument {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
     items: EmbeddedCollection<DrawSteelItem>;
     effects: EmbeddedCollection<DrawSteelActiveEffect>;
   }
 
-  interface BaseItem<Model extends ItemModel = ItemModel> extends ItemData, InstanceType<ClientDocument> {
+  interface BaseItem<Model extends ItemModel = ItemModel> extends ItemData, ClientDocument {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
     effects: EmbeddedCollection<DrawSteelActiveEffect>;
   }
-  interface BaseChatMessage<Model extends MessageModel = MessageModel> extends ChatMessageData, InstanceType<ClientDocument> {
+  interface BaseChatMessage<Model extends MessageModel = MessageModel> extends ChatMessageData, ClientDocument {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
   }
 
-  interface BaseCombat extends CombatData, InstanceType<ClientDocument> {
+  interface BaseCombat extends CombatData, ClientDocument {
     type: "base";
     system: CombatModels.BaseCombatModel;
     combatants: EmbeddedCollection<DrawSteelCombatant>;
     groups: EmbeddedCollection<DrawSteelCombatantGroup>
   }
 
-  interface BaseCombatantGroup<Model extends CombatantGroupModel = CombatantGroupModel> extends CombatantGroupData, InstanceType<ClientDocument> {
+  interface BaseCombatantGroup<Model extends CombatantGroupModel = CombatantGroupModel> extends CombatantGroupData, ClientDocument {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
   }
 
-  interface BaseCombatant extends CombatantData, InstanceType<ClientDocument> {
+  interface BaseCombatant extends CombatantData, ClientDocument {
     type: "base";
     system: CombatantModels.BaseCombatantModel;
     group: DrawSteelCombatantGroup;
   }
 
-  interface BaseJournalEntry extends JournalEntryData, InstanceType<ClientDocument> {
+  interface BaseJournalEntry extends JournalEntryData, ClientDocument {
     pages: EmbeddedCollection<DrawSteelJournalEntryPage>;
     categories: EmbeddedCollection<JournalEntryCategory>;
   }
 
-  interface BaseJournalEntryPage<Model extends JournalEntryPageModel = JournalEntryPageModel> extends JournalEntryPageData, InstanceType<ClientDocument> {
+  interface BaseJournalEntryPage<Model extends JournalEntryPageModel = JournalEntryPageModel> extends JournalEntryPageData, ClientDocument {
     type: Model["metadata"]["type"];
     system: InstanceType<Model>;
   }
 
-  interface BaseScene extends SceneData, InstanceType<ClientDocument> {
+  interface BaseScene extends SceneData, ClientDocument {
     tokens: EmbeddedCollection<DrawSteelTokenDocument>;
     walls: EmbeddedCollection<DrawSteelWallDocument>;
   }
@@ -99,7 +99,7 @@ declare module "@client/documents/_module.mjs" {
     object: DrawSteelToken;
   }
 
-  interface BaseUser extends UserData, InstanceType<ClientDocument> {}
+  interface BaseUser extends UserData, ClientDocument {}
 
   interface BaseWall extends WallData, InstanceType<CanvasDocument> {}
 }

--- a/src/module/utils/_module.mjs
+++ b/src/module/utils/_module.mjs
@@ -6,6 +6,7 @@ export { default as evaluateFormula } from "./evaluate-formula.mjs";
 export { default as getDocumentTypes } from "./get-document-types.mjs";
 export { default as MembersCollection } from "./members-collection.mjs";
 export { default as ModelCollection } from "./model-collection.mjs";
+export { default as performSummon } from "./perform-summon.mjs";
 export { default as simplifyRollFormula } from "./simplify-roll-formula.mjs";
 export { default as tokensToActors } from "./tokens-to-actors.mjs";
 export { default as updateFromCompendium } from "./update-from-compendium.mjs";

--- a/src/module/utils/perform-summon.mjs
+++ b/src/module/utils/perform-summon.mjs
@@ -1,0 +1,51 @@
+import DrawSteelActiveEffect from "../documents/active-effect.mjs";
+
+/**
+ * @import { PerformSummonOptions } from "../_types";
+ */
+
+/**
+ * Places summons.
+ * @param {string} uuid                  The UUID of the actor to summon. If this points to a compendium actor a copy will be imported.
+ * @param {ClientDocument} summonSource  A document that can be checked against to prevent duplicate imports and provide roll data for effect replacement.
+ * @param {PerformSummonOptions} options
+ * @returns {Promise<DrawSteelTokenDocument[] | null>} Returns null if the user did not have permissions.
+ */
+export default async function performSummon(uuid, summonSource, { count = 1, effects = [] } = {}) {
+  /** @type {DrawSteelActor} */
+  const sourceActor = await fromUuid(uuid);
+
+  if (!sourceActor) return void ui.notifications.error("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
+
+  // TODO: Rework into registry or other service to improve performance with large actor collections
+  let worldActor = sourceActor.pack
+    ? game.actors.find(a => (a._stats.compendiumSource === uuid) && (a.getFlag(ds.CONST.systemID, "summonSource") === summonSource.uuid))
+    : sourceActor;
+
+  if (!worldActor) {
+    // Ensure the user has permission to drop the actor and create a Token.
+    if (!game.user.can("ACTOR_CREATE")) {
+      ui.notifications.warn("DRAW_STEEL.Actor.Summoning.Errors.ACTOR_CREATE", { localize: true });
+      return null;
+    }
+
+    worldActor = await game.actors.importFromCompendium(game.packs.get(sourceActor.pack), sourceActor.id, {
+      "flags.draw-steel.summonSource": summonSource.uuid,
+    }, { keepId: true });
+  }
+
+  const actorUpdates = { effects: [] };
+
+  const replacementData = summonSource.getRollData?.() ?? {};
+
+  for (const e of effects) {
+    const data = game.items.fromCompendium(e, { keepId: true, clearFolder: true });
+    for (const change of data.system.changes) {
+      if (typeof change.value !== "string") continue;
+      change.value = DrawSteelActiveEffect._replaceDataRefs(change.value, replacementData);
+    }
+    actorUpdates.effects.push(data);
+  }
+
+  return canvas.tokens.placeActor(worldActor, { count, actorUpdates });
+}


### PR DESCRIPTION
- Added a `/summon` enricher that works with both a document UUID as well as a a portfolio
- Refactored some of the usage of ClientDocument due to some unintended global scope pollution I noticed in the enricher files
- Factored out the summoning to a helper (ds.utils.performSummon); might be correct to just entirely drop it from the ability model?

Closes #2106