### PR TITLE
[#1869] Display potency results

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2547,6 +2547,18 @@
             }
           }
         },
+        "targetResult": {
+          "ContextMenuOptions": {
+            "AdjustPotency": "Adjust Potency"
+          },
+          "PotencyModificationDialog": {
+            "Title": "Potency Modification Dialog",
+            "Surges": {
+              "label": "Surges",
+              "hint": "Expend two surges to increase the potency by 1."
+            }
+          }
+        },
         "test": {
           "HeroTokenReroll": {
             "label": "Hero Token",

--- a/src/module/data/pseudo-documents/message-parts/_types.d.ts
+++ b/src/module/data/pseudo-documents/message-parts/_types.d.ts
@@ -38,6 +38,8 @@ declare module "./target-result.mjs" {
     abilityUuid: string;
     tier: number;
     targetUuid: string;
+    /** Mapping of PRE ids to potency bonuses. */
+    potencies: Record<string, number>;
   }
 }
 

--- a/src/module/data/pseudo-documents/message-parts/target-result.mjs
+++ b/src/module/data/pseudo-documents/message-parts/target-result.mjs
@@ -9,8 +9,8 @@ import { systemPath } from "../../../constants.mjs";
  * @import { ContextMenuEntry } from "@client/applications/ux/context-menu.mjs"
  */
 
-const { DocumentUUIDField, NumberField } = foundry.data.fields;
-const { createFormGroup, createNumberInput, createSelectInput, createTextInput } = foundry.applications.fields;
+const { DocumentUUIDField, NumberField, TypedObjectField } = foundry.data.fields;
+const { createFormGroup, createCheckboxInput, createNumberInput, createSelectInput, createTextInput } = foundry.applications.fields;
 
 /**
  * A part that displays the result of an ability power roll and its consequences for a single target.
@@ -44,6 +44,7 @@ export default class TargetResultPart extends RollPart {
       abilityUuid: new DocumentUUIDField({ nullable: false, type: "Item" }),
       tier: new NumberField({ integer: true, min: 1, max: 3, nullable: false }),
       targetUuid: new DocumentUUIDField({ nullable: false, type: "Actor" }),
+      potencies: new TypedObjectField(new NumberField({ integer: true, nullable: false, initial: 0 })),
     });
   }
 
@@ -107,17 +108,20 @@ export default class TargetResultPart extends RollPart {
     const item = this.ability;
 
     if (item) {
-      for (const pre of item.system.power.effects) {
-        const newButtons = pre.constructButtons(this.tier);
-        if (newButtons) context.ctx.buttons.push(...newButtons);
-      }
-
       context.ctx.foundItem = true;
       context.ctx.tierSymbol = ds.rolls.PowerRoll.RESULT_TIERS[`tier${this.tier}`].glyph;
       context.ctx.resultHTML = await item.system.powerRollText(this.tier);
-    }
 
-    context.ctx.showContextMenu = !!this.rolls.find(roll => (roll instanceof DamageRoll) && !roll.isHeal);
+      if (!actor) return;
+
+      context.ctx.potency = [];
+      for (const pre of item.system.power.effects.sortedContents) {
+        const newButtons = pre.constructButtons(this.tier);
+        if (newButtons) context.ctx.buttons.push(...newButtons);
+        const potency = pre.potencyOption(this.tier, actor, { bonus: this.potencies[pre.id] });
+        if (potency) context.ctx.potency.push(potency);
+      }
+    }
   }
 
   /* -------------------------------------------------- */
@@ -239,23 +243,32 @@ export default class TargetResultPart extends RollPart {
    * @returns {ContextMenuEntry[]}
    */
   _getResultPartContextOptions() {
-    const damageRolls = this.rolls.filter(roll => (roll instanceof DamageRoll) && !roll.isHeal);
-    if (!damageRolls.length) return [];
+    const options = [];
 
-    const baseLocalizationPath = "DRAW_STEEL.ChatMessage.PARTS.abilityResult.ContextMenuOptions.DamageModification";
-    return damageRolls.map(roll => {
+    const damageRolls = this.rolls.filter(roll => (roll instanceof DamageRoll) && !roll.isHeal);
+    const damageRollLocalizationPath = "DRAW_STEEL.ChatMessage.PARTS.abilityResult.ContextMenuOptions.DamageModification";
+    for (const roll of damageRolls) {
       const damageType = ds.CONFIG.damageTypes[roll.options.type]?.label ?? roll.options.type;
-      const label = _loc(`${baseLocalizationPath}.${damageType ? "WithType" : "Typeless"}`, {
+      const label = _loc(`${damageRollLocalizationPath}.${damageType ? "WithType" : "Typeless"}`, {
         total: roll.total,
         type: damageType,
       });
-      return {
+      options.push({
         label,
-        icon: "fa-solid fa-gear",
+        icon: "fa-solid fa-dice-d6",
         visible: () => this.message.isOwner,
         onClick: () => this.modifyDamageDialog(roll),
-      };
+      });
+    }
+
+    options.push({
+      label: "DRAW_STEEL.ChatMessage.PARTS.targetResult.ContextMenuOptions.AdjustPotency",
+      icon: "fa-solid fa-hand-fist",
+      visible: () => this.message.isOwner && this.ability && this.actorTarget,
+      onClick: () => this.modifyPotencyDialog(),
     });
+
+    return options;
   }
 
   /* -------------------------------------------------- */
@@ -268,13 +281,13 @@ export default class TargetResultPart extends RollPart {
     const content = document.createElement("div");
 
     let sourceActor = this.ability?.actor;
-
-    // Retainers use their mentor's surges and surge value
+    // Retainers and companions use their hero's surges and surge damage
     if (sourceActor.type === "retainer") sourceActor = sourceActor.system.retainer.mentor;
+    if (sourceActor.type === "companion") sourceActor = sourceActor.system.companion.master;
 
     const surgeDamage = sourceActor.getRollData()?.chr;
 
-    if (sourceActor.type === "hero") {
+    if (sourceActor?.type === "hero") {
       const surgeMax = Math.min(3, sourceActor.system.hero.surges);
 
       const surges = createFormGroup({
@@ -333,5 +346,67 @@ export default class TargetResultPart extends RollPart {
     if ((!modifications.additionalTerms) && (modifications.damageType === roll.options.type)) return;
 
     return this.createModifiedDamageRoll(roll, modifications);
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Prompt dialog to modify potencies associated with this chat message.
+   */
+  async modifyPotencyDialog() {
+    const actor = this.actorTarget;
+    let sourceActor = this.ability?.actor;
+    // Retainers and companions use their hero's surges
+    if (sourceActor.type === "retainer") sourceActor = sourceActor.system.retainer.mentor;
+    if (sourceActor.type === "companion") sourceActor = sourceActor.system.companion.master;
+
+    const content = document.createElement("div");
+
+    if (sourceActor?.type === "hero") {
+      const surges = createFormGroup({
+        label: "DRAW_STEEL.ChatMessage.PARTS.abilityResult.DamageModificationDialog.Surges.label",
+        hint: "DRAW_STEEL.ChatMessage.PARTS.targetResult.PotencyModificationDialog.Surges.hint",
+        input: createCheckboxInput({ name: "surges", disabled: sourceActor.system.hero.surges < 2 }),
+        localize: true,
+      });
+      content.append(surges);
+    }
+
+    for (const pre of this.ability.system.power.effects.sortedContents) {
+      const potencyData = pre.potencyOption(this.tier, actor, { bonus: this.potencies[pre.id] });
+      if (!potencyData) continue;
+      const potencyInput = createFormGroup({
+        label: pre.name,
+        hint: " ",
+        input: createNumberInput({ name: `potencies.${pre.id}`, step: 1 }),
+        classes: ["slim"],
+      });
+      potencyInput.querySelector("p.hint").innerHTML = potencyData.text;
+      content.append(potencyInput);
+    }
+
+    const fd = await ds.applications.api.DSDialog.input({
+      content,
+      classes: ["modify-potency-dialog"],
+      window: {
+        title: "DRAW_STEEL.ChatMessage.PARTS.targetResult.PotencyModificationDialog.Title",
+        icon: "fa-fw fa-solid fa-gear",
+      },
+    });
+
+    if (!fd) return;
+
+    const modifications = foundry.utils.expandObject(fd);
+
+    const potencies = foundry.utils.deepClone(this._source.potencies);
+
+    for (const [id, adjustment] of Object.entries(modifications.potencies)) {
+      potencies[id] ??= 0;
+      potencies[id] += adjustment + !!modifications.surges;
+    }
+
+    await this.update({ potencies });
+
+    if (modifications.surges) await sourceActor.modifyTokenAttribute("hero.surges", -2, true, false);
   }
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
+++ b/src/module/data/pseudo-documents/power-roll-effects/_types.d.ts
@@ -11,6 +11,20 @@ type PotencySchema = {
   characteristic: string;
 };
 
+export type PotencyChatResult = {
+  text: string;
+  fail: boolean;
+};
+
+export type PotencyChatOptions = {
+  bonus: number;
+};
+
+export type TextOptions = {
+  /** An integer adjustment of the potency value, e.g. Surges. */
+  potencyBonus?: number;
+};
+
 export type DamageSchema = {
   value: string;
   types: Set<string>;

--- a/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/applied-effect.mjs
@@ -6,7 +6,7 @@ import { setOptions } from "../../helpers.mjs";
  * @import { ActiveEffectData } from "@common/documents/_types.mjs";
  * @import { DatabaseWriteOperation } from "@common/abstract/_types.mjs";
  * @import { StatusEffectConfig } from "@client/config.mjs";
- * @import { AppliedEffectSchema } from "./_types";
+ * @import { AppliedEffectSchema, TextOptions } from "./_types";
  * @import { DrawSteelActor } from "../../../documents/_module.mjs";
  */
 
@@ -137,10 +137,11 @@ export default class AppliedPowerRollEffect extends BasePowerRollEffect {
 
   /**
    * @param {1 | 2 | 3} tier
+   * @param {TextOptions} options
    * @inheritdoc
    */
-  toText(tier) {
-    const potencyString = this.toPotencyHTML(tier);
+  toText(tier, options = {}) {
+    const potencyString = this.toPotencyHTML(tier, options.potencyBonus);
     // Sanitize any HTML that may be in the base display string
     const escapedDisplay = Handlebars.escapeExpression(this.applied[`tier${tier}`].display);
     return escapedDisplay.replaceAll("{{potency}}", potencyString);

--- a/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/base-power-roll-effect.mjs
@@ -4,6 +4,7 @@ import TypedPseudoDocument from "../typed-pseudo-document.mjs";
 /**
  * @import { DataSchema } from "@common/abstract/_types.mjs";
  * @import { DrawSteelActor, DrawSteelItem } from "../../../documents/_module.mjs";
+ * @import { PotencyChatResult, PotencyChatOptions, PotencySchema, TextOptions } from "./_types";
  */
 
 const { SchemaField, StringField } = foundry.data.fields;
@@ -192,16 +193,19 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
 
   /**
    * A helper method for generating the potency string (i.e M < 2).
-   * @param {1|2|3} n     The tier.
+   * @param {1|2|3} tier     The tier.
+   * @param {number} [bonus] A numerical adjustment to the potency.
    * @returns {string}    The formatted potency string.
    */
-  toPotencyHTML(tier) {
+  toPotencyHTML(tier, bonus = 0) {
     const tierValue = this[`${this.constructor.TYPE}`][`tier${tier}`];
 
     const characteristic = ds.CONFIG.characteristics[tierValue.potency.characteristic]?.rollKey ?? "";
-    const strength = this.actor
+    let strength = this.actor
       ? ds.utils.evaluateFormula(tierValue.potency.value, this.item.getRollData(), { contextName: this.uuid })
       : tierValue.potency.value.split("@potency.")[1] ?? Number(tierValue.potency.value);
+
+    if (typeof strength === "number") strength += bonus;
 
     const potencySpan = this.constructor.constructPotencyHTML(characteristic, strength);
     return potencySpan.outerHTML;
@@ -212,19 +216,45 @@ export default class BasePowerRollEffect extends TypedPseudoDocument {
   /**
    * Define how an effect renders on sheets and embeds.
    * @param {1 | 2 | 3} tier   The specific tier.
+   * @param {TextOptions} [options]
    * @returns {string}
    * @abstract
    */
-  toText(tier) {}
+  toText(tier, options = {}) {}
 
   /* -------------------------------------------------- */
 
   /**
-   * Constructs button for an Ability Use chat message.
+   * Constructs button(s) for an Ability Use chat message part.
    * @param {1 | 2 | 3} tier    The specific tier.
    * @returns {HTMLButtonElement[] | null} An array of buttons to add to the footer of the message, or null if there are none.
    */
   constructButtons(tier) {
     return null;
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Constructs potency info for a Target Result chat message part.
+   * @param {1 | 2 | 3} tier          The specific tier.
+   * @param {DrawSteelActor} target   The targeted Actor actor.
+   * @param {PotencyChatOptions} [options={}]
+   * @returns {PotencyChatResult | null} Returns null if no potency associated with this result.
+   */
+  potencyOption(tier, target, options = {}) {
+    /** @type {PotencySchema} */
+    const potencyInfo = this[`${this.constructor.TYPE}`][`tier${tier}`].potency;
+
+    if (potencyInfo.characteristic === "none") return null;
+
+    const strength = ds.utils.evaluateFormula(potencyInfo.value, this.item.getRollData(), { contextName: this.uuid }) + (options.bonus ?? 0);
+    const fail = target.checkPotency(strength, potencyInfo.characteristic);
+    // nullish fail means target doesn't have characteristics
+    if (fail === null) return null;
+    return {
+      fail,
+      text: this.toText(tier, { potencyBonus: options.bonus ?? 0 }),
+    };
   }
 }

--- a/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/damage-effect.mjs
@@ -3,6 +3,10 @@ import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 import DamageRoll from "../../../rolls/damage.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 
+/**
+ * @import { TextOptions } from "./_types";
+ */
+
 const { SchemaField, SetField } = foundry.data.fields;
 
 /**
@@ -137,9 +141,10 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
 
   /**
    * @param {1 | 2 | 3} tier
+   * @param {TextOptions} [options]
    * @inheritdoc
    */
-  toText(tier) {
+  toText(tier, options = {}) {
     const { value, types, potency, ignoredImmunities } = this.damage[`tier${tier}`];
     if (Number(value) === 0) return "";
 
@@ -174,7 +179,7 @@ export default class DamagePowerRollEffect extends BasePowerRollEffect {
 
     if (potency.characteristic === "none") return result;
 
-    const potencyString = this.toPotencyHTML(tier);
+    const potencyString = this.toPotencyHTML(tier, options.potencyBonus);
 
     return _loc("DRAW_STEEL.POWER_ROLL_EFFECT.DAMAGE.formattedPotency", {
       damage: result,

--- a/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/forced-movement-effect.mjs
@@ -2,7 +2,7 @@ import { requiredInteger, setOptions } from "../../helpers.mjs";
 import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
 
-/** @import { ForcedMovementSchema } from "./_types" */
+/** @import { ForcedMovementSchema, TextOptions } from "./_types" */
 
 const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
@@ -113,9 +113,10 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
 
   /**
    * @param {1 | 2 | 3} tier
+   * @param {TextOptions} [options]
    * @inheritdoc
    */
-  toText(tier) {
+  toText(tier, options = {}) {
     const tierValue = this.forced[`tier${tier}`];
     const isVertical = tierValue.properties.has("vertical");
     const baseDistance = this.actor
@@ -159,7 +160,7 @@ export default class ForcedMovementPowerRollEffect extends BasePowerRollEffect {
       distanceString = formatter.format(formattedParts);
     }
 
-    const potencyString = this.toPotencyHTML(tier);
+    const potencyString = this.toPotencyHTML(tier, options.potencyBonus);
     const escapedDisplay = Handlebars.escapeExpression(tierValue.display);
     const finalText = escapedDisplay.replaceAll("{{potency}}", potencyString);
     return finalText.replaceAll("{{forced}}", distanceString);

--- a/src/module/data/pseudo-documents/power-roll-effects/gain-resource-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/gain-resource-effect.mjs
@@ -2,6 +2,7 @@ import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 
 /**
  * @import DrawSteelActor from "../../../documents/actor.mjs";
+ * @import { TextOptions } from "./_types";
  */
 
 const { NumberField, StringField } = foundry.data.fields;
@@ -133,9 +134,10 @@ export default class GainResourcePowerRollEffect extends BasePowerRollEffect {
 
   /**
    * @param {1 | 2 | 3} tier
+   * @param {TextOptions} [options={}]
    * @inheritdoc
    */
-  toText(tier) {
+  toText(tier, options = {}) {
     // Sanitize any HTML that may be in the base display string
     return Handlebars.escapeExpression(this.resource[`tier${tier}`].display);
   }

--- a/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
+++ b/src/module/data/pseudo-documents/power-roll-effects/other-effect.mjs
@@ -1,5 +1,9 @@
 import BasePowerRollEffect from "./base-power-roll-effect.mjs";
 
+/**
+ * @import { TextOptions } from "./_types";
+ */
+
 const { StringField } = foundry.data.fields;
 
 /**
@@ -49,10 +53,11 @@ export default class OtherPowerRollEffect extends BasePowerRollEffect {
 
   /**
    * @param {1 | 2 | 3} tier
+   * @param {TextOptions} [options={}]
    * @inheritdoc
    */
-  toText(tier) {
-    const potencyString = this.toPotencyHTML(tier);
+  toText(tier, options = {}) {
+    const potencyString = this.toPotencyHTML(tier, options.potencyBonus);
     // Sanitize any HTML that may be in the base display string
     const escapedDisplay = Handlebars.escapeExpression(this.other[`tier${tier}`].display);
     return escapedDisplay.replaceAll("{{potency}}", potencyString);

--- a/src/styles/system/applications/sidebar/tabs/chat.css
+++ b/src/styles/system/applications/sidebar/tabs/chat.css
@@ -13,7 +13,6 @@
         display: flex;
         justify-content: space-between;
         flex-direction: row-reverse;
-
         margin-block: -6px;
 
         img {
@@ -24,7 +23,10 @@
           text-align: center;
           font-size: var(--font-size-16);
           font-weight: bold;
-          line-height: 30px;
+        }
+
+        > * {
+          line-height: 40px;
         }
       }
 
@@ -91,6 +93,19 @@
           padding: 6px 10px;
           margin-block-start: 0;
           margin-inline: calc(22px - 10px);
+        }
+      }
+
+      .message-part-potency {
+        span.potency {
+          font-family: "Draw Steel Glyphs";
+          font-size: var(--font-size-16);
+          text-transform: lowercase;
+          line-height: 0.9;
+        }
+        input[type="checkbox"],
+        span.characteristic {
+          flex: 0 0 25px;
         }
       }
 
@@ -255,5 +270,15 @@
         }
       }
     }
+  }
+}
+
+/* Not strictly sure if this is the best place for this? */
+.modify-potency-dialog {
+  p.hint span.potency {
+    font-family: "Draw Steel Glyphs";
+    font-size: var(--font-size-16);
+    text-transform: lowercase;
+    line-height: 0.9;
   }
 }

--- a/templates/sidebar/chat/parts/target-result.hbs
+++ b/templates/sidebar/chat/parts/target-result.hbs
@@ -1,4 +1,3 @@
-{{#if ctx.showContextMenu}}
 <div class="message-part-header">
   <a class="fa-fw fa-solid fa-ellipsis-vertical" data-action="resultPartContext"></a>
   {{#if ctx.target.owner}}
@@ -10,14 +9,23 @@
   {{/if}}
   <img src="{{ctx.target.img}}">
 </div>
-{{/if}}
 {{#if part.flavor}}
 <div class="message-part-flavor">{{ctx.flavor}}</div>
 {{/if}}
 <div class="message-part-rolls">
   {{#each ctx.rolls}}{{{this}}}{{/each}}
 </div>
-{{#if ctx.buttons.length}}
+{{#if ctx.potency}}
+<div class="message-part-potency">
+  {{#each ctx.potency}}
+  <div class="flexrow">
+    <input type="checkbox" class="potency-toggle" {{checked fail}} disabled>
+    <span class="label">{{{text}}}</span>
+  </div>
+  {{/each}}
+</div>
+{{/if}}
+{{#if ctx.buttons}}
 <footer class="message-part-buttons">
   {{#each ctx.buttons as |button|}}{{{button.outerHTML}}}{{/each}}
 </footer>


### PR DESCRIPTION
Built upon our existing target part framework to render potency results. This involved some pass through work to make sure the text could dynamically display the modified potency values. This also has the side benefit of finishing off surge management as a concept now that we can handle surges for both damage and potencies.

<img width="285" height="293" alt="image" src="https://github.com/user-attachments/assets/b44fa476-3c50-42eb-abbc-d84f5f119d19" />
<img width="395" height="254" alt="image" src="https://github.com/user-attachments/assets/b5f3922e-4e8c-4d46-855e-cee7fc063d3c" />

Closes #1869